### PR TITLE
Few corrections to sum_eng_train.csv

### DIFF
--- a/ur3_corpus_data/translated_parallel_data/sum_eng_train_alt.csv
+++ b/ur3_corpus_data/translated_parallel_data/sum_eng_train_alt.csv
@@ -1,0 +1,15958 @@
+NUMB mac bauc$NUMB billy goat , slaughtered ,
+ki kuganita$from Kugani
+kicib lukala$under seal of Lukalla ;
+iti ezemamarsuen$month : “ Festival of Amar-Suen , ”
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+lukala$Lukalla ,
+dubsar$scribe ,
+dumu ure$son of Ur-e’e
+NUMB sila$NUMB lambs
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga ,
+intaea$Inta’e’a
+idab$accepted ;
+iti kisikininazu$month : “ ki-siki of Ninazu , ”
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB$NUMB .
+lugal kalga$the strong man/king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+n mana$NUMB minas ,
+ekiciba nanna gara$Nanna's Established Sealed-items Storeroom ,
+munagin$he standardized for him .
+pisanduba$Basket-of-tablets
+kicib laia lugalukkene nubandagu$sealed documents , debts of Lugal-ukkene , manager of oxen ,
+igal$are here .
+anunitum$For Annunītum ,
+damanir$his spouse ,
+cusuen$Šū-Sîn ,
+kiag enlila$the beloved of Enlil ,
+lugal enlile$the king whom Enlil
+kiag cagana$as beloved in his heart
+inpa$did choose ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+eani$her temple
+munadu$he built for her .
+NUMB udunita bargal bauc $NUMB male sheep with fleece , slaughtered ,
+ki lututa $from Lu-Utu .
+kicib lukala $under seal of Lukalla .
+iti paue $month “ Pa’ue , ”
+mu huhnuri bahul $year : “ Ḫuḫnuri was destroyed . ”
+lukala $Lukalla ,
+dubsar $scribe ,
+dumu ure cuc $son of Ur-E’e , chief livestock administrator .
+pisanduba$Basket-of-tablets
+kicib daba a erinaka$xxx
+urmes nubandagu$xxx
+iti NUMBkam$xxx
+igal$xxx
+iti sigicubagarata$xxx
+iti dumuzice$xxx
+mu cusuen lugale mada zabcali muhul$xxx
+nindara$For Nindara ,
+lugal uru$the powerful king ,
+lugalanir$his master ,
+namti$for the life
+ibisuen$of Ibbi-Sîn ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubakace$and king of the four world quarters ,
+urningirsu$Ur-Ningirsu ,
+enmeziana$Enmeziana ,
+cennu$the šennu-priest
+en kiag nanceke$and the en-priest of Nanše ,
+munadim$fashioned  for him .
+NUMB udu$NUMB sheep ,
+ki abasagata$from Abbasaga
+ahuwaqar idab$Aḫu-waqar accepted ;
+iti sesdagu$month : “ Piglets feast . ”
+NUMB udu niga X$NUMB sheep , barley-fed , … ,
+NUMB macgal niga nkam us$NUMB buck , barley-fed , of NUMB grade ,
+NUMB udu niga$NUMB sheep , barley-fed ,
+enlil ninlil$for Enlil and Ninlil ;
+NUMB udu niga nanna$NUMB sheep , barley-fed , for Nanna ;
+NUMB udu niga saga us$NUMB sheep , barley-fed , of ordNUMB grade ,
+NUMB udu niga$NUMB sheep , barley-fed ,
+siskur ki suen eusakar$siskur-offering with Suen , House of Crescent ;
+NUMB udu niga siskur inanna ca egal$NUMB sheep , barley-fed , siskur-offering for Inanna in the palace ,
+babancen mackim$Babanšen , responsible official ;
+X udu$… sheep ,
+X$…
+X marhuni lu harci$… for Marḫuni from Ḫarši ;
+NUMB udu niga ahabatal lu hibilat$NUMB sheep , barley-fed , for Aḫab-atal , man of Ḫibilat ;
+NUMB macgal niga ilidagan lu ebla$NUMB buck , barley-fed , for Ilī-Dagan from Ebla ;
+urcarugin sukkal mackim$Ur-šarrugin , the messenger , responsible official
+iti u NUMB la NUMB bazal$of the month , day NUMB elapsed ,
+ziga ca tumal$“ booked-outs ” in Tummal ,
+ki endingirmu$from En-dingirmu ;
+iti cueca$month : “ Šu’eša , ”
+mu cacrum bahul$year : “ Šašrum was destroyed ; ”
+NUMB la NUMB$NUMB .
+pisanduba$Basket-of-tablets
+i ekicibata ea$xxx
+cu tia$xxx
+gatie$xxx
+mu usa badgal badu mu usabi$xxx
+lugalemahe$Lugal-emaḫe ,
+dubsar$scribe ,
+dumu lugalkugani$son of Lugal-kugani .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+dubsar$scribe ,
+ARADzu$is your servant .
+NUMB ce$NUMB barig , NUMB ban2 of barley .
+cagal udu niga$fodder for grain-fed sheep ,
+ki gududuta$from Gududu ,
+kicib urmami$under seal of Ur Mami ,
+giri gina$via Gina
+iti X$month : “ … , ”
+mu simurum bahul$year : “ Simurrum was destroyed ; ”
+urmami$Ur-Mami ,
+dumu inimcara$son of Inim-Šara ,
+kurucda caraka$animal fattener of Šara .
+NUMB GAN absinbi NUMB ninda NUMBta igal$NUMB bur3 surface area , their furrows : per NUMB ninda NUMB each being ;
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area , NUMB less NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+aca durbartab$field Hillock-Urbartab ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area , NUMB each ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 surface area , NUMB less NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca kaNUMB GAN durbartab$field ka-bur'u of Du-Urbartab ;
+ceckala engar$Šeškalla , the plowman ;
+NUMB GAN NUMBta$NUMB eše3 surface area , NUMB each ;
+NUMB GAN NUMBta$NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+aca akicah$field Aki-šaḫ ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+NUMB GAN NUMBta$NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB bur NUMB ban2 ,
+aca zalagagectin$field Zalga-ageštin ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+aca zaNUMB$field Za-nēr ;
+urabzu engar$Ur-Abzu , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca akicah$field Akišaḫ ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB iku surface area , NUMB less NUMB each ;
+NUMB GAN NUMBta$NUMB bur3 surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+zizbi NUMB gur$its emmer : NUMB gur NUMB barig ,
+gigbi NUMB sila$its wheat : NUMB barig NUMB ban2 NUMB sila3 ,
+aca latur$field Latur ;
+lugalmagure engar$Lugal-magure , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 surface area , NUMB less NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca icum$field Išum ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca lugal$field King ;
+NUMB GAN NUMBta$NUMB bur3 surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca zaNUMB$field Za-nēr ;
+caramutum engar$Šara-mutum , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ,
+aca giapinkura$field Gi-apin-kuřa ;
+NUMB GAN NUMBta$NUMB bur3 surface area , NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+aca zaNUMB$field Za-nēr ;
+ukkene engar$Ukkene , the plowman ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB iku surface area , NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area , NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB barig NUMB ban2 ;
+cunigin zizbi NUMB gur$total , its emmer : NUMB gur NUMB barig ;
+cunigin gigbi NUMB sila$total , its wheat : NUMB barig NUMB ban2 NUMB sila3 ;
+nubandagu carakam$manager of oxen : Šarakam ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB less NUMB each ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+aca latur$field Latur ;
+uremah engar$Ur-emaḫ , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+aca agectin usa dumulugal$field Ageštin bordering Prince ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 surface area , NUMB less NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca amarsuencarakiag$field Amar-Suen-of-Šara-beloved ;
+abasaga engar$Abba-saga , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca dukici$field Hillock-of-acacia ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca zaNUMB$field Za-nēr ;
+lugalcala engar$Lugal-šala , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area , NUMB each ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB iku surface area , NUMB less NUMB each ;
+zizbi NUMB sila gur$its emmer : NUMB gur NUMB barig NUMB sila3 ,
+aca ukunuti$field Uku-nuti ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca asaldua$field Poplar-planted ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+aca puauz$field Pu-a’uz ;
+cecani engar$Šešani , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB ban2 ,
+aca asaldua$field Poplar-planted ;
+lugalguene engar$Lugal-gu-ene , the plowman ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2 ,
+urlugal$Ur-lugal ;
+cunigin NUMB GAN NUMBta$total : NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 surface area at NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB barig NUMB ban2 ;
+cunigin zizbi NUMB sila gur$total , its emmer : NUMB gur NUMB barig NUMB sila3 ;
+nubandagu gugua$manager of oxen : Gu’ugu’a
+ugula urlugal$foreman : Ur-lugal ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ,
+aca giapinkura$field Gi-apin-kuřa ;
+urmami engar$Ur-Mami , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+aca dukici$field Hillock-of-acacia ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca akicah$field Akišaḫ ;
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca lugal$field King ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi$its barley : NUMB ,
+aca kaGAN durbartab$field ka-GAN of Du-Urbartab ;
+akala engar$Ayakalla , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB less NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+zizbi NUMB gur$its emmer : NUMB gur ,
+gigbi NUMB gur$its wheat : NUMB gur NUMB ban2 ,
+aca latur$field Latur ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca zalagagectin$field Zalaga’ageštin ;
+urninazu engar$Ayakalla , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi$its barley : NUMB ;
+aca ducara$field Hillock-of-Šara ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca usa dumu lugal$field bordering on Prince ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ;
+aca zaNUMB$field Za-nēr ;
+nigarkidu engar$Nigar-kidu , the plowman ;
+NUMB gur$NUMB gur ,
+lugalazida$Lugal-azida ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB each ,
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB barig NUMB ban2 ,
+cunigin zizbi NUMB gur$total , its emmer : NUMB gur ,
+cunigin gigbi NUMB gur$total , its wheat : NUMB gur NUMB ban2 ,
+nubandagu lugalazida$oxen manager : Lugal-azida ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca lamah$field Lamaḫ ;
+lugalazida engar$Ayakalla , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca durbartab$field Hillock-of-Urbartab ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca carahuma$Šaraḫuma
+hubalis engar$Ḫuballis , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca dugecika$field Hillock-of-plantoil ;
+lugalcunire engar$Lugal-šunire , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca lamah$field Lamaḫ ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca zaNUMB$field Za-nēr ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca puauz$field Pu’a’uz ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+NUMB GAN NUMBta$NUMB eše3 surface area at NUMB each ,
+zizbi NUMB gur$its emmer : NUMB gur ;
+aca ukunuti$field Ukunuti ;
+icarum engar$Išarrum , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca icum$field Išum ;
+uranice engar$Uraniše , the plowman ;
+NUMB ce gur$NUMB gur barley ,
+ludingira$Lu-dingira ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2 ,
+urmami$Ur-Mami ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB eše3 surface area at NUMB each ,
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB ban2 ;
+cunigin zizbi NUMB gur$total , its emmer : NUMB gur ;
+nubandagu urmami$oxen manager : Ur-Mami ,
+ugula ludingira$foreman : Lu-dingira ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca giapinkura$field Gi-apin-kuřa ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca igiemahce$field Igi-emaḫše ;
+lusaizu engar$Lu-sa-izu , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca icum$field Išum ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca amarsuencarakiag$field Amar-Suen-Šara-kiag ;
+ursuen engar$Ur-Suen , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca latur$field Latur ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca zalaga$field Flash ;
+lugalzagesi$Lugal-zagesi ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca durbartab$field Hillock-of-Urbartab ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca zaNUMB$field Za-nēr ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca amarsuencarakiag$field Amar-Suen-Šara-kiag
+ursagamu engar$Ur-saga , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca akicah$Akišaḫ ;
+urama engar$Ur-amma , the plowman ;
+NUMB ce gur$NUMB gur NUMB barig ;
+lubanda$Lu-banda ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 surface area at NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB barig ;
+nubandagu lubanda$oxen manager : Lu-banda ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca lamah$field Lamaḫ ;
+urgigir engar$Ur-gigir , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca lamah$field Lamaḫ ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca dugecika$field Hillock-of-plantoil ;
+engarzi engar$Engarzi , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca usa dumu lugal$field bordering Prince ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca carahuma$field Saraḫuma ;
+ceckala engar$Šeškalla , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+zizbi NUMB gur$its emmer : NUMB gur ;
+gigbi NUMB sila gur$its wheat : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ;
+aca ukunuti$field Ukunuti ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca dukici$field Hillock-of-acacia ;
+abagina engar$Abbagina , the plowman ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca puauz$field Pu’a’uz ;
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca lugal$field King ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi$its barley : NUMB ;
+aca kaGAN durbartab$field ka-GAN Hillock-of-Urbartab ;
+calimbeli engar$Šālim-belī , the plowman ;
+NUMB ce gur$NUMB gur barley ,
+ceckala$Šeškalla ;
+NUMB gur abagina$NUMB gur , Abbagina ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB barig ;
+cunigin zizbi NUMB gur$total , its emmer : NUMB gur ;
+cunigin gigbi NUMB sila gur$total , its wheat : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ;
+nubandagu ceckala dumu tirgu$oxen manager : Šeškalla , son of Tirgu ,
+ugula abagina$foreman : Abbagina ;
+NUMB GAN NUMBta$NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca ugurtur$field Ururtur ;
+kala engar$Kalla , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB ban2 ;
+aca lamah$field Lamaḫ ;
+urdumuzida engar$Ur-Dumuzida , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca asaldua$field Planted-poplar ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca lugal$field King ;
+urbaba engar$Ur-Baba , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB less NUMB each ,
+NUMB GAN NUMBta$NUMB iku surface area at NUMB each ,
+cebi NUMB sila gur$NUMB gur NUMB barig NUMB sila3 ,
+aca ukunuti$field Ukunuti ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca usa dumu lugal$field bordering on Prince ;
+ceckala engar$Šeškalla , the plowman ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca akicah$field Akišaḫ ;
+urdun engar$Ur-dun , the plowman ;
+NUMB gur$NUMB gur NUMB barig ,
+ceckala$Šeškalla ;
+NUMB sila gur$NUMB gur NUMB ban2 NUMB sila3 ,
+urgepar$Ur-gepar ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin cebi NUMB sila gur$total , its barley : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ;
+nubandagu ceckala$oxen manager : Šeškalla ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB les NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+zizbi NUMB gur$its emmer : NUMB gur NUMB barig ;
+gigbi NUMB gur$its wheat : NUMB gur NUMB barig NUMB ban2 ;
+aca latur$field Latur ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ;
+aca zalaga$field Flash ;
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca kaGAN$field Ka-GAN ;
+uregula$Ur-egula ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+NUMB GAN NUMBta$NUMB eše3 surface area at NUMB each ,
+caba aca bala NUMB GAN NUMB la NUMBta igal$therein , field of the bala : NUMB eše3 NUMB iku surface area at NUMB less NUMB , being ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca ugurtur$field Ugurtur ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca zalaga$field Flash ;
+lucara engar$Lu-Šara , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca zaNUMB$field Za-nēr ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+caba aca bala NUMB GAN NUMBta igal$therein , field of the bala : NUMB eše3 surface area at NUMB , being ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca icum$field Išum ;
+urdingira engar$Ur-dingira , the plowman ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca X$field … ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca zaNUMB$field Za-nēr ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca zalaga$field Flash ;
+luninura engar$Lu-Ninura , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca giapinkura$field Gi-apin-kuřa ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : <46 gur> ;
+aca amarsuencarakiag$field Amar-Suen-Šara-kiag ;
+carakam engar$Šarakam , the plowman ;
+NUMB gur$NUMB gur ,
+urama$Ur-amma ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : <10 bur3> 3/4! iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN aca bala NUMB la NUMBta$total : NUMB eše3 NUMB iku surface area , field of the bala , at NUMB less NUMB each ;
+cunigin NUMB GAN aca bala NUMBta$total : NUMB eše3 surface area , field of the bala , at NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB ban2 ;
+cunigin zizbi NUMB gur$total , its emmer : NUMB gur NUMB barig ;
+cunigin gigbi NUMB gur$total , its wheat : NUMB gur NUMB barig NUMB ban2 ;
+nubandagu urama$oxen manager : Ur-amma ,
+ugula urgepar$foreman : Ur-gepar ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca akicah$field Akišaḫ ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca X$field … ;
+ginamu engar$Ginamu , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+zizbi NUMB gur$its emmer : NUMB gur ;
+aca ukunuti$field Ukunuti ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB iku surface area at NUMB less NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+caba aca bala NUMB GAN NUMB la NUMBta igal$therein , field of bala : NUMB iku surface area at NUMB less NUMB , being ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca ugurtur$field Ugurtur ;
+cakuge engar$Šakuge , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca durbartab$field Hillock-of-Urbartab ;
+lugina engar$Lu2-gina , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca akicah$field Akišaḫ ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca dukici$field Hillock-of-acacia ;
+caramah engar$Šara-amaḫ , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB ban2 ;
+aca dugecika$field Hillock-of-plantoil ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca carahuma$field Šaraḫuma ;
+urguedina engar$Ur-gu’edina , the plowman ;
+NUMB ce gur$NUMB gur barley ,
+lugalitida$Lugal-itida ;
+NUMB gur urgepar$NUMB gur , Ur-gepar ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN aca bala NUMB la NUMBta$total : NUMB iku surface area , field of the bala , at NUMB less NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB ban2 ;
+cunigin zizbi NUMB gur$total , its emmer : NUMB gur ;
+nubandagu lugalitida$oxen manager : Lugal-itida ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB X X sila gur$its barley : NUMB gur … ;
+aca X$field … ;
+NUMB GAN NUMBta$NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB X gur$its barley : NUMB gur … ;
+aca zaNUMB$field Za-nēr ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca zalaga$field Flash ;
+abamu engar$Abbamu , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca giapinkura$field Gi-apin-kuřa ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi$its barley : NUMB ;
+aca amarsuencarakiag$field Amar-Suen-Šara-kiag ;
+nigurum engar$Nigurum , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca latur$field Latur ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ;
+aca puauz$field Pu’a’uz ;
+urmes engar$Ur-mes , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB iku surface area at NUMB less NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca latur$field Latur ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca lugal$field King ;
+urdumuzida engar$Ur-Dumuzida , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca icum$field Išum ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi$its barley : NUMB ;
+aca kaGAN$field Ka-GAN ;
+lugalnirgal engar$Lugal-nirgal , the plowman ;
+NUMB gur lutu$NUMB gur , Lu-Utu ;
+NUMB gur urani$NUMB gur , Urrani ;
+NUMB gur dadumu$NUMB gur NUMB barig , Dadumu ;
+NUMB gur inimanizi$NUMB gur NUMB barig NUMB ban2 , Inimanizi ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area at NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB barig NUMB ban2 ;
+nubandagu urani$oxen manager : Urrani ,
+ugula lutu$foreman : Lu-Utu ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB sila gur$its barley : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ;
+aca giapinkura$field Gi-apin-kuřa ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca akicah$field Akišaḫ ;
+lutu engar$Lu-Utu , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+zizbi NUMB gur$its emmer : NUMB gur ;
+aca latur$field Latur ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca dukici$field Hillock-of-acacia ;
+inimcara engar dumu urgigir$Inim-Šara , the plowman , son of Ur-gigir ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca durbartab$field Hillock-of-Urbartab ;
+NUMB GAN NUMBta$NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca puauz$field Pu’a’uz ;
+lugalmagure$Lugal-magure ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca icum$field Išum ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca dugecika$field Hillock-of-plantoil ;
+urdumuzida engar$Ur-Dumuzida , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3u surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca dugecika$field Hillock-of-plantoil ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca lugal$field King ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca X$field … ;
+luinanna engar$Lu-Inanna , the plowman ;
+NUMB gur$NUMB gur NUMB barig ,
+luduga$Lu-duga ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin cebi NUMB sila gur$total , its barley : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ;
+cunigin zizbi NUMB gur$total , its emmer : NUMB gur ;
+nubandagu luduga$oxen manager : Lu-duga ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ;
+aca lamah$field Lamaḫ ;
+lugalhegal engar$Lugal-ḫegal , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca lamah$field Lamaḫ ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca akicah$field Akišaḫ ;
+luduga engar$Lu-duga , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB iku surface area at NUMB less NUMB each ,
+zizbi NUMB gur$its emmer : NUMB gur ;
+aca ukunuti$field Ukunuti ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca amarsuencarakiag$field Amar-Suen-Šara-kiag ;
+ARADcara engar$ARAD-Šara , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca zalaga$field Flash ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca zaNUMB$field Za-nēr ;
+silasig engar$Silasig , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca usa dumu lugal$field bordering on Prince ;
+NUMB GAN NUMBta$NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi$its barley : NUMB ;
+aca kaGAN durbartab$field KaGAN of Hillock-of-Urbartab ;
+uremah engar$Ur-emaḫ , the plowman ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB barig NUMB ban2 ;
+cunigin zizbi NUMB gur$total , its emmer : NUMB gur ;
+nubandagu urcita$oxen manager : Ur-šita ,
+ugula urculpae$foreman : Ur-Šulpa’e ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca carahuma$field Šarahuma ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca amarsuencarakiag$field Amar-Suen-Šara-kiag ;
+nigdupae engar$Nigdupa’e , the plowman ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca carahuma$field Šarahuma ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca dugecika$field Hillock-of-Urbartab ;
+carazida engar$Šara-zida , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 NUMB iku surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca giapinkura$field Gi-apin-kuřa ;
+urdamu engar$Ur-Damu , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca carahuma$field Šaraḫuma ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB eše3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca zaNUMB$field Za-nēr ;
+cecani engar$Šešani , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca lamah$field Lamaḫ ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB less NUMB each ,
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca latur$field Latur ;
+cecani engar dumu iribare$Šešani , the plowman , son of Iribare ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca durbartab$field Hillock-of-Urbartab ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB eše3 surface area at NUMB less NUMB each ,
+zizbi NUMB gur$its emmer : NUMB gur NUMB barig ;
+aca ukunuti$field Ukunuti ;
+NUMB GAN NUMBta$NUMB eše3 NUMB iku surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca usa dumu lugal$field bordering on Prince ;
+NUMB GAN NUMBta$NUMB eše3 surface area at NUMB each ,
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca zalaga$field Flash ;
+uremah engar$Ur-emaḫ , the plowman ;
+NUMB gur urculpae$NUMB gur , Ur-Šulpa’e ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB barig ;
+cunigin zizbi NUMB gur$total , its emmer : NUMB gur NUMB barig ;
+nubandagu urculpae$oxen manager : Ur-Šulpa’e ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ,
+NUMB GAN NUMB la NUMBta$NUMB bur3 surface area at NUMB less NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca lugal$field King ;
+NUMB GAN NUMBta$NUMB bur3 surface area at NUMB each ,
+cebi NUMB gur$its barley : NUMB gur ;
+aca durbartab$field Hillock-of-Urbartab ;
+eradan engar$Erra-dan , the plowman ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+NUMB GAN NUMB la NUMBta$NUMB bur3 surface area , NUMB les NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB ban2 ;
+aca lugal$field King ;
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku surface area , NUMB each ;
+cebi NUMB gur$its barley : NUMB gur NUMB barig ;
+aca durbartab$field Hillock-of-Urbartab ;
+X engar$…la , the plowman ;
+NUMB gur$NUMB gur
+caninga$Ša-ninga ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 surface area at NUMB less NUMB each ;
+cunigin cebi NUMB gur$total , its barley : NUMB gur NUMB barig NUMB ban2 ;
+ugula caninga$foreman : Ša-ninga ,
+GANgu$plow-domain ;
+NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cebi NUMB gur$its barley : NUMB gur ;
+aca akicah$field Akišaḫ ;
+lukala engar$Lukalla , the plowman ;
+nubandagu lugalazida$oxen manager : Lugal-azida ;
+gu gula$oxen of Gula ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB each ,
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB šar2 NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMB la NUMBta$total : NUMB šar2 NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB less NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB eše3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN NUMBta$total : NUMB bur3 NUMB iku surface area at NUMB each ;
+cunigin NUMB GAN aca bala NUMBta$total : NUMB eše3 surface area , field of bala , at NUMB each ;
+cunigin NUMB GAN aca bala NUMB la NUMBta$total : NUMB eše3 NUMB iku surface area , field of bala , at NUMB less NUMB each ;
+cunigin NUMB GAN aca bala NUMB la NUMBta$total : NUMB iku surface area , field of bala , at NUMB less NUMB each ;
+cunigin cebi NUMB guru NUMB sila gur$total , its barley : NUMB silo NUMB gur NUMB barig NUMB ban2 NUMB sila3 ;
+cunigin zizbi NUMB sila gur$total , its emmer : NUMB gur NUMB barig NUMB sila3 ;
+cunigin gigbi NUMB sila gur$total , its wheat : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ;
+niginba NUMB GAN$grand total : NUMB šar2 NUMB bur3 NUMB iku surface area ;
+niginba cebi NUMB guru NUMB sila gur$grand total , its barley : NUMB silo NUMB gur NUMB barig NUMB ban2 NUMB sila3 ;
+ce gecea$grain , threshed ;
+GAN kabduga$surface areas , inspected ,
+daumma$in Da-Umma ,
+giri luculgira$via Lu-Šulgira
+mu ibisuen lugale simurum muhul$year : “ Ibbi-Suen , the king , Simurrum destroyed . ”
+pisanduba$Basket-of-tablets
+di tila$xxx
+lucara$xxx
+luebgal$xxx
+ludingira$xxx
+urictaran$xxx
+dikubime$xxx
+igal$xxx
+ARADnanna$xxx
+sukkalmah ensi$xxx
+mu cusuen lugal$xxx
+numunani$to his seed
+hebtile$may he put an end .
+tukumbi$If
+gunesaga$from the cupboard
+u ubtae$he has removed it ,
+e nigura$and into a storehouse
+X$he shall bring it ,
+pisanduba$Basket-of-tablets
+kiri kabduga$xxx
+girsuta$xxx
+guabace$xxx
+igal$xxx
+mu en nanna karzida bahun$xxx
+ana$For
+i$the Divine River ,
+belicu$his lord ,
+culgi$Šulgi ,
+danum$the mighty ,
+X uri$king of Ur
+u X$and king
+enugi$For Ennugi
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+NUMB la NUMB guruc u NUMBce$NUMB male laborere workdays ,
+tir X$forest Šum-bad-…
+X$charcoal …
+gamala$Gamala ;
+ugula urama$foreman : Ur-amma ;
+kicib lugalnir$under seal of Lugalnir ;
+iti ezemculgi$month : “ Festival of Šulgi , ”
+mu narua badu$year : “ The stele was erected . ”
+lugalnir$Lugalnir ,
+dubsar$scribe ,
+dumu urcara$son of Ur-Šara ,
+cadubaka$chief accountant .
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+girisega$xxx
+erin sagapin$xxx
+e nance$xxx
+giri ureninnu$xxx
+dumu alamu$xxx
+igal$xxx
+mu cacrum bahul$xxx
+NUMB guruc hunga$NUMB male laborers , hirelings ,
+abi NUMB ginta kubabbar$the labor : NUMB shekel each , silver ,
+cagalbi NUMB ceta$the fodder : NUMB barig barley each ,
+kubabbarbi NUMB gin$its silver : NUMB shekels ,
+cebi NUMB gur$its barley : NUMB gur ;
+iti NUMBce$for NUMB month ,
+gizibi NUMB gu$its fodder-reed : NUMB talents ,
+ikunum cu bati$Ikunum received ;
+iti ezemninazu$month : “ Festival of Ninazu , ”
+mu ara NUMBkamac simurum bahul$year : “ For the ordNUMB time Simurrum was destroyed . ”
+NUMB udu niga NUMBkam us$NUMB sheep , barley-fed , of ordNUMB grade ,
+NUMB udu niga inanna$NUMB sheep , barley-fed , for Inanna ,
+ca X X X X$in … ;
+n mac X X$NUMB bucks … ,
+X UD X lugal X$…
+ca urima$in Ur ;
+NUMB udu niga NUMB X$NUMB sheep , barley-fed , NUMB … ,
+NUMB udu niga enki$NUMB sheep , barley-fed , for Enki ,
+NUMB udu niga dublamah$NUMB sheep , barley-fed , at Dublamaḫ ,
+ca eriduga$in Eridu ,
+atu ragaba mackim$Atu , rider , responsible official ;
+NUMB udu niga inanna unu$NUMB sheep , barley-fed , for Inanna of Uruk ,
+ahuni sagi mackim$Aḫuni , cupbearer , responsible official ;
+iti u NUMB la NUMB bazal$of the month , day NUMB elapsed ,
+ki naluta bazi$from Nalu booked out ,
+ca urima$in Ur ;
+iti ezemana$month : “ Festival of An , ”
+mu en nanna karzida bahun$year : “ The high-priestess of Nanna in Karzida was hired . ”
+amarsuen$Amar-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of four quarters
+urculpae$Ur-Šulpa’e ,
+dubsar$scribe ,
+dumu urhaia$son of Ur-Ḫaya ,
+ARADzu$your servant .
+pisanduba$Basket-of-tablets
+gurumak$inspections ,
+daba$seized ,
+girisega ensika$personnel of the governor ,
+erin urnigar dumu ursukkal$troops of Ur-Nigar , son of Ur-Sukkal ,
+erin urgigir dumu ginimu$troops of Ur-Gigir , son of Ginimu ,
+cuku mucendu$fishermen , bird-hunters ,
+euduniga girsu$house of fattened sheep of Girsu ,
+igal$are here ;
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destroyed . ”
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of leeks , NUMB shekels of oil , NUMB shekels of potash ,
+puzurmama$Puzur-Mama ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of leeks , NUMB shekels of oil , NUMB shekels of potash ,
+nursuen$Nur-Suen ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of leeks , NUMB shekels of oil , NUMB shekels of potash ,
+lusaga$Lu-saga ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of leeks , NUMB shekels of oil , NUMB shekels of potash ,
+kunanna$Ku-Nanna ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga X$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of leeks , NUMB shekels of oil , NUMB shekels of potash ,  … ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga nune$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of leeks , NUMB shekels of oil , NUMB shekels of potash ,  Nune ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga urcu$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels leeks , NUMB shekels of oil , NUMB shekels of potash ,  Ur-šu ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga X$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels leeks , NUMB shekels of oil , NUMB shekels of potash ,  Alla-x ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga lucgina$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels leeks , NUMB shekels of oil , NUMB shekels of potash ,  Lu-usz-gina ;
+NUMB kac NUMB ninda NUMB sila i itizu$NUMB ban2 of beer , NUMB ban2 of bread , NUMB sila3 of oil ,  Idissu ;
+NUMB kac dug dida saga NUMB dug dida du NUMB$NUMB ban2 of beer , the jug of fine-quality sweet wort  NUMB ban2 ;
+NUMB zigu saga NUMB dabin NUMB sila i$NUMB ban2 of fine-quality pea-flour , NUMB barig NUMB ban2 of semolina , NUMB sila3 of oil
+kas huhunurita era$the messengers that have come from Ḫuḫnuri .
+cunigin NUMB sila kac NUMB dug dida saga NUMB dug dida du NUMB$Total : NUMB barig NUMB ban2 NUMB sila3 of beer , NUMB jug of fine-quality sweet wort ;
+cunigin NUMB sila ninda NUMB zigu saga NUMB dabin$total : NUMB ban2 NUMB sila3 of bread , NUMB ban2 of fine-quality pea-flour , NUMB barig NUMB ban2 of semolina ;
+cunigin NUMB sila NUMB gin cum cunigin NUMB sila NUMB gin i$total : NUMB sila3 NUMB shekels of leeks ; total : NUMB sila3 NUMB shekels of oil ;
+cunigin NUMB gin naga$total : NUMB shekels of potash .
+u NUMBkam$ordNUMB day ,
+iti paue$month : “ pa’u’e , ”
+mu simanum bahul$year : “ Simanum was destroyed . ”
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal X$and king … ,
+X$…-ene
+ki nubandata$from the nubanda
+X$…-Iškur
+cu bati$received ;
+iti cesagku$month : “ Harvest , ”
+u NUMB zala$ordNUMB day passed ,
+mu guzamah enlila badim$year : “ Great-throne of Enlil was fashioned . ”
+pisanduba$Basket-of-tablets
+gurumak daba$inspections , seized ,
+geme ucbar$female weavers ,
+ca kinunir$in Kinunir ,
+ca nigin$in Nigin ,
+ca lagac$in Lagash ,
+u ca uru$and in Uru ,
+gabari ensigal$copies of big-governor ,
+urlamma ensi$Ur-Lamma , governor ,
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+gurum ak simug$xxx
+dubsar ekiciba$xxx
+gala nigin$xxx
+nubanda urnance$xxx
+nubanda urutu$xxx
+nubanda lukala$xxx
+sagi$xxx
+abairi$xxx
+ekurucda girsu$xxx
+nubanda ahua$xxx
+e nance$xxx
+ec didlibi$xxx
+emuhaldim$xxx
+gala guaba$xxx
+udulu dubsar gu udu$xxx
+lu kas sadu$xxx
+cuku mucendu$xxx
+NUMB gu NUMB mana siki$NUMB talent NUMB mana wool ,
+ekiciba ca nibruta$from the storage facility in Nippur ,
+dudu$Dudu
+cu bati$received ;
+iti ezemninazu$month : “ Festival of Ninazu , ”
+mu usa ara NUMBkamac simurum bahul$year after : “ For the ordNUMB time Simurrum was destroyed . ”
+pisanduba$Basket-of-tablets
+zi KA$flour …
+iria gara$in the city set ,
+NUMB GAN$NUMB iku fields ,
+NUMB gurta$NUMB gur each ,
+girsuta$from Girsu
+guabace$to Guabba ,
+igal$are here ;
+bala dug sag$bala of the head-jugs ,
+mu simurum bahul$year : “ Simurum was destroyed . ”
+pisanduba$Basket-of-tablets
+dubgida lu idabkene$long-tablets of the takers ,
+giri luningirsu$via Lu-Ningirsu ,
+igal$are here ;
+mu usa urbilum bahul$year following : “ Urbilum was destroyed . ”
+NUMB ce gur$NUMB gur NUMB barig barley ,
+ce aca ambartur$barley of the field Small-marsh ,
+ziKA a geme ucbar$…-flour , labor of the female textile workers ,
+lagackace$to Lagash ,
+ki lugula$from Lugula ,
+sanga dumuzita$high priest of Dumuzi ,
+kicib luningirsu$under seal of Lu-Ningirsu ,
+giri lutu dumu lugina$via Lu-Utu , son of Lugina ;
+mu mada zabcali bahul$year : “ The lands of Zabšali were destroyed . ”
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil ,
+cukubum$for Šukubum ;
+NUMB sila kac saga NUMB sila ninda NUMB gin cum NUMB gin i$NUMB sila3 fine beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil ,
+ugula ucbar cecsaga$for the foreman of weavers , Šeš-saga ;
+NUMB sila kac saga NUMB sila ninda NUMB gin i NUMB gin naga$NUMB sila3 fine beer , NUMB sila3 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+ludamu$for Lu-Damu ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+cuenlil$for Šu-Enlil ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil ,
+banican$for Banišan ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil ,
+nabasa$for Nabasa ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekel alkali-plant ,
+nahanum$for Naḫanum ;
+n sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin nag$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+ursaga$for Ur-saga ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+mida$for Mida’a ;
+n sila kac n sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+X NI X$for … ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+imti sukkalme$for … ;  are messengers ;
+NUMB sila kac NUMB sila ninda NUMB cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+caga$for Šaga ;
+cunigin NUMB kac saga cunigin NUMB n kac$total : NUMB ban2 fine beer ; total : NUMB ban2 NUMB beer ;
+cunigin n n sila ninda cunigin NUMB sila la NUMB gin cum$total : NUMB ban2 NUMB sila3 bread ; total : NUMB sila3 less NUMB shekels onions ;
+cunigin NUMB sila NUMB gin i cunigin NUMB la NUMB gin naga$total : NUMB sila3 NUMB shekels oil ; total : NUMB less NUMB shekels alkali-plant .
+u NUMBkam$ordNUMB day ;
+iti cesagku$month : “ Harvest ; ”
+mu usa simanum bahul$year after : “ Simanum was destroyed . ”
+pisanduba$Basket-of-tablets
+dubgida$long-tablets of
+lutu sadu$Lu-Utu , chief surveyor ,
+igal$are here ;
+mu simurum lulubu ara NUMB la NUMBkamac bahul$year : “ Simurum Lulubu for the ordNUMB time were destroyed . ”
+pisanduba$Basket-of-tablets
+niginba ceba$xxx
+u gurua taka$xxx
+girsuta$xxx
+guabace$xxx
+igal$xxx
+mu cusuen lugal urimake madarabzu enkika bindu$xxx
+pisanduba$Basket-of-tablets
+dub gida$long-tablets ,
+lu nigdab$takers
+ugnim$of Ugnim ,
+igal$are here ;
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents . … ,
+urgigir cabra$Ur-gigir , the chief household administrator ,
+igal$are here ;
+mu enmahgalana en nanna bahun$year : “ Enmahgalana , en- of Nanna , was hired . ”
+urcara$Ur-Šara ,
+dubsar$scribe ,
+dumu lugalucur$son of Lugal-ušur .
+pisanduba$Basket-of-tablets
+sagnigura$xxx
+lu nigdabakene$xxx
+igal$xxx
+mu ibisuen lugal urimake simurum muhul$xxx
+NUMB gu u$NUMB grass ox ,
+NUMB udu u$NUMB grass small cattle ,
+NUMB mac gaba$NUMB unweaned male goats ,
+cugid emuhaldim$šugid offerings for the house of the cook
+mu agaus u lu cukurakenece$in the name of the royal guard and prebend-holders .
+ARADmu mackim$ARADmu was maškim .
+u nkam$nth day .
+ki X$Out of nn’s
+bazi$booked .
+giri nannamaba dubsar$Via : Nanna-maba the scribe .
+iti ezemcusuen$Month “ Šu-Suen festival , ”
+mu ibisuen lugal$year : “ Ibbi-Suen is king . ”
+NUMB gu NUMB udu$NUMB ox , NUMB small cattle .
+pisanduba$Basket-of-tablets
+girisega e bagara$xxx
+e uru$xxx
+e gatumdu$xxx
+e igalim$xxx
+e inanna$xxx
+e ninsun$xxx
+pisanduba$Basket-of-tablets
+sagnigura$debits
+u ziga$and credits ,
+cabi suga$therefroms , restitutions , of
+basa dubsar kurucda$Basa , scribe of fatteners ,
+igal$are here ;
+mu bad mada badu$year : “ The wall of the lands was erected . ”
+pisanduba$Basket-of-tablets
+dubgida$long-tablets of
+lubaba dumu balu$Lu-Baba , son of Balu ,
+u lugula$and Lugula ,
+dumu urigizibara$son of Ur-Igizibara ,
+igal$are here ;
+mu harci hurti bahul$year : “ Ḫarsi Ḫurti were destroyed . ”
+pisanduba$Basket-of-tablets
+kicib daba caze$sealed documents of conveyances of Šaze ,
+ureka$Ur-e’e ,
+igal$are here ;
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+NUMB sila ga$NUMB suckling lambs ,
+NUMB kir ga$NUMB suckling female lamb ,
+utuda$newborns ;
+u NUMBkam$the ordNUMB day
+ca nagabtuma$inside the Fattening House
+ludingira$Lu-dingira
+idab$accepted ;
+iti kisikininazu$month : “ ki-siki of Ninazu , ”
+mu guza enlila badim$year : “ The throne of Enlil was fashioned ; ”
+NUMB$NUMB .
+NUMB kac dida NUMB sila kac saga$One pot of dida beer , five sila3 of high-quality beer ,
+NUMB ninda NUMB gin i NUMB gin naga$one ban2 of bread , two shekels of oil and two shekels of alkali ,
+NUMB ku NUMB sa cum$three fish and three bunches of onions
+agua sukkal gabac$Agu’a , the messenger ,  to Persia ;
+NUMB kac dida NUMB sila i$one pot of dida beer , six shekels of oil ,
+NUMB ninda NUMB gin i NUMB gin naga$one ban of bread , two shekels of oil , two shekels of alkali ,
+NUMB ku NUMB sa cum$three fish and three bunches of onions
+ikala sukkal X$Ikalla , the messenger , … ;
+NUMB sila kac NUMB sila ninda$Three sila3 of beer , two sila3 of bread ,
+NUMB gin i NUMB gin naga$two shekels of oil , two shekels of alkali ,
+NUMB ku NUMB sa cum$one fish , one bunch of onions
+dugamu kausa$Dugamu the … ;
+cunigin NUMB kac dida du NUMB$total : two pots of average-quality dida beer ;
+cunigin NUMB sila kac saga cunigin NUMB gin i$total : five sila3 of high-quality beer ; total : NUMB shekels of oil ;
+cunigin NUMB sila ninda cunigin NUMB gin i$total : NUMB ban2 NUMB sila3 of bread ; total : six shekels of oil ;
+cunigin NUMB gin naga$total : NUMB shekels of alkali ;
+cunigin NUMB ku cunigin NUMB sa cum$total : NUMB fish ; total : NUMB bunches of onions ;
+u NUMBkam$ordNUMB day ,
+iti sigicubagar$month : “ Bricks-placed-in-moulds , ”
+mu usa ma enki babdu$year after : “ The boat of Enki was caulked . ”
+NUMB sa gi$NUMB bundles of reed , 
+kicib lugalezem$under seal of Lugal-ezem . 
+NUMB gu manu$NUMB bundles of willow wood ,
+NUMB asal NUMB kucta$NUMB poplar trunks , NUMB cubits each
+ki aduta$From Adu ? ;
+kicib ensika$under seal of the governor ,
+ca bala$of the bala ;
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+amarsuen$Amar-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four quarters
+urlisi$Ur-Lisi ,
+ensi$governor
+umma$of Umma ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+acata eda$from the fields sent out ,
+e ninmar$house of Ninmar ,
+igal$are here ;
+mu ibisuen lugal$year : “ Ibbi-Suen is king . ”
+ca nibru$in Nippur .
+NUMB GAN aca ugurtursagdu$NUMB bur3 field area : fields of Ugurtur-sagdu ;
+NUMB GAN aca ucgida$NUMB bur3 field area : field of Long-side ;
+NUMB GAN aca X$NUMB bur3 field area : field of … ;
+nigala kin X ak$property , … work done ;
+NUMB GAN$NUMB bur3 field area
+aca agarsagdu$field of Agar-sagdu ;
+X NUMB GAN DIC$… NUMB bur3 field area : one
+aca ducara$field of Du-Šara ;
+NUMB GAN aca aegirGAN lucara$NUMB bur3 field area : field of Weir-field of Lu-Šara ;
+nigala ade gue NUMB GANta ibdab$property , flood irrigation with oxen at NUMB bur3 field area , seized .
+pisanduba$Basket-of-tablets
+enbi tare$xxx
+nigka a$xxx
+igal$xxx
+mu cacru bahul$xxx
+pisanduba$Basket-of-tablets
+etum$xxx
+sagnigura$xxx
+u ziga$xxx
+duga$xxx
+iti macdaguta$xxx
+iti diri cesagkuce$xxx
+iti NUMBkam$xxx
+mu en nanna karzida bahun$xxx
+igal$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four quarters
+turamdagan$Tūram-Dagan ,
+cui$barber ,
+ARADzu$is your servant .
+ningirsu$For Ningirsu ,
+ursag kalga$the mighty warrior
+enlila$of Enlil ,
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+e bagarakani$his Bagara temple
+munadu$he built for him .
+inanna$To Innna ,
+ninani$his mistress ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+e durankikani$her Duranki temple
+munadu$he built for her
+kibe munagi$and restored to its previous condition for her .
+namtilanice$For his life
+a munaru$he dedicated  to her .
+pisanduba$Basket-of-tablets
+pisan urigalim$xxx
+dumu amini$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+mu didli$xxx
+ce erine gua$xxx
+igal$xxx
+e ninmarka namerim baku$xxx
+giri gudea$xxx
+mu enunugal bahun$xxx
+pisanduba$Basket-of-tablets
+ce dea$barley delivered ,
+urlamma ensi$Ur-Lamma , governor ,
+mu karhar ara NUMBkam bahul$year : “ Karḫar for the ordNUMB time was destroyed , ”
+mu ancan$year : “ Anšan , ”
+mu usa ancan$year : following “ Anšan , ”
+mu nanna karzida$year : “ Nanna of Karzida , ”
+mu bad mada$year : “ Wall of the lands , ”
+mu e puzuricdagan$year : “ The house of Puzriš-Dagan , ”
+ce dea iri igi NUMB gara$barley delivered , cities ordNUMB set ,
+ce dea gurgi mu cacrum bahul$barley delivered , … year : “ Šašrum was destroyed , ”
+nigdudu ce mu e puzuricdagan$… barley , year : “ The house of Puzriš-Dagan , ”
+ce dea mu usa e puzuricdagan$barley delivered , year following : “ The house of Puzriš-Dagan , ”
+a hunga aca duge urima$labor of hirelings , field of Duge of Ur .
+pisanduba$Basket-of-tablets
+kiri kabduga girsuta$xxx
+guabace$xxx
+igal$xxx
+mu e cara badu$xxx
+enlil$For Enlil ,
+lugal kurkura$king of all the lands ,
+lugalnir$his master ,
+amarsuen$Amar-Suena ,
+nibrua$one whom in Nippur
+enlile$Enlil
+mu pada$nominated ,
+sagus$the constant supporter
+e enlilka$of the temple of Enlil ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+ekuraigigal$the Ekura-igigal ,
+e X$the ziggurat temple ,
+e kiagani$his beloved temple ,
+munadu$he built for him .
+pisanduba$Basket-of-tablets
+di tila$xxx
+igal$xxx
+mu usa e puzuricdagan badu$xxx
+pisanduba$Basket-of-tablets
+udu cukura$sheep of allocation ,
+X X X X$…
+girsuta$from Girsu
+guabace$to Guabba
+igal$are here .
+mu cusuen lugal urimake urbilum muhul$year : “ Šu-Suen , king of Ur , Urbilum destroyed . ”
+NUMB udu$NUMB sheep ,
+NUMB macgal cimacgi$NUMB Šimašgi buck goats ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga ,
+endingirmu$En-dingirmu
+idab$accepted ;
+iti cueca$month : “ Šu-eša , ”
+mu enmahgalana en nanna bahun$year : “ Enmaḫ-gal-ana , lord of Nanna , was installed ; ”
+NUMB$.
+NUMB u$NUMB ewe ,
+bauc u NUMBkam$slaughtered , the ordNUMB day ,
+ca tumal$in Tummal ;
+ki endingirmuta$from Endingirmu
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti ezemninazu$month : “ festival of Ninazu , ”
+mu en nanna bahun$year : “ the en-priestess of Nanna was installed . ”
+pisanduba$Basket-of-tablets
+niginba ceba$xxx
+u gurua takabi$xxx
+girsuta$xxx
+guabace$xxx
+igal$xxx
+mu ibisuen lugal$xxx
+NUMB mana zabar$NUMB mina of bronze ,
+bigubi NUMB gin$its “ loss ” : NUMB shekels ,
+naggabi NUMB gin$its tin : NUMB shekels ,
+uruda luhabi NUMB mana NUMB gin$its cleaned copper : NUMB mina NUMB shekels ,
+bigu uruda luhabi NUMB gin NUMB ce$its cleaned copper “ loss ” : NUMB shekels NUMB grains ,
+suhebi NUMB gin NUMB ce$its arsenic ? : NUMB shekel NUMB grains ,
+pisanduba$Basket-of-tablets
+etum$xxx
+sagnigura$xxx
+u ziga$xxx
+ki ahunita$xxx
+iti macdagu$xxx
+iti ezemanace$xxx
+iti NUMBkam$xxx
+mu amarsuen lugal$xxx
+lugal enlile$the king whom Enlil
+kiag$as beloved
+cagana$in his heart
+inpa$did choose
+sipa kalamace$as the shepherd of his country ,
+lugal kalga$the strong king ,
+pisanduba$Basket-of-tablets
+kacdea u ninda cura$Beer ceremonty and Bread-spread
+culgira$of Šulgi
+igal$are here ;
+cusuen$For Šũ-Sîn ,
+kiag enlila$the beloved of Enlil ,
+lugal enlile$the king whom Enlil
+kiag cagana$as one beloved in his heart
+inpa$did choose ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+dingir kiagani$his beloved god ,
+habaluge$Habaluge ,
+ensi$the governor
+adab$of Adab ,
+ARADdane$his servant ,
+e kiagani$his beloved temple
+munadu$he built for him .
+pisanduba$Basket-of-tablets
+im a uda hedab$xxx
+ca sagdanaka$xxx
+iti cunumun$xxx
+iti munugu$xxx
+iti ezemdumuzi$xxx
+igal$xxx
+mu en nanna karzida bahun$xxx
+pisanduba$Basket-of-tablets
+dub gida$long-tablets
+ce ca sila X NUMB DUB$barley …
+lugalsikisu$Lugal-
+X X GAR u X X ki$…
+igal$are here ;
+mu simurum lulubu ara NUMB la NUMBkamac bahul$year : “ Simurum Lulubu for the ordNUMB time were destroyed . ”
+NUMB amar macdamunus$NUMB female gazelle fawn
+tulidutuci$for Tulid-Šamši ,
+belili mackim$Bēlī-ilī , responsible official ;
+ca mukurata$from the delivery ,
+u NUMBkam$the ordNUMB day ,
+ki intaeata bazi$from Inta’e’a booked out ,
+giri nannamaba dubsar$via Nanna-maba , the scribe ;
+iti sesdagu$month : “ Piglet feast , ”
+mu cusuen lugal$year : “ Šu-Sin is king ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+niginba sikiba$xxx
+igal$xxx
+mu e cara$xxx
+ummaka badu$xxx
+NUMB sa gizi$NUMB bundles , fodder-reed ,
+guniginba NUMB sata$their bales at NUMB bundles each ,
+gi dumugi cukune$reeds of dumugi and fisheries laborers ;
+NUMB sa gizi$NUMB bundles , fodder-reed ,
+guniginba NUMB sata$their bales at NUMB bundles each ,
+ki urenlilata$from Ur-Enlil ,
+kicib gurzan$under seal of Gurzaran ,
+giri basaga$via Basaga ,
+ganun aba$storehouse of A’abba ;
+iti minec$month : “ Mineš , ”
+mu usa kimac bahul$year after : “ Kimaš was destroyed . ”
+gurzan$Gurzaran
+dumu ala$son of Alla .
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters .
+NUMB mana gina$NUMB mana , established ,
+luigimana$Lu-Igimana .
+nanna$For Nanna ,
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+NUMB mana$five minas
+munagin$he standardized for him .
+pisanduba$Basket-of-tablets
+gurumak daba$inspections of dab ,
+erin sagapin$troops , head plowmen ,
+ugIL$porters ,
+e culgi$of the house of Šulgi ,
+u e ningeczida$and the house of Ningešzida ,
+igal$are here ;
+mu huhunuri bahul$year : “ Ḫuḫnuri was destroyed ”
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewes ,
+NUMB sila$NUMB lambs ,
+cugid emuhaldimce$šugid offerings for the kitchen ;
+u NUMBkam$ordNUMB day ,
+ki abasagata bazi$from Abbasaga booked out ;
+iti cesagku$month : “ Harvest , ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destroyed ; ”
+NUMB$NUMB .
+NUMB sila ga$NUMB male suckling lambs ,
+NUMB kir ga$NUMB suckling ewe lambs ,
+utuda$newborns ,
+ca nagabtum$in nakabtum ,
+u NUMBkam$ordNUMB day ;
+culgiamu idab$Šulgi-ayagu received ;
+iti ezemah minkam$month “ Great Festival , ” second ,
+mu en nanna bahun$year : “ The high-priestess of Nanna was hired ; ”
+NUMB udu$NUMB sheep .
+na NUMB mana$stone : NUMB mana .
+NUMB guruc u NUMBce$NUMB laborer workdays ,
+zar taba$sheaves piled up ;
+ugula lukala$foreman : Lukalla ;
+kicib aba$under seal of A’aba ;
+iti sigicubagara$month : “ Bricks cast in moulds ”
+mu usa e puzurdagan badu mu usabi$year after : “ The house of Puzriš-Dagan was erected , ” year after that .
+lucara$Lu-Šara ,
+dubsar$scribe ,
+dumu inimcara$son of Inim-Šara
+saduka$the chief surveyor .
+lugirizal$Lu-Girizal ,
+dubsar$scribe ,
+dumu dadumu$son of Dadu-mu .
+NUMB udu niga $NUMB sheep , barley-fed ,
+NUMB macgal niga cimacgi $NUMB big-billy , barley-fed , Šimašgian ,
+e muhaldimce $to the kitchen
+mu kaskenece $because of the runners ;
+ARADmu mackim $ARADĝu is the enforcer ;
+iti u NUMB bazal $of the month the ordNUMB day has passed ;
+ca unuga $in Uruk
+ziga $booked out ;
+ki ludingira $from Lu-dingira
+iti ubigu $month “ ubi feast , ”
+mu kimac u hurti bahul $year : “ Kimaš and Ḫurti were destroyed ; ”
+NUMB udu $NUMB sheep .
+enlil$Enlil
+X$indeed gave to him ,
+X$to
+cusuen$Šū-Sîn ,
+X$the mighty ,
+lugal uri$the king of Ur
+u lugal$and king
+X$of the world quarters
+X$the four ,
+X$favorite
+enlil$of Enlil
+X$and
+suen$Sîn ,
+X simackim$the lands of Simaški .
+X$He destroyed
+mada zabcali$the land of Zabšali ,
+X$the land of Sigriš ,
+X nibulmat$the land of Nibulmat ,
+X alumidatim$the land of Alumiddatim ,
+X garta$the land of Garta ,
+X catilu$and the land Šatilu —
+cunigin NUMB mada$a total of six lands .
+azahar$Azaḫar ,
+bulma$Bulma ,
+nucucmar$Nušušmar ,
+nucganelum$Nušganelum ,
+zizirtum$Zizirtum ,
+arahir$Araḫir ,
+indasu X$Indasu …
+u nic X$and the life of …
+X X$in order with his life
+X X$to escape … ,
+u X$and the deity …
+u X$and the deity …
+X$and the gods
+cara X$the whole … ,
+u ninurta$and Ninurta
+mackim X$as bailiff …
+X X X X$in …
+X kusig$From the gold
+X X$which he plundered
+X$a statue of himself
+X$he created , and
+X$to
+enlil$Enlil
+X$his lord
+X$for
+X$his life
+a munaru$he dedicated it .
+X X$The one who tablet
+X$this
+X$shall remove ,
+enlil$may Enlil
+u X$and Ninlil
+X$his foundation
+X$tear out
+u X$and his seed
+X$pluck up .
+musara$Inscription
+ur indasu$on the hip of Indasu ,
+lugal caga$the captive king .
+indasu$Indasu ,
+ensi$governor
+zabcali$of Zabšali .
+musara$Inscription
+zagana$on his shoulder .
+cusuen$Šū-Sîn ,
+kiag enlila$beloved of Enlil ,
+lugal enlile$the king whom Enlil
+kiag cagana$as the one beloved of his heart
+inpa$did choose ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur and
+lugal an ubda limmuba$king of the four world quarters .
+musara$Inscription
+murgu X$on the back of … ,
+lu indasu$a man of Indasu
+lugal caga$the captive king ,
+giri anusa$with a foot pressed down on him .
+titi$Titi ,
+ensi$governor
+nucucmar$of Nušušmar .
+musara$Inscription
+za zidana$on his right shoulder .
+samri$Samri ,
+ensi$governor
+X$of …-li-x .
+musara$Inscription
+girina$on his foot .
+X$Nu-x-li ,
+ensi$governor
+alumidatim$of Alumiddatum
+musara$Inscription
+gabana$on his chest .
+bunirni$Bunirni ,
+ensi$governor
+sigric$of Sigriš .
+musara$Inscription
+za gubu$on his left shoulder
+egirana$behind it .
+barihiza$Bariḫiza ,
+ensi$governor
+arahir$of Araḫir .
+musara$Inscription
+egir za gubuna$behind his left shoulder .
+waburtum$Waburtum ,
+ensi$governor
+lulubim$of Lulubum .
+musara$Inscription
+za gubuna$on his left shoulder .
+NUMB lu cuduamec absar$They are six captured men , written upon
+NUMB lu enugbi nubsar$and their six guards , not written upon .
+nenibzu$Nenibzu ,
+ensi$governor
+zizirtum$of Zizirtum .
+musara$Inscription
+egir zidana$behind his right side .
+tirubiu$Tirubi'u ,
+ensi$governor
+nucganelum$of Nušganelum .
+musara$Inscription
+egir za zidani$behind his right shoulder .
+X$…-amti ,
+ensi$governor
+garta$of Garta .
+musara$Inscription
+zasi zidani$on his right shoulder-top .
+dungat$Dungat ,
+ensi$governor
+nibulmat$of Nibulmat .
+musara$Inscription
+zasi zidani$on his right shoulder-top .
+NUMB lu cuduamec absar$They are four captured men , written upon
+NUMB lu enugbi nubsar$and their four guards , not written upon .
+igina egirana$In front of him , behind him ,
+zida gubuna$on his right and left sides .
+musara$Inscriptions
+lugal cagamec$the captive kings
+u cusuen$and Šū-Sîn ,
+lu indasu$who upon Indasu
+giri anusa$has pressed down his foot .
+e aca laturta$A dike from the field Latur
+NUMB ninda gid NUMB sarta saharbi NUMB sar$NUMB ninda long at one , its soil : NUMB sar ;
+NUMB ninda gid nutuku$NUMB ninda long without ;
+NUMB ninda gid NUMB sarta$NUMB ninda long at NUMB sar per ,
+saharbi NUMB saram$its soil : NUMB sar ;
+NUMB ninda gid NUMB sarta$NUMB ninda long at NUMB sar per ,
+saharbi NUMB sar$its soil : NUMB sar ;
+NUMB ninda gid NUMB sarta$NUMB ninda long at NUMB sar per ,
+saharbi NUMB sar$its soil : NUMB sar ;
+NUMB ninda gid NUMB sarta$NUMB ninda long at NUMB sar per ,
+saharbi NUMB sar$its soil : NUMB sar ;
+NUMB ninda gid NUMB sarta$NUMB ninda long at NUMB sar per ,
+saharbi NUMB sar$its soil : NUMB sar ;
+NUMB ninda gid NUMB sarta$NUMB ninda long at NUMB sar per ,
+saharbi NUMB sar$its soil : NUMB sar ;
+NUMB ninda gid NUMB sarta$NUMB ninda long at NUMB sar per ,
+saharbi NUMB sar$its soil : NUMB sar ;
+NUMB ninda gid NUMB sarta$NUMB ninda long at NUMB sar per ,
+saharbi NUMB sar$its soil : NUMB sar ;
+NUMB ninda gid NUMB sarta$NUMB ninda long at NUMB sar per ,
+sahar$its soil : ;
+NUMB ninda NUMB sarta$NUMB ninda long at NUMB sar per ,
+saharbi NUMB sar$its soil : NUMB sar ;
+cunigin NUMB sar sahar$total : NUMB sar soil ;
+kin e ra$work “ striking ” the dike ,
+e sadura igi emah$the dike at the end of the field facing Emaḫ ;
+mu en inanna unu mace ipa$year : “ The en-priest of Inanna in Uruk was chosen by means of a goat ; ”
+NUMB$NUMB . NUMB
+pisanduba$Basket-of-tablets
+pisan ludingira dumu kusaga$xxx
+nita kalga$the strong man ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+namtilanice$for his life
+NUMB mana$thirty minas
+munagin$he standardized  for him .
+NUMB udu alum niga$NUMB sheep , ašlum , grain-fed ,
+bauc ca libir$slaughtered , among the “ old , ”
+u NUMBkam$ordNUMB day ;
+ki turamdaganta$from Tūram-Dagan
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti sesdagu$month : “ Piglet-feast , ”
+mu X$year : “ … ; ”
+NUMB$NUMB .
+amarsuen$Amar-Suen ,
+nibrua$in Nippur
+enlile$by Enlil
+mu pada$called by name ,
+sagus$“ headrest ”
+e enlilka$in the house of Enlil ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners .
+NUMB gu sikikura$NUMB talents of mountain wool
+ki ensita$from the governor
+dadaga$Dadaga
+cu bati$received ;
+iti paue$month : “ Pa’u’e , ”
+mu usa kimac bahul$year after : “ Kimaš was destroyed . ”
+namrac$that which into booty
+munaka$he had made for him
+namtilanice$for his life
+a munaru$he dedicated to him .
+lugalic$Šarriš ,
+X$scribe .
+inanna$For Inanna
+ninsuana$Ninsiana ,
+ninanir$his mistress ,
+amarsuen$Amar-Suena ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+eani$her temple
+munadu$he built for her .
+pisanduba$Basket-of-tablets
+sagnigura$credits ,
+cabi suga$therefroms , restitutions , of
+ceckala dumu nasilim$Šeškalla , son of Nasilim ,
+igal$are here .
+n gin n ce ku$NUMB shekels … grains of silver , 
+mac acaga$interest of the field , 
+ki urdunta$from Ur-dun 
+dadaga$did Dadaga 
+cu bati$receive ; 
+mu urbilum bahul$year : “ Urbilum was destroyed . ” 
+pisanduba$Basket-of-tablets
+nigkak sagnigura$accounts , debits ,
+engar dumugugur$plowmen , young oxen turners , of
+e nance$the house of Nanše
+u e dumuzi$and the house of Dumuzi ,
+igal$are here ;
+mu simurum bahul$year : “ Simurum was destroyed . ”
+NUMB cuera dumu urgilgameska$NUMB : Šu-Erra , son of Ur-Bilgames ,
+NUMB gin kubabbarce$for NUMB shekels of silver
+ahima insa$Aḫīma bought .
+pusunum ugulagecdakani$Pussunum , his officer-of-sixty ,
+nusa bidu$“ He did not buy him ” said ;
+NUMB cuera$NUMB : Šu-Erra
+NUMB cukubum$NUMB : Šukubum
+NUMB azuli X$NUMB : Azuli … ,
+namluinimace imtaec$as witnesses appeared .
+caba cuera namerim kude bacum$Among them , Šu-Erra to take the oath was delivered .
+cuera namerim unku$After Šu-Erra had sworn ,
+ahima sag cuna bangigi$Aḫīma the slave took over ;
+igi luamanace$in the presence of Lu-amana ;
+mu amarsuen lugale urbilum muhul$year “ The king Amar-Suen Urbilum destroyed . ”
+NUMB gin NUMB ce kubabbar$NUMB shekels NUMB grains of silver ,
+urce ki urenlilata$for interest , from Ur-Enlila ,
+lugalsaga$Lugal-saga ,
+u urcumah$and Ur-Šumaḫ ,
+cu bati$received .
+iti kuCIM$month : “ KuŠIM , ”
+u NUMB bazal$the ordNUMB day passed ,
+mu simanum bahul$year : “ Simanum was destroyed . ”
+NUMB gu NUMB mana sikigi$NUMB talents NUMB minas of yellowish wool
+ki naramilita$from Naram-ilī ,
+muku$delivery ;
+culgimicar$Šulgi-mišar
+cu bati$received ;
+iti cesagku$month : “ Harvest , ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Sin , the king , Urbilum destroyed . ”
+NUMB undaga$NUMB : Undaga ,
+iti cesagkuta$from the month “ Harvest ”
+lucara idab$Lu-Šara took control of .
+X$…
+ugula ludingira$foreman : Lu-dingira
+mu ma enki babdu$Year : “ The boat of Enki was caulked . ”
+lucara$Lu-Šara ,
+dubsar$scribe ,
+dumu lugalinimgina$son of Lugal-inim-gina .
+NUMB sila$NUMB lamb ,
+ensi umma$the governor of Umma ;
+NUMB udu cimacgi niga$NUMB Šimašgi sheep , grain-fed ,
+NUMB sila ARADmu$NUMB lamb , ARADmu ;
+NUMB gukkal niga NUMB mac niga$NUMB fat-tailed sheep , NUMB billy , grain-fed ,
+NUMB sila lugalkuzu$NUMB lamb , Lugal-kuzu ;
+NUMB sila$NUMB lambs ,
+ninlilimti$Ninlil-imti ;
+u NUMBkam$the ordNUMB day ,
+muku$as delivery
+abasaga idab$did Abbasaga accept ;
+iti ezemekigal$month “ Festival-of-Mekigal , ”
+mu X X$year : “ … . ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+kicib daba$xxx
+cecsaga ugula ucbar$xxx
+igal$xxx
+mu en eridu bahun$xxx
+NUMB dug dida NUMB sila kac saga $NUMB jug wort , NUMB sila3 fine beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ,
+puzurecdar sukkal gabac $for Puzriš-Ištar , the messenger , to the frontier ;
+NUMB dug dida NUMB sila kac $NUMB jug wort , NUMB sila3 beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ,
+lugaldingirmu $for Lugal-dingirmu ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundle onions ,
+nigbaba sukkal gabac $for Nig-Baba , the messenger , to the frontier ;
+cunigin NUMB dug dida du NUMB $total : NUMB jugs of common wort , NUMB ban2 ;
+cunigin NUMB sila kac saga cunigin NUMB sila kac $total : NUMB sila3 fine beer ; total : NUMB sila3 beer ;
+cunigin NUMB sila ninda cunigin NUMB gin i $total : NUMB ban2 NUMB sila3 bread ; total : NUMB shekels oil ;
+cunigin NUMB gin naga cunigin NUMB sa cum $total : NUMB shekels alkali-plant ; total NUMB bundles onions ;
+u NUMBkam $ordNUMB day ,
+iti X $month : …
+mu usa X $year following : …
+NUMB sila X X X$NUMB ban2 NUMB sila3 …
+NUMB sila X$NUMB barig NUMB ban2 NUMB sila3 …
+NUMB sila X$NUMB barig NUMB ban2 NUMB sila3 for E-…
+ki ludingira dumu inimcarata$from Lu-dingira , son of Inim-Šara ;
+NUMB sila X X$NUMB ban2 NUMB sila3 …
+NUMB sila X X$NUMB barig NUMB ban2 NUMB sila3 …
+NUMB sila X$NUMB barig NUMB ban2 NUMB sila3 for E-…
+ki ludingira dumu inimcarata$from Lu-dingira , son of Inim-Šara ;
+iti ubigu$month : “ ubi feast , ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destroyed . ”
+culgi$Šulgi ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+utuGIRgal$Utu-GIRgal ,
+dubsar$scribe ,
+catam ARADzu$official , your servant
+NUMB dug dida du NUMB sila kac saga $NUMB jug of common wort , NUMB sila3 fine beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB ku NUMB sa cum $NUMB fish , NUMB bundles onions ,
+nurickur gabac $for Nūr-Adda , to the frontier ;
+NUMB dug dida du NUMB sila kac du $NUMB jug of common wort , NUMB sila3 common beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB ku NUMB sa cum $NUMB fish , NUMB bundles onions ,
+idickur $for Idī-Adda ;
+u NUMBkam $ordNUMB day ,
+iti cekaragala $month : “ Barley at the quay . ”
+pisanduba$Basket-of-tablets
+niginba ceba$grand totals , rations ,
+u gurua takabi$and in the silo left ,
+girsuta$from Girsu
+guabace$to Guabba ,
+igal$are here ;
+mu X$year : “ … . ”
+NUMB laia lugalbanda$NUMB as arrears of Lugal-banda ,
+NUMB hada$NUMB of Ḫada ,
+NUMB urgalce$NUMB of Ur-galše ,
+NUMB duga$NUMB of Duga ,
+NUMB urgudena$NUMB of Ur-gudena .
+pisanduba$Basket-of-tablets
+im duru$wet tablets ,
+igal$are here .
+abakala$Abbakalla ,
+dumu urmes$son of Ur-mes .
+pisanduba$Basket-of-tablets
+etum$xxx
+sag nigka$xxx
+u ziga$xxx
+beliazu$xxx
+iti cesagkuta$xxx
+iti ezemekigalce$xxx
+iti NUMBkam$xxx
+mu cusuen lugal urimake bad martu muriqtidnim mudu$xxx
+igal$xxx
+pisanduba$Basket-of-tablets ;
+dub gida$long-tablets
+kicib ce X da$sealed documents … ,
+e X X NE$house of … ,
+igal$are here ;
+mu amarsuen lugal$year : “ Amar-Suen is king . ”
+amarsuen$Amar-Suen ,
+nibrua$in Nippur
+enlile$by Enlil
+mu pada$called by name ,
+sagus$“ headrest ”
+e enlilka$in the house of Enlil ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners .
+NUMB sila duh gur lugal$NUMB gur NUMB barig NUMB sila3 bran , royal ,
+NUMB geme u NUMBce$NUMB workdays , female laborers ,
+NUMB gu NUMB mana manu$NUMB talents NUMB mana willow ,
+NUMB sa gi$NUMB , NUMB bundles of reed ,
+situm$the remainder ;
+iti akiti$month : “ Akitu , ”
+mu simurum lulubum ara NUMB la NUMBkamac bahula$of the year : “ Simurrum , Lullubum for the ordNUMB time were destroyed ; ”
+NUMB ce gur$NUMB gur barley ,
+NUMB gig gur$NUMB gur wheat ,
+cagal gu udu mac ance$fodder of oxen , sheep , goats and equids ;
+NUMB gur ceba martune$NUMB gur NUMB barig barley rations of the Martu ,
+iti cesagku$month : “ Harvest ; ”
+NUMB ce gur$NUMB gur barley ,
+NUMB gig gur$NUMB gur wheat ,
+cagal gu udu mac ance$fodder of oxen , sheep , goats and equids ;
+NUMB gur ceba martune$NUMB gur NUMB barig barley rations of the Martu ,
+iti diri cesagku$month extra : “ Harvest ; ”
+X X da X X$…
+ce X X$…
+nigsa gu udu X X$exchange good for oxen , sheep , … ;
+NUMB sila gur ce kac ninda$NUMB gur NUMB barig NUMB ban2 NUMB sila3 barley , beer , bread ;
+NUMB sa gi$NUMB bundles of reed ;
+NUMB gu manu$NUMB talents , willow ;
+naptanum nugua u ude gida u NUMBkam$Nabdanum not fed and to the day stretched , one workday ;
+NUMB duh gur$NUMB gur NUMB barig bran ,
+duhbi balaka$its bran of the bala
+iti cesagku u iti diri cesagku$month : “ Harvest , ” and month extra : “ Harvest ; ”
+cunigin NUMB guru NUMB sila ce gur culgira$total : NUMB silo NUMB gur NUMB ban2 NUMB sila3 barley , Šulgi ,
+cunigin NUMB gig gur$total : NUMB gur wheat ,
+cebi NUMB guru NUMB sila gur$its barley : NUMB silo NUMB gur NUMB ban2 NUMB sila3 ;
+cunigin NUMB sila duh gur$total : NUMB gur NUMB barig NUMB sila3 bran ;
+cunigin NUMB geme u NUMBce$total : NUMB workdays , female laborers ;
+cunigin NUMB gu NUMB mana manu$total : NUMB talents NUMB mana willow ;
+cunigin NUMB sa gi$total : NUMB , NUMB bundles of reed ;
+sagnigurakam$is the debits ;
+cabita$therefrom
+NUMB sila ce gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 barley ,
+diri nigkak$surplus of the  account ,
+iti akiti$month : Akitu ,
+mu simurum lulubum ara NUMB la NUMBkamac bahul$year : “ Simurrum , Lullubum for the ordNUMB time were destroyed ; ”
+NUMB sila gig gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 wheat ,
+ekicibaka banku$into the sealed house brought ,
+giri lutu ugula kikken$via Lu-Utu , foreman of the mill ;
+NUMB duh gur$NUMB gur NUMB ban2 bran ,
+culgiamu$Šulgi-ayamu ;
+X X$…
+n duh gur$NUMB gur … bran ,
+muku$delivery ;
+laia NUMB sila ce gur$deficit : NUMB gur NUMB barig NUMB ban2 NUMB sila3 barley ;
+NUMB duh gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 bran ;
+NUMB geme u NUMBce$NUMB workdays , female laborers ;
+NUMB gu NUMB mana manu$NUMB talents NUMB mana willow ;
+NUMB sa gi$NUMB bundles of reed ;
+laiam$are the deficit ;
+nigkak$account of
+bala urlamma ensi girsu$the bala of Ur-Lamma , governor of Girsu ;
+iti cesagkuta$month : “ Harvest , ”
+iti diri cesagkuce$month extra : “ Harvest ; ”
+iti NUMBkam$of two months ;
+bala X$bala …
+mu simurum lulubum ara NUMB la NUMBkamac bahul$year : “ Simurrum , Lullubum for the ordNUMB time were destroyed . ”
+pisanduba$Basket-of-tablets
+dub gida$xxx
+lugaligisasa$xxx
+igal$xxx
+mu cacru bahul$xxx
+pisanduba$Basket-of-tablets
+mu didli ceba$xxx
+girisega cairi didli$xxx
+gu i nigincedu$xxx
+igal$xxx
+mu simurum bahul$xxx
+NUMB dingirsaga$NUMB , Dingir-saga ,
+NUMB urnumucda$NUMB , Ur-Numušda ,
+NUMB utulagacgal$NUMB , Utu-Lagaš-gal ,
+NUMB urnance$NUMB , Ur-Nanše ,
+cagume$they are ox-drivers ;
+NUMB lugatumdu$NUMB , Lu-Gatumdu ,
+NUMB kuli$NUMB , Kuli ,
+NUMB babaizu$NUMB , Baba-izu ,
+erinme$they are worktroopers ;
+igiNUMBgalta$at NUMB shekel each ,
+iti munuguta$from month : “ Malt feast , ”
+iti ezemculgice NUMB gin$to month : “ Festival of Šulgi ” : NUMB shekels ;
+NUMB ada NUMB gur$NUMB , Adda , NUMB  NUMB barig ,
+NUMB luningirsu NUMB gur$NUMB , Lu-Ningirsu , NUMB  NUMB barig ,
+erinme$they are worktroopers ;
+iti munuguta$from month : “ Malt feast , ”
+iti ceila u NUMB bazalce NUMB gin$to month : “ Grain carried , ” day NUMB completed : NUMB shekels ;
+kubi NUMB gin$its silver : NUMB shekels ;
+ce cukurabi NUMB gur$its barley of rations : NUMB gur NUMB barig ;
+a hunga inim X X$labor of the hirelings , on orders of Su-… ;
+irita nue X$“ from the city not going out ” … ,
+e gatumdu X$house of Gatumdu … ;
+mu cusuen lugal urimake mada zabcali muhul$year : “ Šu-Suen , the king of Ur , the lands of Zabašali destroyed . ”
+pisanduba$Basket-of-tablets
+dub gida$xxx
+lu nigdaba a egibil$xxx
+girsuta$xxx
+guabace$xxx
+igal$xxx
+mu en nanna karzida bahun$xxx
+n n ce gur$… gur barley
+GANgu$of GANgu-fields ;
+NUMB gur cuku urninki$NUMB gur prebend , Ur-Ninki ;
+ugula urbaba$foreman : Ur-Baba ;
+NUMB gur$NUMB gur ,
+ugula daga$foreman : Da’aga ;
+NUMB gur$NUMB gur ,
+NUMB ziz gur$NUMB gur emmer ,
+ugula carakam$foreman : Šara-kam ;
+NUMB gur GANgu NUMB$NUMB gur  GANgu-fields ;
+NUMB gur cuku habalu$NUMB gur , prebend of Habalu ,
+ugula egalesi$foreman : Egal-esi ,
+aca nagabtum$field Nagabtum ,
+kisu nagabtum$threshing floor Nagabtum ;
+NUMB gur ugula carakam$NUMB gur , foreman : Šara-kam ,
+NUMB gur ugula egalesi$NUMB gur , foreman : Egal-esi ,
+aca abu$field Abu ;
+NUMB gur ugula egalesi$NUMB gur , foreman : Egal-esi ,
+aca dukusig$field Gold-Mound ;
+NUMB gur aca nagabtum$NUMB gur , field Nagabtum ;
+NUMB gur aca abu$NUMB gur , field Abu ;
+gur aca dukusig$NUMB gur , field Gold-Mound ;
+ugula daga$foreman : Da’aga
+n NUMB gur aca dukusig$… NUMB gur , field Gold-Mound ;
+n gur aca abu$NUMB gur , field Abu ;
+X X X$…
+X sahar um X$…
+X dukusig$… Gold-Mound .
+NUMB ce gur lugal$NUMB gur NUMB barig barley , royal ,
+idub tultata$from the depot of Tulta ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2 ,
+idub urnigarta$from the depot of Ur-nigar ;
+ce ura erin engar cagu u nubandagu$loan barley of worktrooper2 , ploughmen , ox-drivers , and oxen managers
+urmamake$did Ur-Mama
+cu bati$recieve .
+mu sanga inanna$… Inanna
+idub uruta$from the depot of Urub ;
+mu guza enlila badim$year : “ The throne of Enlil was fashioned . ”
+urabzu$Ur-abzu ,
+dumu lugalucur$son of Lugal-ušur ,
+nubandagu cara$Oxen manager of Šara .
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+akala$Ayakalla ,
+cabra$household manager ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+etum gurum ak$xxx
+ab eturaka$xxx
+ca dukuge eamara u ca guedina$xxx
+gabari$xxx
+akala ensika$xxx
+igal$xxx
+mu en nanna karzida bahun$xxx
+NUMB sila ensi kic$NUMB lamb , governor of Kish ;
+NUMB sila burmama$NUMB lamb , Burmama ;
+NUMB acgar niga ensi nibru$NUMB female kid , grain-fed , governor of Nippur ;
+NUMB sila ensi adab$NUMB lamb , governor of Adab ;
+NUMB gu NUMB gu gecdu guna$NUMB oxen , NUMB ox , breeder , speckled ,
+NUMB gu X NUMB la NUMB mac$NUMB ox , … , NUMB billy goats ,
+PIbil martu$of PI-bi2-il , Amorite ;
+NUMB sila urgula nubanda$NUMB lamb , Ur-Gula , nubanda ;
+NUMB amar macda eaili$NUMB calf-gazelle , Ea-ilī ;
+NUMB ud$NUMB nanny goats ,
+NUMB macgal gecdu$NUMB billy goats , full-grown , breeders ,
+s,elucdagan$Ṣelluš-Dagan
+muku$delivery ;
+iti akiti$month : “ Akitu , ”
+mu simurum u lulubu ara NUMB la NUMBkamac bahul$year : “ Simurrum and Lullubum for the ordNUMB time were destroyed ; ”
+u NUMBkam$ordNUMB day .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urigalim$Ur-Igalim ,
+dubsar$scribe ,
+dumu X$son of E-… ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+gurumak$inspections ,
+guapin guba$plow-oxen , stationed ,
+ce gecea$threshed barley ,
+ka cudua$… ,
+aca daba$field of takers
+ca cucin$in Susa ,
+igal$are here ;
+mu en nanna karzida bahun$year : “ The en- of Nanna in Karzida was hired . ”
+X$For …
+X$…
+X X$…
+luningirsu$did Lu-Ningirsu ,
+dubsar$the scribe ,
+dumu lubake$child of Luba ,
+namtice$for  life ,
+u namti$and for the life
+dam dumunace$of his wife and child ,
+a munaru$dedicate it ;
+burba ninmu$of this bowl , “ My lady ,
+iginida$… ” ,
+mubim$is its name .
+pisanduba$Basket-of-tablets
+etum$xxx
+sagnigura$xxx
+u ziga$xxx
+ki intaea$xxx
+iti ezemahta$xxx
+iti cesagkuce$xxx
+iti NUMBkam$xxx
+caba iti diri NUMBam$xxx
+mu guza enlila badim$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+i cida$oil counted ,
+nubanda girsukene$overseers of Girsu
+u ce nigala$and barley on hand ,
+giri urlamma dumu sadu$via Ur-Lamma , son of chief surveyor ,
+igal$are here .
+mu urbilum bahul$year : “ Urbilum was destroyed . ”
+cusuen$Šũ-Sîn ,
+mu pada$chosen by nsme
+ana$by An ,
+kiag enlila$beloved of Enlil ,
+lugal enlile$the king by Enlil
+ca kuge pada$chosen by his sacred heart
+namsipa kalama$for shepherdship of the country
+u an ubda limmubace$and of the four quarters of the world ,
+lugal kalga$strong king ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four quarters of the world ,
+dingiranir$his god ,
+ituria$Itũrīa ,
+ensi$governor
+acnunaka$of Ešnunna ,
+ARADdanie$his servant ,
+eani$his temple
+munandu$he built for him .
+igipec$Ratface ,
+dumu urickur$son of Ur-Iškur .
+laia NUMB dabin gur lugal$Deficit : NUMB gur NUMB barig NUMB ban2 dabin-flour , royal ,
+zi bala ensi kazaluka ziga$flour , bala of the governor of Kazallu , booked out ;
+ki lugalezemta$from Lugal-ezem ,
+urtur$Ur-tur
+susudam$will be repaid ;
+mu bad badu$year : “ The wall was erected . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+u kicib ra ce sila gala$xxx
+mananna kaguruka$xxx
+ingal$xxx
+e ningal$xxx
+mu cacru bahulta$xxx
+mu en nanna karzida bahunce$xxx
+mubi NUMBam$xxx
+NUMB murgu pec$NUMB date palm spines ,
+NUMB umbin ma$NUMB boat ribs ? ,
+NUMB usuh adace$NUMB pine trees for ada-planks ,
+ki lukalata$from Lukalla ,
+marsac$to the boat house ,
+kicib lusaizu$under seal of Lu-sa-izu .
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+NUMB guruc NUMB ginta$NUMB male laborers , NUMB shekel  each ,
+iti GANmacta$from month : “ GANmaš ”
+iti gurabimumuce$to month “ Oxen-… , ”
+abi NUMB gin ku$its labor : NUMB  NUMB shekels silver ;
+NUMB guruc NUMBta$NUMB male laborers , NUMB shekel  each ,
+iti ezemlisita$from month "Festival of Lisi"
+iti ezembabace$to month "Festival of Baba , "
+iti NUMBkam$of NUMB months ,
+abi NUMB gin$its labor : NUMB  NUMB shekels ;
+cunigin NUMB mana NUMB gin kubabbar$total : NUMB mana NUMB shekels silver
+sagnigurakam$are the debits ;
+cabita$therefrom
+NUMB gin urenki$NUMB shekels , Ur-Enki ;
+NUMB gin bazi$NUMB shekels , Bazi ;
+NUMB gin igiNUMBgal$NUMB shekels ,
+lubaba$Lu-Baba ;
+NUMB gin la NUMB ce kubabbar$NUMB shekels less NUMB grains silver ,
+giri urtirac$via Ur-Tiraš ;
+NUMB gin ku agul kubabbar$NUMB shekels silver , agul silver ,
+eki sanga ninmar$Eki , temple household manager of Ninmar ;
+NUMB gin inadu$NUMB shekels , released ;
+cunigin NUMB gin igiNUMBgal kubabbar$total : NUMB  NUMB shekels silver ,
+muku$deliveries ;
+laia NUMB gin la igiNUMBgal$the deficit : NUMB  NUMB less NUMB shekels ,
+nigkak abamu$account of Abbamu ,
+mu usa bad mada badu$year after : “ The wall of the land was erected . ”
+NUMB mac lagip$NUMB kid of Lagip ,
+NUMB mac burmama$NUMB kid of Burmama ,
+NUMB sila X$NUMB lamb of … ,
+NUMB sila dingirbani$NUMB lamb of Ilum-bani ,
+NUMB sila curimku$NUMB lamb of Šurimku ,
+NUMB sila imer$NUMB lamb of Imer ,
+NUMB mac eamalik$NUMB kid of Ea-malik ,
+NUMB mac tudari$NUMB kid of Tudari ,
+NUMB sila erecum$NUMB lamb of Errēšum ,
+NUMB mac abili$NUMB kid of Abī-ilī ,
+n X$NUMB … of …-ni ,
+NUMB sila celebum$NUMB lamb of Šelebum ,
+NUMB sila dada ukul$NUMB lamb of Dada the soldier ,
+NUMB sila abuza$NUMB lamb of Abuza ,
+NUMB sila s,eliculgi$NUMB lamb of Ṣelli-Šulgi ,
+NUMB sila hunum cuc$NUMB lambs of Hunum , the chief livestock manager ,
+NUMB sila lugalmelam ensi nibru$NUMB lambs of Lugal-melam , governor of Nippur ,
+NUMB sila cuidim$NUMB lamb of Šu-Idim ,
+NUMB udu NUMB sila urbaba ugula ugIL$NUMB sheep NUMB lamb of Ur-Baba , the foreman of menials ,
+NUMB sila watarum sanga$NUMB lambs of Watarum , the temple administrator ;
+u NUMBkam$the ordNUMB day ,
+muku abasaga idab$delivery , Abbasaga accepted ;
+iti ezemana$month : “ Festival of An , ”
+mu enunugal inanna unu bahun$year : “ Enunugal of Inanna was hired in Uruk . ”
+pisanduba$Basket-of-tablets
+gurum ak girisega$xxx
+etum$xxx
+e culgi$xxx
+igal$xxx
+mu ibisuen lugal$xxx
+pisanduba$Basket-of-tablets
+gurum ak namNUMB duna$xxx
+cabra sangane$xxx
+igal$xxx
+mu urbilum$xxx
+NUMB u gukkal$NUMB grain-fed ewe ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+ahuwer idab$Aḫu-wer accepted ;
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB udu$NUMB sheep .
+pisanduba$Basket-of-tablets
+niginba geme ucbar lu azlag$xxx
+girsuta$xxx
+guabace$xxx
+mu magurmah$xxx
+u tug gada egal kura$xxx
+igal$xxx
+mu e cara umma badu$xxx
+pisanduba$Basket-of-tablets
+im etum$clay  in the ‘house’
+u im didli enbi tare$and clay , singles , enquiries ,
+erin balaka$labor troops of the bala ,
+igal$are here ;
+mu usa cusuen lugal urimake bad martu muriqtidnim mudu$year following : “ Shu-Suen , king of Ur , the Amorrite-Wall muriq-tidnim erected . ”
+pisanduba$Basket-of-tablets
+tug kila tag$xxx
+ziga geme ucbar cusuen$xxx
+pisanduba$Basket-of-tablets
+muku$deliveries ,
+kicib catamene$sealed documents of the officials ,
+iti ezemana u NUMBta$from month “ Festival-of-An , ” ordNUMB day ,
+itice$to month “ , ”
+itikam$months ,
+mu usa bad martu muriqtidnim badu$year following : “ The Amorite wall  mūriq-tidnim was erected , ”
+igal$are here .
+NUMB kuc udu niga$NUMB hide , grain-fed sheep ;
+NUMB kuc mac niga$NUMB hide , grain-fed goat ;
+kuc udu sadu$sheep hides , regular offerings ,
+ki ickurillata$from Adda-illat ,
+anahili$Anah-ili
+cu banti$did receive .
+iti ezemana$Month : “ An-festival , ”
+mu naruamah munedu$year : “ he erected the great stele for them . ”
+NUMB kuc udu niga$NUMB hide , grain-fed sheep ;
+NUMB kuc mac niga$NUMB hide , grain-fed goat ;
+kuc udu sadu$sheep hides , regular offerings ,
+ki ickurillata$from Adda-illat ,
+anahili$Anah-ili
+cu banti$did receive .
+ca garcana$In Garšana .
+iti ezemana$Month : “ An-festival , ”
+mu naruamah enlil ninlilra munedu$year : “ he erected the great stele for Enlil and Ninlil . ”
+NUMB guruc u NUMBce$NUMB male laborer , for NUMB workdays ,
+kar ummata irisarigce ma gida$from Umma-harbor to Irisagrig barge punted ,
+u NUMBce ce ma siga$for NUMB workday barley into the barge loaded ,
+irisarigta$from Irisagrig
+u NUMBce kunzida kiri gectince ma gida$two workdays to reservoir of Vineyard barge punted ,
+u NUMBce eduru uriruaka ce bala$for NUMB workday at Uriru-village barley transferred ,
+kunzida i amarsuenitumce ce gaga$to reservoir of Amar-Suenītum canal barley carried ,
+kunzida i amarsuenitumta$from reservoir of Amar-Suenītum canal
+u NUMBce irisarigce ma gida u ma bala ak$for NUMB workdays to Irisagrig barge punted and transfer done ;
+u NUMBce irisarigta ka damimamace ma gida$for NUMB workdays from Irisagrig to mouth of Damimama barge punted ,
+u NUMBce ummace ma diriga$for NUMB workdays to Umma barge floated ,
+u NUMBce ma bala$for NUMB workday barge unloaded ;
+u NUMBce ce bala$for NUMB workday barley transferred ;
+ugula urmes$foreman : Urmes ,
+kicib adumu$under seal of Adumu ;
+mu ma enki babdu$year : “ The boat of Enki was caulked . ”
+ursuen$Ur-Suen ,
+dubsar$scribe ,
+dumu urgigir$son of Ur-gigir ,
+catam$official .
+NUMB dabin gur lugal$NUMB gur flour , ,
+NUMB zi sig gur$NUMB gur rough-ground flour ,
+NUMB munu sie gur$NUMB gur sprouted malt ,
+NUMB CIM du gur$NUMB gur ŠIM , regular ,
+NUMB CIM saga gur$NUMB gur ŠIM , high ,
+ki adata$from Adda
+luduga cu bati$did Lu-duga receive ;
+iti minec$month “ mineš . ”
+NUMB dabin gur lugal$NUMB gur flour , ,
+NUMB zi sig gur NUMB cim du gur$NUMB gur rough-ground flour , NUMB gur ŠIM , regular ,
+NUMB munu sie gur NUMB cim saga gur$NUMB gur sprouted malt , NUMB gur ŠIM , high ,
+ki adata$from Adda
+luduga cu bati$did Lu-duga receive ;
+kicib luduga$under seal of Lu-duga ;
+iti minec$month “ mineš . ”
+luduga$Lu-duga ,
+dubsar$the scribe ,
+dumu duga$son of Duga .
+laia NUMB gin geme u NUMBce$Deficit : NUMB , NUMB shekels workdays , female laborers ,
+ki dadagata$from Dadaga
+ururbartab$to Ur-Urbartab
+susudam$will be repaid ;
+mu harci kimac bahul$year : “ Ḫarši and Kimaš were destroyed . ”
+ururbartab$Ur-Urbartab ,
+dubsar$scribe ,
+dumu dingira$son of Dingira .
+pisanduba$Basket-of-tablets
+gurumak daba$grasped personnel inspections
+malah$of sailers ,
+lu marsa$xxx
+gacam damgar$damgar erin$xxx
+agauc ma u zala$xxx
+e culgi$xxx
+igal$are here ;
+mu amarsuen lugale urbilum muhul$year : “ xxx . ”
+hachur sadu bure cua$Apples , regular covered bowl offerings ,
+iti cekaragalata$from the month “ barley brought to the harbor , ”
+u NUMB barazalata$from the ordNUMB day having passed ,
+u NUMBce egala kura$for five days brought into the palace
+giri abaqir$via Abbaqir
+iti cekaragala$Month “ barley brought to the harbor , ”
+mu cusuen lugal urima magurmah enlil ninlilra munedim$year “ Šu-Suen , the king of Ur , the large barge for Enlil and Ninlil he built . ”
+pisanduba$Basket-of-tablets
+ca dugan ziga$in the pouches credits ,
+ziga$credits of
+mancum bursag$Manšum , the stone bowl cutter ,
+igal$are here ;
+mu amarsuen lugal$year : “ Amar-Suen is king . ”
+pisanduba$Basket-of-tablets
+u udu gi udu gukkal udu ka kecra$xxx
+ensika$xxx
+mu huhunuri bahulta$xxx
+mu cusuen lugal urimake bad martu muriqtidnim muduce$xxx
+mu NUMBkam$xxx
+igal$xxx
+inanna$For Inanna
+nin ku nuna$Ninkununa
+ninani$his mistress ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+ecbur$the Ešbur ,
+e kiagani$her beloved temple ,
+munadu$he built for her .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+nannamaba$Nanna-maba ,
+dubsar$scribe ,
+dumu unabcen$son of Unabšen ,
+ARADzu$is your servant .
+NUMB tug guna$One “ neck ” garment
+ki ikalata$from Ikalla ,
+mu aguce$in place of Agu ,
+kicib akala$under seal of Ayakala ;
+iti eitiNUMB$month : “ Six-month-house , ”
+mu en inanna unu mace ipa$year : “ The high-priest of Inanna of Uruk was chosen by extispicy . ”
+akala$Ayakala ,
+dubsar$scribe ,
+dumu ermu$son of Ermu .
+laia NUMB carazame$Deficit : NUMB Šara-zame ,
+NUMB lugalniglagare$and NUMB Lugal-nig-lagare ,
+u NUMBce$for NUMB days ,
+abi NUMB ginta$the labor : NUMB shekels ,
+urdamu$to Ur-Damu
+ugula susudam$the foreman , to be replaced ;
+ca bala$part of the bala ;
+mu ara NUMBkam cacurum bahul$year : “ A ordNUMB time Šašrum was destroyed . ”
+urlisi$Ur-Lisi ,
+ensi umma$governor of Umma
+urdamu$Ur-Damu ,
+dumu lugalucumgal$son of Lugal-ušumgal
+ARADzu$your servant .
+lamma$To Lamma ,
+ninanir$her mistress ,
+namti$for the life
+amarsuen$of Amar-Suena ,
+lugal kalga$the mighty king ,
+lugal urimakace$king of Ur ,
+halababa$Hala-Baba ,
+dam urlamma$the wife of Ur-Lamma
+dubsarke$the scribe ,
+a munaru$dedicated  to her .
+urnamma$Ur-Namma ,
+lugal urima$king of Ur ,
+lu e ninunuka$the person who the temple of Ninunu
+indua$built .
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+luduga $for Luduga ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+dani $for Dayyānī ;
+NUMB kac NUMB ninda NUMB sa cum $NUMB ban2 beer , NUMB ban2 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+nannazi muhaldim $for Nanna-zi , the cook ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+lugalmelam muhaldim $for Lugal-melam , the cook ;
+NUMB sila kac NUMB sila ninda NUMB  $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+hubua $for Ḫubu’a ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+abbabba $for Abba-abba ;
+cunigin NUMB la NUMB sila kac NUMB sila ninda NUMB sa cum $total : NUMB ban2 less NUMB sila3 beer ; NUMB ban2 NUMB sila3 bread ; NUMB bundles onions ;
+NUMB sila NUMB gin i NUMB gin naga $NUMB sila3 NUMB shekels oil ; NUMB shekels alkali-plant ;
+u NUMBkam $ordNUMB day ,
+iti dumuzi $month : “ Dumuzi . ”
+NUMB sila kac saga NUMB sila ninda $NUMB sila3 fine beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali plant ,
+NUMB ku NUMB sa cum $NUMB fish , NUMB bundle onions ,
+lunanna $for Lu-Nanna ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i $NUMB shekels oil ,
+NUMB gin naga $NUMB shekels alkali-plant ,
+NUMB ku NUMB sa cum $NUMB fish , NUMB bundle onions ,
+urnanna $for Ur-Nanna ;
+NUMB ninda NUMB kac du $NUMB ban2 bread , NUMB ban2 common beer ,
+NUMB sila igec $NUMB sila3 sesame oil ,
+cagal kasene $provisions for messengers ,
+giri urnanna $via Ur-Nanna ;
+u NUMBkam $ordNUMB day ,
+iti sigicubagar $month : “ Bricks cast in moulds . ”
+X$…
+lugal kiengi kiurike$the king of Sumer and Akkad ,
+lugal kiengi kiurike$his/her temple
+munadu$he built for him/her .
+NUMB ce gur lugal $NUMB gur NUMB ban2 barley ,
+ce urace $as a barley loan
+ki urNIta $from UrNI ,
+urnigar $Ur-nigar
+cu bati $has received ;
+kicib atu $under seal of Atu ;
+iti amarasi $month : “ Amar-ayasi , ”
+mu urbilum bahul $year : “ Urbilum was destroyed . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmubake$king of the four corners
+akala$to Ayakala ,
+ensi$governor
+umma$of Umma ,
+ARADdanir$his servant ,
+inaba$he gifted {this seal) .
+pisanduba$Basket-of-tablets
+etum$xxx
+sagnigura$xxx
+u ziga$xxx
+ki ludingira dumu inimcarata$xxx
+iti akitita$xxx
+iti ezemanace$xxx
+iti NUMBkam$xxx
+mu harci u kimac bahul$xxx
+pisanduba$Basket-of-tablets
+dugan$xxx
+cabi suga e kas u bursag$xxx
+ca girsu$xxx
+igal$xxx
+mu enmahgalana$xxx
+NUMB sila ga$NUMB suckling male lambs ,
+NUMB kir ga$NUMB suckling female lambs ,
+NUMB mac ga$NUMB suckling male kids ,
+NUMB acgar ga$NUMB suckling female kid ,
+utuda$newborns ;
+u NUMBkam$ordNUMB day ,
+culgiamu$Šulgi-ayamu
+idab$received ;
+iti cesagku$month : “ Harvest , ”
+mu amarsuen lugal$year : “ Amar Suen  king . ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+sagnigura$xxx
+gudea dumu lani$xxx
+igal$xxx
+mu simanum bahul$xxx
+pisanduba$Basket-of-tablets
+nigkak a$xxx
+e lunga$xxx
+u e kikken$xxx
+igal$xxx
+iti mucudu$xxx
+u amarasi$xxx
+mu amarsuen lugal$xxx
+NUMB sila enlil$One lamb  Enlil ,
+NUMB sila ninlil$one lamb  Ninlil ,
+muku zabardab$delivery of the zabardab ;
+NUMB sila ninhursag$one lamb  Ninhursag ,
+NUMB sila culpae$one lamb  Šulpa’e ,
+muku kurgirinice$delivery of Kur-giriniše ;
+zabardab mackim$he zabardab was the responsible official ;
+NUMB macda euzga$one antelope  the E’uzga ,
+muku atu$delivery of Atu ;
+urculgira mackim$Ur-Šulgira was the responsible official ;
+NUMB sila enlil$0ne lamb  Enlil ,
+muku lugalnirgal$delivery of Lugal-nirgal ;
+izariq mackim$Issarik was the responsible official ;
+NUMB udu NUMB ud ba X E$one sheep and one nanny goat …
+u NUMBkam$on the third day ;
+mu en nanna mace ipa$year : “ The high priestess of Nanna was chosen via extispicy . ”
+pisanduba$Basket-of-tablets
+etum$xxx
+sagnigura$xxx
+u ziga$xxx
+lugina cabra$xxx
+iti ezemekigal$xxx
+mu harci u kimac bahulta$xxx
+iti ezemculgi$xxx
+mu guza enlila badimce$xxx
+iti NUMBkam$xxx
+NUMB gukkal NUMB macda$NUMB fat-tailed rams , NUMB gazelle ,
+u NUMBkam$ordNUMB day ;
+ki abasagata$from Abbasaga
+utamicaram idab$Uta-mišaram received ;
+iti kisikininazu$month : “ ki-siki of Nin-azu ; ”
+mu enunugal inanna unu bahun$year : “ En-unu-gal of Inanna of Uruk was hired ; ”
+NUMB$NUMB .
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB la NUMB sar al NUMB sarta$NUMB less NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar kici kura NUMB sarta$NUMB sar , acacia cut at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB guruc u NUMBce$NUMB male laborer workdays ,
+absinta lag ririga$from the furrows clods struck down ,
+a caguka$labor of the plow assistants ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB la NUMB$its labor : NUMB less NUMB workdays ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar al du NUMB sarta$NUMB sar , hoed … at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar |ZI&ZI|ce zea NUMB sarta$NUMB sar , … pulled out at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar kici kura NUMB sarta$NUMB sar , acacia cut at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar kici kura NUMB sarta$NUMB sar , acacia cut at NUMB sar ,
+abi u NUMB la NUMB$its labor : NUMB less NUMB workdays ;
+NUMB guruc u NUMBce$NUMB male laborer workdays ,
+absinta lag ririga$from the furrows clods struck down ,
+NUMB guruc u NUMBce$NUMB male laborer workdays ,
+kausa gara$… set ;
+NUMB sar haran bura NUMB sarta$NUMB sar , … loosened out at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar haran bura NUMB sarta$NUMB sar , … loosened at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+a lu hunga$labor of the hired men ,
+aca urgu$field Urgu ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMBkam$its labor : NUMB workdays ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar al du NUMB sarta$NUMB sar , hoed … at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB sar al du NUMB sarta$NUMB sar , hoed … at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB guruc u NUMBce$NUMB male laborer workdays ,
+absinta lag ririga$from the furrows clods struck down ,
+a lu hunga$labor of the hired men ;
+NUMB sar al NUMB sarta$NUMB sar , hoed at NUMB sar ,
+abi u NUMB la NUMB$its labor : NUMB less NUMB workdays ;
+NUMB la NUMB guruc u NUMBce$NUMB less NUMB male laborer workdays ,
+absinta lag ririga$from the furrows clods struck down ,
+a caguka$labor of the plow assistants ,
+aca muru$field Muru ;
+NUMB sar al du NUMB sarta$NUMB sar , hoed … at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+a caguka$labor of the plow assistants ;
+NUMB sar al du NUMB sarta$NUMB sar , hoed … at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+NUMB guruc u NUMBce$NUMB male laborer workdays ,
+absinta lag ririga$from the furrows clods struck down ,
+a lu hunga$labor of the hired men ,
+aca sipada$field Herder ;
+NUMB sar gecgaz NUMB sarta$NUMB sar , bush flatted at NUMB sar ,
+abi u NUMB$its labor : NUMB workdays ;
+aca lamah$field Lamaḫ ;
+a lu hunga NUMB silata$labor of the hired men , NUMB sila3 ,
+acage kin ak$fieldwork ;
+ugula lugalnesage$foreman : Lugal-nesage ;
+kicib lubalasaga$under seal of Lu-balasaga ;
+mu simanum bahul$year : “ Simanum was destroyed . ”
+lubalasaga$Lu-balasaga ,
+dubsar$scribe ,
+dumu dingira$son of Dingira .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urculpae$Ur-Šulpa’e ,
+dubsar$scribe ,
+dumu nannamaba$son of Nanna-maba ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+lugalamaru$xxx
+igal$xxx
+mu simurum bahul$xxx
+bazi$To Bazi
+unadu$speak
+urnance dumu dab lunaruakara$“ To Ur-Nansze DAB5-worker of Lu-Naru'a ,
+ecgirice$the nose-rope
+nabadu$he shall not attach . ”
+NUMB udu$NUMB sheep ,
+NUMB ud$NUMB nanny goat ,
+NUMB sila$NUMB male lamb ,
+NUMB kir$NUMB female lamb ,
+NUMB sila ga$NUMB suckling lamb ,
+bauc$slaughtered ,
+u NUMBkam$the ordNUMB day ,
+ki naluta$from Nalu
+urnigar$Ur-nigar
+cu bati$received ;
+iti sesdagu$month : “ Piglet feast , ”
+mu kimac bahul$year : “ Kimaš was destroyed . ”
+inanna$Inanna ,
+paplal$Paplal ,
+dumu amarsumun$son of Amarsumun ,
+X sanga$… temple administrator
+enlil$of Enlil ,
+X$…
+X X KI $of …
+X $Dawa-… ,
+|PA.|  $governor
+zaul $of Za'ul .
+X X $… ,
+|PA.| $governor
+huhnuri $of Huḫnuri .
+X X$…-mat ,
+|PA.| $governor
+X $of …-laka .
+X $…-a ,
+cagina $military governor
+X $of …-al
+sabum$Sabum .
+pisanduba$Basket-of-tablets
+kicib laia gi$sealed documents , deficits of reeds ,
+sila gala$in the ‘street’ located ,
+ki bidugata$from Biduga ,
+igal$are here .
+pisanduba$Basket-of-tablets
+mu didli ceba$xxx
+cagu$xxx
+iti ezemlisi$xxx
+u iti cunumun$xxx
+igal$xxx
+mu usa kimac mu usabi$xxx
+pisanduba$Basket-of-tablets
+nigkak$xxx
+gu udu$xxx
+igal$xxx
+mu enmahgalana en nanna bahun$xxx
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+cukabta$to Šū-kabta ,
+cagina$general ,
+ARADdanir$his servant ,
+inaba$he gifted .
+pisanduba$Basket-of-tablets
+nigkak dub gida$accounts , long-tablets ,
+dub gida$long-tablets
+kaguru$of the silo manager ,
+u dubsar zidakene$and scribes of flour ,
+mu simurum ara NUMBkamac bahul$year : “ Simurum for the ordNUMB time was destroyed . ”
+NUMB sa gi$NUMB bundles of reed
+urguedina$may Ur-Gu’edina
+henabcumu$give to him .
+culgi$Šulgi ,
+nita kalga$strong man ,
+lugal urima$the king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urlisi$Ur-Lisi ,
+ensi$governor ,
+umma$of Umma ,
+ARADzu$is your servant .
+NUMB udu NUMB mac$NUMB sheep , NUMB billy goat ,
+ugula ahuni cuc$foreman : Ahuni , cattle manager ;
+NUMB udu$NUMB sheep ,
+sipa unugame$herders of Uruk ;
+NUMB udu ugula namhani cuc$NUMB sheep , foreman : Namhani , cattle manager ;
+NUMB la NUMB udu$NUMB sheep ,
+NUMB mac$NUMB billiy goats ,
+ugula urnigar cuc$foreman : Ur-nigar , cattle manager ;
+NUMB udu$NUMB sheep ,
+NUMB mac$NUMB billy goat ,
+ugula iphur cuc$foreman : Iphur , cattle manager ;
+NUMB udu NUMB mac$NUMB sheep , NUMB billy goat ,
+ugula cuea cuc$foreman : Šu-Ea , cattle manager ;
+NUMB udu sipa umma$NUMB sheep , herder of Umma ;
+NUMB mac ugula imidecdar cuc$NUMB billy goat , foreman : Imid-Ištar , cattle manager ;
+NUMB mac ugula urbaba cuc$NUMB billy goat , foreman : Ur-Baba , cattle manager ;
+cunigin NUMB udu NUMB mac$Total : NUMB sheep , NUMB billy goats ,
+macdarea sipakene$as m-offering of the herders ,
+muku nasa idab$the delivery taken over by Nasa ;
+iti ezemana$month : “ Festival of An , ”
+mu harci u kimac bahul$year : “ Ḫarši and Kimaš were destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak girisega$xxx
+lugina kaguru$xxx
+nigka lu ma gida$xxx
+inimah nanna lugalnata$according to the great command of Nanna his lord ,
+u cucin$when Susa he
+muhula$destroyed ,
+namrac$and to booty
+munaka$he made ,
+n dusunita amar ga$NUMB suckling male equids ,
+NUMB dusumunus amar ga$NUMB suckling female equid ,
+utuda$newborns ;
+giri bululu$via Bululu ,
+muku$delivery ,
+nasa idab$Nasa accepted .
+mu hurti u harci bahul$year : “ Ḫurti and Ḫarši were destroyed . ”
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents of conveyances
+agu$of Agu ,
+mu enunugal inanna bahun$year : “ Enunugal of Inanna was installed ”
+u mu cacru bahulce$and to year : “ Šašru was destroyed , ”
+igal$are here .
+NUMB dug dida NUMB sila kac saga$NUMB jug of wort , NUMB sila3 fine beer ,
+NUMB ninda NUMB gin i NUMB gin naga$NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum$NUMB bundles onions ,
+cuilia gabac$for Šu-iliya , … ;
+NUMB dug dida NUMB sila kac$NUMB jug of wort , NUMB sila3 beer ,
+NUMB ninda NUMB gin i NUMB gin naga$NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum$NUMB bundles onions ,
+baba gabac$for Babaya , … ;
+NUMB dug dida NUMB sila kac$NUMB jug of wort , NUMB sila3 beer ,
+NUMB ninda NUMB gin i NUMB gin naga$NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum$NUMB bundles onions ,
+halaca gabac$for Ḫalaša , … ;
+cunigin NUMB dug dida du NUMB$total : NUMB jugs of common wort , NUMB ban2 per jug ;
+cunigin NUMB sila kac saga cunigin NUMB sila kac$total : NUMB sila3 fine beer ; total : NUMB sila3 beer ;
+cunigin NUMB ninda cunigin NUMB gin i cunigin NUMB gin naga$total : NUMB ban2 bread ; total : NUMB shekels oil ; total : NUMB shekels of alkali-plant ;
+cunigin NUMB la NUMB sa cum$total : NUMB bundles onions ;
+u NUMBkam$ordNUMB day ;
+iti lisi$month : “ Lisi , ”
+mu cusuen lugale naruamah enlila munadu$year : “ Šu-Suen , the king , the great stele of Enlil erected . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+idub$xxx
+ce gec e$xxx
+idab$xxx
+mu en eridu cita culgike bahun$xxx
+NUMB ce cukura$NUMB barig barley rations ,
+urmami$Ur-Mami ,
+guru apisalta$from the silo of Apisal ,
+ki gududuta$from Gududu
+kicib lugalinimgina$seal of Lugal-inimgina ;
+iti paue$month “ Pa’u’e , ”
+mu simanum bahul$year : “ Simanum was destroyed . ”
+lugalinimgina dubsar$Lugal-inimgina
+dumu lugalnesage$son of Lugal-nesage .
+NUMB sar sahara aca$NUMB sar of dirt , at the field Isala ,
+aca isala$field of Salla-canal ,
+ugula ipul$foreman : Ipul ;
+iti cesagku$Month : “ harvest , ”
+mu guza badim$year : “ The throne was fashioned . ”
+luduga$Lu-duga ,
+dubsar$the scribe ,
+dumu urnigar cuc$son of Ur-Nigar , chief cattle administrator .
+NUMB ce gur$NUMB gur barley
+katar$Ka-tar ;
+NUMB ludamu$NUMB barig NUMB : Lu-Damu ;
+NUMB gur baluga$NUMB gur NUMB barig NUMB ban2 : Baluga ;
+a lu hunga aca uhub$wages of the hirelings at the field Uḫub ;
+iti sig u NUMB bazal$month “ Bricks , ” the ordNUMB day passed .
+ninhursag$For Ninhursag ,
+ninani$his mistress ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+e kec$the temple of Keš ,
+e kiagani$her beloved temple ,
+munadu$he built for her .
+pisanduba$Basket-of-tablets
+gurum daba igikarga$xxx
+e ningirsu$xxx
+e cabra$xxx
+e gecbare$xxx
+e culgi$xxx
+e namhani$xxx
+e cusuen$xxx
+e ningeczida$xxx
+u e inanna$xxx
+igal$xxx
+mu magurmah badim$xxx
+NUMB gu$NUMB ox ,
+NUMB u$NUMB ewes ,
+NUMB ud$NUMB nanny goats ,
+cugid emuhaldimce$šugid offerings for the kitchen ;
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+bazi$booked out ;
+iti kisikininazu$month : “ kisiki of Ninazu , ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destroyed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+kicib daba$seized sealed documents
+ki akala acgab$xxx
+igal$are here .
+mu en eridu bahun$Year : She was installed as en-priestess of Eridu
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+nursuen$Nūr-Adda ,
+dubsar$scribe ,
+dumu idiera$son of Idī-Erra ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+kicib daba$xxx
+basa$xxx
+igal$xxx
+mu cacru bahul$xxx
+u a cukurake si musa$and having put in order the subsistance ration expenditures ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+ninsun urima$to Ninsun of Ur
+inaba$he presented .
+pisanduba$Basket-of-tablets
+mu didli ce cukura$xxx
+girisega ki$xxx
+X$xxx
+mu naruamah badu$xxx
+pisanduba$Basket-of-tablets
+udu cukura$sheep , distribution ,
+u udu gida$and sheep … ,
+igal$are here ;
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destroyed . ”
+pisanduba$Basket-of-tablets
+ziga$xxx
+kicib euzu$xxx
+iti ezemculgita$xxx
+igal$xxx
+mu cusuen lugal urimake mada zabcali muhul$xxx
+pisanduba$Basket-of-tablets
+udu$xxx
+udu gukkal$xxx
+kinunirta$xxx
+guabace$xxx
+pisanduba$Basket-of-tablets
+niginba ceba$grand totals of barley rations
+girsuta$from Girsu
+guabace$to Guabba
+igal$are here ;
+mu kimac bahul$year : “ Kimaš was destroyed . ”
+NUMB gu mu NUMB$NUMB ox of NUMB year ,
+basaga$Basaga ;
+NUMB gu mu NUMB$NUMB ox of NUMB year
+urninmuga$Ur-Ninmuga ;
+NUMB gu mu NUMB$NUMB ox of NUMB years
+ure$Ur-e’e ;
+NUMB gu mu NUMB$NUMB ox of NUMB year
+lugalmagure dumu X$Lugal-magure son of … ;
+NUMB gu mu NUMB$NUMB ox of NUMB year
+bazige$Bazige ;
+NUMB ab mu NUMB$NUMB cow of NUMB years
+ala dumu urtec$Alla son of Ur-teš ;
+NUMB ab mu NUMB$NUMB cow of NUMB years
+luebgal dumu X$Lu-ebgal , son of KU… ;
+NUMB kunganita gec$NUMB male mule for the yoke ,
+nannakuzu dumu atu$Nanna-kuzu , son of Atu ;
+cunigin NUMB ab mu NUMB$total : NUMB cows of NUMB years ;
+cunigin NUMB gu mu NUMB$total : NUMB ox of NUMB years ;
+cunigin NUMB gu mu NUMB$total : NUMB oxen of one year
+cunigin NUMB kunganita gec$total : NUMB male mule for the yoke ;
+muku cara$delivery for Šara ;
+iti cunumun$month : “ Sowing , ”
+mu cusuen lugal urimake naruamah enlil ninlilra munedu$year : “ Šu-Suen , king of Ur , Great-Stele for Enlil and Ninlil erected . ”
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+puzurhaia $for Puzriš-Ḫaya ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+lukala $for Lukalla ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+dingirsukkal $for Dingir-sukkal ,
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+urninmar $for Ur-Ninmar ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+X $for … ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+ili $for Ilī ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+lunanna $for Lu-Nanna ;
+cunigin NUMB sila kac NUMB sila ninda NUMB sa  $total : NUMB ban2 NUMB sila3 beer ; NUMB ban2 NUMB sila3 bread ; NUMB bundles onions ;
+NUMB sila NUMB gin i NUMB gin naga $NUMB sila3 NUMB shekel oil ; NUMB shekels alkali-plant ;
+u NUMBkam $ordNUMB day ,
+ iti dal $month : “ Flight . ”
+NUMB sila$NUMB male lamb ,
+NUMB kir$NUMB female lamb ,
+NUMB sila ga$NUMB suckling lamb ,
+bauc u NUMBkam$slaughtered , the ordNUMB day ,
+ki naluta$from Nalu
+urnigar$Ur-nigar
+cu bati$received ;
+iti kisikininazu$month : “ ki-siki of Ninazu , ”
+mu kimac hurti bahul$year : “ Kimaš  Ḫurti were destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak$accounts of
+luningirsu dumu ikala$Lu-Ningirsu , son of Ikalla ,
+urningirsu dumu urbaba$Ur-Ningirsu , son of Ur-Baba ,
+atu$Atu ,
+utubara dumu amu$Utu-bara , son of Amu ,
+lubimu$Lubimu ,
+agi$Agi
+uregal$Ur-egal ,
+urguena$Ur-guena ,
+aladimu$Alla-dimu
+urbaba dumu urnance$Ur-Baba , son of Ur-Nanše ,
+ARADbaba dumu lugalsaga$ARAD-Baba , son of Lugalsaga ,
+mu guza enlila badim$year : “ The chair of Enlil was fashioned . ”
+NUMB gu niga$NUMB fattened oxen ,
+mu ab NUMBce$instead of NUMB cows .
+kicib lucara$Sealed document of Lu-Šara .
+ki intaeata$From Intae'a ,
+urkununa$Ur-Kununa ,
+cu bati$received .
+iti ezemah$Month “ big festival , ”
+mu magurmah badim$Year : “ the lofty barge was furnished . ”
+cusuen$Šu-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners ,
+urkununa$Ur-kununa ,
+dubsar$scribe ,
+dumu luningirsu kurucda$son of Lu-Ningirsu , the fattener ,
+ARADzu$is your slave .
+NUMB gin kubabbar$xxx
+laia suga$xxx
+tug ucbarbi NUMBkam$xxx
+giri ikala$xxx
+nigka$xxx
+mu mada zabcalika$xxx
+ugu gududu bagar$xxx
+nigka$xxx
+mu ibisuen lugalka$xxx
+ikala nigka banak$xxx
+mu kicib ugua gara$xxx
+pisandubaka$in the basket-of-tablets ;
+ki gududuta tumdace$xxx
+kicib ikala$xxx
+mu ibisuen lugal$xxx
+ikala$xxx
+dubsar$xxx
+dumu lusaga$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+ARADzu$is your servant .
+cara$For Šara ,
+lugalanir$his master ,
+namti$for the life
+cusuen$of Šū-Sîn ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur
+lugal an ubda limmubakace$and king of the four world quarters ,
+NUMB X X$NUMB … ,
+NUMB tug ucbar$NUMB weaver garments ,
+NUMB sila icah$NUMB sila3 lard ,
+NUMB gu imbabbar$NUMB talent gypsum ,
+ki ikalata$from Ikalla ,
+kicib akala$under seal of Ayakalla ;
+iti paue$month : “ pa’u’e , ”
+mu e cara badu$year : “ The house of Šara was erected . ”
+akala$Akalla ,
+dumu lugalemah$son of Lugal-emaḫ .
+pisanduba$Basket-of-tablets
+nigkak$xxx
+esir gecgi X$xxx
+u a$xxx
+marsa$xxx
+igal$xxx
+mu guza badim$xxx
+NUMB sila igec$NUMB sila3 of plant oil ,
+ki carakamta$from Šara-kam ,
+kicib ensi$sealed tablet of the governor .
+iti nesag$Month : “ nesag offering , ”
+mu usa bad martu badu mu usabi$year after : “ The Amorite wall was built , ” year after .
+cusuen$Šu-Suen
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+akala$Ayakalla ,
+ensi$governor
+umma$of Umma ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+ceba sikiba$barley rations , wool rations , of
+geme ucbar$female weavers
+igal$are here ;
+mu dumumunus lugal ensi zabcali bantuku$year : “ The princess to the governor of Zabsali was married . ”
+NUMB ad udu niga$NUMB cadaver , ram , grain-fed ,
+ki baga kurucdata$from Ba’aga , the fattener ,
+ickurabi agrig$did Adda-rabi , the agrig ,
+cu bati$receive ;
+iti ezemlisi u NUMB bazal$month “ Festival of Lisi , ” day NUMB elapsed ,
+mu en inanna unu mace ipa$year : “ The priest of Inanna of Uruk by goat was chosen . ”
+pisanduba$Basket-of-tablets
+kicib daba marsa$sealed documents of conveyances of the shipyard
+lusaizu$of Lu-sa-izu
+igal$are here ;
+mu simanum bahul$year : “ Simanum was destroyed , ”
+u$and
+mu bad martu badu$year : “ The Amorite wall was erected . ”
+ninurima$For Ninurima ,
+ninani$his mistress ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+e karzidakani$her Karzida temple
+munadu$he built for her .
+NUMB naga gur$NUMB gur of alkali-plant
+ki akala dubsar damgarta$from Akalla , scribe of the exchange agents ,
+dingirake$did Dingira
+cu bati$receive .
+NUMB naga gur$NUMB gur of alkali-plant
+ki akala dubsar damgarta$from Akalla , scribe of the exchange agents ,
+dingirake cu bati$did Dingira receive .
+iti minec$Month : “ mineš ” ,
+mu puzurdagan badu$year : “ Puzriš-Dagan was erected ” .
+NUMB nigurum$NUMB  Nigurum ,
+enuga tila$living in the prison ,
+iti lisi$from the month “ Lisi ” ,
+mu naruamah baduta$of the year : “ when the lofty stela was erected ” ,
+iti dumuzi$to the month “ Dumuzi ” ,
+mu mada zabcali bahulce$of the year : “ when Madazabšali was destroyed ” .
+ugula X$Overseer : Lu-ku-…
+kicib atu$Sealed document of Atu .
+atu dubsar$Atu , the scribe ,
+dumu nigarkidu$Son of Nigar-kidu ,
+galagal$The police chief .
+NUMB cahzeda$NUMB piglet ,
+iti u NUMB bazal$of the month , ordNUMB day passed ;
+NUMB udu niga$NUMB grain-fed sheep ,
+iti u NUMB bazal$of the month , ordNUMB day passed ;
+NUMB cahzeda$NUMB piglet ,
+iti u NUMB bazal$of the month , ordNUMB day passed ;
+NUMB udu niga$NUMB grain-fed sheep ,
+iti u NUMB bazal$of the month , ordNUMB day passed ;
+NUMB udu niga$NUMB grain-fed sheep ,
+iti u NUMB bazal$of the month , ordNUMB day passed ;
+sadu kianag cukabta$rations of the libation place of Šukabta ,
+ki ickurillata$out of Adad-tillati
+bazi$booked ;
+ca garcana$in Garšana ;
+iti ezemninazu$month “ Festival of Ninazu ; ”
+mu cusuen lugal urimake e cara ummaka mudu$year : “ Šu-Suen , king of Ur , the house of Šara in Umma erected ; ”
+gabari$copy .
+NUMB gin guruc u NUMBce$NUMB workdays ,
+situm mu cusuen lugal$remaining .
+NUMB cakuge$NUMB : Ša-kuge ,
+gabus apindu$herding apprentice of Apin-du .
+NUMB lucara$NUMB : Lu-Šara .
+NUMB ug nincuburandul$NUMB  porter : Ninšubur-andul ,
+cagu urgigir lugalkugani idab$oxen driver of Ur-gigir , Lugal-kugani took responsibility for him .
+NUMB urculpae$NUMB : Ur-Šulpa'e .
+NUMB lucara$NUMB : Lu-Šara .
+NUMB lugalurani$NUMB : Lugal-urani ,
+gabra apindu mu kuganice$gabra of Apin-du , instead of Kugani .
+NUMB urpaue$NUMB : Ur-Papu'e .
+NUMB urmami$NUMB : Ur-Mami .
+NUMB urculpae simug$NUMB : Ur-Šulpa'e , smith .
+NUMB X$NUMB .
+NUMB urbilgames$NUMB : Ur-Gilgameš .
+NUMB ug urkimah$NUMB  porter : Ur-kimah .
+NUMB ug urutu$NUMB  porter : Ur-Utu .
+NUMB cecani$NUMB : Šeš-ani .
+NUMB ug lugamu$NUMB  porter : Lu-gamu .
+NUMB ug ealubi$NUMB  porter : Ea-lubi .
+NUMB ug hegina$NUMB  porter : Hegina .
+NUMB ug lugirizal$NUMB  porter : Lu-girizal ,
+gabra akala$gabra of Akala ,
+ama lugalgue$“ mother ” of Lugal-gue .
+NUMB nabasa$NUMB : Nabasa .
+NUMB ceckala$NUMB : Šeškala .
+NUMB muzuda$NUMB : Muzuda .
+NUMB iniminanna$NUMB : Inim-Inanna ,
+cagu lugalnesage$oxen driver of Lugal-nesage ,
+gabus nigdupae$herding apprentice of Nigdu-pa'e .
+NUMB urculpae$NUMB : Ur-Šulpa'e .
+NUMB lumagana$NUMB : Lu-Magana .
+NUMB uremah$NUMB : Ur-emah .
+NUMB dugacara$NUMB : Duga-Šara .
+NUMB ARADmu$NUMB : ARAD2-mu ,
+libiram$they are of the previous .
+NUMB lucgina$NUMB : Lu-uš-gina .
+NUMB ARADmu$NUMB : ARAD2-mu ;
+dumu lugaligihucme$they are sons of Lugal-igihuš ,
+ime takata$remainder from the previous year .
+NUMB undaga dumu ubar$NUMB : Undaga , son of Ubar ,
+ki ludingira ugulata$from the foreman Lu-dingira .
+NUMB urenlila tir$NUMB : Ur-Enlila , forester .
+NUMB ug urdumuzi dumu X$NUMB  porter : Ur-Dumuzi , son of ARAD2-x ,
+ki ARAD ugulata$from the foreman ARAD2 .
+iti NUMBce$It is  twelve months
+iti cesagkuta$from month “ Harvest ”
+iti dumuzice$until the month “ Dumuzi ” .
+NUMB ug luculgira dumu lugalbad dumu dirita$NUMB  porter : Lu-Šulgira , son of Lugal-bad , from the “ excess children ” ,
+iti NUMBce$for NUMB months ,
+iti lisita$from month “ Lisi ”
+iti dumuzice$until the month “ Dumuzi ” .
+a ugILbi u NUMB$The corresponding production of the porters : NUMB , NUMB days .
+a dumugibi u NUMB$The corresponding production of “ dumugi ” : NUMB , NUMB days .
+NUMB guruc u NUMBce$NUMB workdays ,
+a udua ugIL sagba ziga$the production of free days of  porter already booked out of the debits .
+NUMB guruc u NUMBce$NUMB workdays ,
+a dumugi cectaba bala guba$the production of “ dumugi apprentices ” in bala service .
+cunigin NUMB gin guruc u NUMBce$Together : NUMB , NUMB workdays
+sagnigurakam$are the debit .
+cabita$Therefrom
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca audagula aca audatur u aca ensika$harvested and sheaves piled up in the Audagula field , in the Audatur field and in the Governor field .
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca nuna aca namhani u aca icibene$harvested and sheaves piled up in the Prince field , in the Namhani field and in the Incantation priests field .
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca gusuhub aca badua aca uduninarali u gaba aca gibil$harvested and sheaves piled up in the Oxen boot field , in the field Constructed wall , in the field Cattle herder of Nin-Arali and  across from the new field .
+NUMB guruc u NUMBce$295) workdays ,
+ada guba aca carahegal aca engarbazi u aca audagula$irrigation work in the field Šara is abundance , in the field Plough of Bazi and in the Audagula field .
+NUMB guruc u NUMBce$NUMB workdays ,
+kabku aca nunata sahar ziga acage a duga aca nuna u aca namhani$water installation in the Prince field , earth excavated , irrigation in the Prince field and in the Namhani field .
+kicib daga$Sealed tablet of Da'aga .
+NUMB$NUMB , NUMB
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca igiemahce u aca ninura$harvested and sheaves piled up in the field Before Emah and in the field Ninura .
+NUMB guruc u NUMBce$NUMB workdays ,
+ada guba aca igiemahce u aca ninura$irrigation work in the field Before Emah and in the field Ninura .
+kicib akala$Sealed tablet of Akala .
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca GANmah aca ninudu u aca engarbazi$harvested and sheaves piled up in the field GANmah , in the field Ninnudu and in the field Plough of Bazi .
+NUMB guruc u NUMBce$NUMB workdays ,
+kabku GANmahta sahar ziga u u nagabtuma gara$from the water installation of GANmah earth excavated and green plants placed in the pen .
+NUMB guruc u NUMBce$NUMB workdays ,
+kabku gusuhubka ka ecahda siga$the water installation of the Oxen boot  filled in .
+NUMB guruc u NUMBce$NUMB workdays ,
+kabku aca nunata sahar ziga$from the water installation of the Prince field earth excavated .
+NUMB guruc u NUMBce$NUMB workdays ,
+ada guba aca engarbazi$irrigation work in the field Plough of Bazi .
+NUMB guruc u NUMBce$NUMB workdays ,
+u lugal kisuraka guba$stationed at the King’s bridge  of Kisurra .
+NUMB guruc u NUMBce agala kecra madaga ma gar apisalta ka girgece ma gida u ma gura$NUMB workdays , agala leather bags bound , in Madaga loaded into a barge , from Apisal to the fork from Girgiz punted and the barge returned .
+NUMB$NUMB , NUMB .
+kicib NUMB lugina$NUMB sealed tablets of Lu-gina .
+NUMB guruc u NUMBce$NUMB workdays ,
+acage a duga aca ninuraduna$field irrigation work performed in the field Ninura-duna ,
+ka ida puzurmamace haran gaga$to the fork of the canal Puzur-Mama HARAN plants carried .
+kicib cakuge$Sealed tablet of Ša-kuge .
+NUMB guruc u NUMBce$NUMB workdays ,
+kunzida udagaka guba$stationed at the reservoir of the Daga bridge .
+NUMB guruc u NUMBce gi nagabtum udagada tuca$NUMB workdays , staying at the “ reed nagabtum-pen ” with the Daga bridge .
+kicib lucara dumu iribare$Sealed tablet of Lu-Šara , son of Iri-bare .
+NUMB guruc u NUMBce$NUMB workdays ,
+kunzida e lammaka guba$at the reservoir of the Lamma temple in service .
+kicib lugalinimgina$Sealed tablet of Lugal-inim-gina .
+NUMB guruc u NUMBce$NUMB workdays ,
+kabku culpaeta sahar ziga$from the water installation at the Šulpa'e earth excavated ,
+ada guba aca culpae$irrigation work in the Šulpa'e field ,
+kabku audatur kura u culuh ak$water installation of the Audatur  and cleaned .
+kicib lugalhegal$Sealed tablet of Lugal-hegal .
+NUMB guruc u NUMBce$NUMB workdays ,
+ada guba aca badua aca icibene u aca udulusaga$irrigation work in the field Constructed wall , in the Incantation priests field and in the field Herders of Lusag .
+kicib nabasa$Sealed tablet of Nabasa .
+NUMB guruc u NUMBce$NUMB workdays ,
+acage a duga aca caragugal$field irrigation work performed in the field Šara-gugal
+kicib NUMB agugu$Two sealed tablets of Agugu .
+NUMB la NUMB guruc u NUMBce$NUMB less NUMB workdays ,
+marsa guba ugu ure bagar$stationed in the boathouse , booked into the debit section of Ur-e’e .
+kicib urnungal$Sealed tablet of Ur-Nungal .
+tura ealubi$Sick : Ea-lubi ,
+iti dalta$from the month “ Flight ”
+iti dumuzice$until the month “ Dumuzi ” ,
+abi u NUMBkam$the corresponding production : NUMB days .
+kicib ure$Sealed tablet of Ur-e'e .
+NUMB guruc u NUMBce$NUMB workers , NUMB workdays each ,
+abi u NUMBkam$the corresponding production : NUMB days ,
+madagac gena$having gone to Madga .
+kicib lugalitida$Sealed tablet of Lugal-itida .
+NUMB$NUMB , NUMB
+NUMB guruc u NUMBce$NUMB workdays ,
+e bahara guba$stationed in the pottery factory .
+kicib inimcara$Sealed tablet of Inim-Šara .
+NUMB guruc u NUMBce$NUMB workdays ,
+guru GANmah im ura$silo of GANmah plastered with clay .
+kicib gududu$Sealed tablet of Gududu .
+NUMB guruc u NUMBce$NUMB workdays ,
+kisu ninuduata apisalce inu imla$from the threshing floor of the  Ninnudu to Apisal straw hung out .
+NUMB guruc u NUMBce$NUMB workdays ,
+ganun dukusigta guru apisalce gi ma gara ma gida u ma bala$reed loaded into the barge , barge from the Dukuge storage house to the silo of Apisal punted and barge unloaded .
+kicib NUMB luduga$Two sealed tablets of Lu-duga .
+NUMB guruc u NUMBce$NUMB workdays ,
+kunzida e lammakace niguna bala gaga$transport of the bala load to the reservoir of the Lamma temple .
+NUMB guruc u NUMBce$NUMB workdays ,
+apisalta nibruce ma nigara u ce muca gida$from Apisal to Nippur barge with rough ground flour and muša grain punted .
+kicib cecsaga$Sealed tablet of Šeš-sag .
+NUMB guruc u NUMBce$NUMB workdays ,
+kisu caragugalka ce bala$from the threshing floor of Šara-gugal barley transferred .
+NUMB guruc u NUMBce$NUMB workdays ,
+eamara dabin bala ce ma siga$in E-amara flour transferred , barley loaded in the barge .
+NUMB guruc u NUMBce$NUMB workdays ,
+apisalce ma ce gida ma bala u ce bala$barge with barley to Apisal punted , barge unloaded and barley transferred .
+NUMB guruc u NUMBce$NUMB workdays ,
+kisu ninuduata eduruabukace ce ziga$from the threshing floor of Ninnudu for the Abu village barley winnowed .
+NUMB guruc u NUMBce$NUMB workdays ,
+kunzida agizeaka guba$stationed at the reservoir of Agizea .
+NUMB guruc u NUMBce$NUMB workdays ,
+kunzida e lammakace zi gaga$to the Lamma temple reservoir flour carried .
+NUMB$NUMB .
+NUMB guruc u NUMBce$NUMB workdays ,
+apisalta nibruce ma zida gida zi bala u ma su apisalce gura$from the Apisal to Nippur barge with flour punted , flour transferred and empty barge returned to Apisal .
+NUMB guruc u NUMBce$NUMB workdays ,
+ummace gu nigada gena$walked with fattening oxen to Umma .
+giri lusuen kurucda$Responsible : Lu-Suen , the fattener .
+NUMB guruc u NUMBce$NUMB workdays ,
+apisalta nibruce ma i ga ku gida$from Apisal to Nippur barge with oil , cheese and fish punted ;
+ara NUMBkam$first time .
+NUMB guruc u NUMBce$NUMB workdays ,
+apisalta nibruce ma i ga gida i ga egala kura u ma gura$from the Apisal to Nippur barge with oil and cheese punted , oil and cheese brought into the royal estate and barge returned ;
+ara NUMBkam$second time .
+NUMB guruc u NUMBce$NUMB workdays ,
+apisalta nibruce ma i ga gida i ga egala kura u ma gura$from Apisal to Nippur barge with oil and cheese punted , oil and cheese brought into the royal estate and barge returned ;
+ara NUMBkam$third time .
+giri akala ragaba$Responsible : Akala , the “ ragaba ” .
+NUMB guruc u NUMBce$NUMB workdays ,
+apisalta nibruce ma i ga ku nisi gida u ma gura$from Apisal to Nippur barge with oil , cheese , fish and vegetables punted and barge returned .
+giri turamili$Responsible : Turam-ili .
+NUMB guruc u NUMBce$NUMB workdays ,
+apisalta nibruce ma ku gida u ma gura$from Apisal to Nippur barge with fish punted and barge returned .
+giri niglagare$Responsible : Nig-lagare .
+NUMB$NUMB .
+NUMB guruc u NUMBce$NUMB workdays ,
+eduru amarsuenta ma gida min$from the Amar-Suen village barge punted , ditto ,
+kisu auda ce bala ce ziga u guru apisal im ura$at the threshing floor of Auda  barley transferred , barley winnowed , and silo of Apisal plastered with clay .
+NUMB sar NUMB gin kin u saharba$NUMB  shekels , grass and earth worked ;
+guruce NUMB ginta$per workday NUMB  shekels ,
+abi u NUMB gin$the corresponding production : NUMB shekels days ;
+ugu ureka bagar$booked into the debit section of Ur-e’e .
+NUMB guruc u NUMBce$NUMB workdays ,
+gizi cagal udu niga sadu caraka zea aca naramsuen eudu apisalce gaga$good reed , fodder for the fattening sheep , the regular offerings of Šara , torn out in the field of Naræm-Sin , to the sheep fold in Apisal carried .
+kicib luhaia$Sealed tablet of Lu-Haja .
+NUMB guruc u NUMBce$NUMB workdays ,
+kisu ninuduata eamarace inu gaga$from the threshing floor of Ninnudu to E-amara straw carried .
+kicib atu cuc$Sealed tablet of Atu , chief cattle administrator .
+NUMB gin$NUMB shekels .
+NUMB guruc u NUMBce$NUMB workdays ,
+a udua ugIL$production of free days of the porters .
+NUMB guruc u NUMBce$NUMB workers , each NUMB days ;
+abi u NUMB$the corresponding production is NUMB days .
+bala guba balace gena u balata gura$stationed in the bala , gone to bala , returned from the bala .
+NUMB$NUMB .
+cunigin NUMB gin guruc u NUMBce$Together NUMB , NUMB shekels workdays
+zigam$booked out .
+laia NUMB gin u NUMBce$deficit : NUMB , NUMB shekels workdays .
+nigkak a erinaka$Account of the production of the erin workers .
+lucara ugula dumu lugalinimgina$Lu-Šara is the foreman , son of Lugal-inim-gina .
+iti NUMBkam$It is  NUMB months
+iti cesagkuta$from the month “ Harvest ”
+iti dumuzice$until the month “ Dumuzi ” ;
+mu ma enki babdu$Year : “ the boat of Enki was caulked ” .
+NUMB ce gur lugal numun$NUMB royal gur of seed grain ,
+NUMB gur$NUMB gur , NUMB barig ;
+ekicibace$to the sealed warehouse ;
+cusuen$Šū-Sîn ,
+kiag enlila$beloved of Enlil ,
+lugal enlile$the king whom Enlil
+kiag cagana$as beloved in his heart
+inpa$did choose ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+e kiagani$his beloved temple
+mudu$he built .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+ce erin$xxx
+ce ura suga$xxx
+sulat$For Šullat
+u hanic$and Haniš ,
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+eani$his temple
+munadu$he built for him .
+sulat$For Šullat
+u hanic$and Haniš ,
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+eani$his temple
+munadu$he built for him .
+pisanduba$Basket-of-tablets
+nigkak ca nibru$xxx
+lugirizal nukiri$xxx
+X za X$xxx
+igal$xxx
+mu bad baduta$xxx
+mu usa e puzurdagan badu mu usabice$xxx
+pisanduba$Basket-of-tablets
+kicib daba guedina$xxx
+ipae dumu X$xxx
+dadumu lugalnesage$xxx
+inimcara dumu daga$xxx
+lugalukkene lugalkuzu$xxx
+urenlila$xxx
+basa lugalictaran$xxx
+ceckala dumu dada$xxx
+urgigir dumu baran$xxx
+urmes ipae$xxx
+urninsu cecani$xxx
+agugu lugalezem$xxx
+urgigir dumu lugaluni$xxx
+abagina dumu X$xxx
+urculpae X$xxx
+igal$xxx
+mu en X$xxx
+nin X X X$the queen of … ,
+ninani$his mistress ,
+namti$for the life
+culgi$of Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurikace$and king of Sumer and Akkad ,
+AN zi gi X$PN
+pisanduba$Basket-of-tablets
+dub gida$long-tablets
+ugula X$foreman Lu-… ,
+X X X X X$… ,
+igal$are here ;
+mu urbilum$year : “ Urbilum . ”
+NUMB ad udu mac hia$NUMB carcasses , various sheep and goats ,
+ki naramilita$from Naram-ilī
+urnigar$did Ur-nigar
+cu bati$receive ;
+iti macdagu$month “ Gezelle-feast , ”
+mu usa kimac u hurti bahul$year after : “ Kimaš and Ḫurti were destroyed . ”
+pisanduba$Basket-of-tablets
+gurumak daba$inspections of dab ,
+erin sagapin$troops of head-plowmen ,
+e ningeczida$house of Ningešzida ,
+igal$are here ;
+mu cacrum bahul$year : “ Šašrum was destroyed . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urmes$Ur-mes ,
+dumu ursaga$son of Ursaga ,
+ensi irisarig$governor of Irisagrig ,
+ARADzu$is your servant .
+nance$For Nanše ,
+nin induba$the lady of the boundary marker ,
+ninani$his mistress ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urimake$king of Ur ,
+e cececgarakani$her Temple Established by the Brothers
+munadu$he built for her .
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+erin sagapin$xxx
+e nance$xxx
+e nindara$xxx
+ugIL$xxx
+e nindara$xxx
+sagapin ugIL e uru$xxx
+igal$xxx
+mu usa kimac bahul$xxx
+NUMB gu gi$NUMB , NUMB talents of reeds
+ceta sa$in barley exchanged ,
+ki lugalitidata$from Lugal-itida ,
+dumu girini$son of Girini ,
+ugu lukala bagar$into the debit of Lukalla placed ;
+kicib urcara caduba$sealed document of Ur-Šara , the archivist ;
+mu ku guza enlila badim$year : “ silver-chair of Enlil was fashioned . ”
+urcara$Ur-Šara ,
+dubsar$scribe ,
+dumu lugalucur$the son of Lugal-ušur .
+nanna$To Nanna
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+namtilanice$for his life
+a munaru$he dedicated  to him .
+alanba$Of this statue
+nanna X$Nanna is My … Wall
+mubim$is its name .
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+sipa unu$xxx
+kinunir$xxx
+nigin$xxx
+guaba$xxx
+sipa cagan$xxx
+sipa unu culgi$xxx
+u sagapin e ninhursag$xxx
+igal$xxx
+mu harci bahul$xxx
+NUMB gugec$NUMB plow-oxen ,
+NUMB abmah$NUMB mature cow ,
+ki dageta$from Dage ;
+gu nigur icib culgira$the oxen are the property of the incantation priest of Šulgi ;
+lugalhegal$Lugal-ḫegal
+idab$took ;
+aca urgalamace$to the field of Ur-galama ;
+iti cesagku$month : “ Harvest , ”
+mu ibisuen lugal$year : “ Ibbi-Suen is king . ”
+NUMB gugec$NUMB plow-oxen ,
+NUMB abmah$NUMB mature cow ,
+ki dageta$from Dage ;
+gu nigur icib culgira$the oxen are the property of the incantation priest of Šulgi ;
+lugalhegal$Lugal-ḫegal
+idab$took ;
+aca urgalamace$to the field of Ur-galama ;
+iti cesagku$month : “ Harvest , ”
+mu ibisuen lugal$year : “ Ibbi-Suen is king . ”
+lugalhegal$Lugal-ḫegal ,
+cabra lugalmagure$manager of Lugal-magure ,
+dumu sagazu$son of Sagazu .
+utu$For Utu ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king or Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+eani$his temple
+munadu$he built for him .
+pisanduba$Basket-of-tablets
+di tila$xxx
+urlamma$xxx
+ensi$xxx
+mu kimac bahul$xxx
+NUMB gu niga$NUMB oxen , grain-fed ,
+NUMB ancelibir NUMB X$NUMB donkey , “ old ” , NUMB …
+NUMB mac NUMB sila$NUMB male goats , NUMB ban2 NUMB sila ,
+NUMB sila gar$NUMB ban2 NUMB sila of kašk-cheese ,
+im NUMBkam$ordNUMB tablet ;
+NUMB gu$NUMB oxen ,
+NUMB ancelibir$NUMB donkeys , “ old ” ,
+NUMB udu$NUMB sheep ,
+NUMB ce gur$NUMB gur barley ,
+im NUMBkam$ordNUMB tablet ;
+NUMB sila ce gur$NUMB gur , NUMB barig NUMB ban2 NUMB sila3 ,
+im NUMBkam$ordNUMB tablet ;
+NUMB ce gur$NUMB gur barley ,
+im NUMBkam$ordNUMB tablet ;
+NUMB gin kubabbar$NUMB shekels silver ,
+im NUMBkam$ordNUMB tablet ;
+NUMB udu mac hia$NUMB various sheep and goats ,
+im NUMBkam$ordNUMB tablet ;
+NUMB gu NUMB mana NUMB gin NUMB ce kubabbar$NUMB oxen , NUMB mana NUMB shekels NUMB grains silver ,
+n NUMB sila inun NUMB sila gar$NUMB ban2 two sila3 of clarified butter , NUMB barig NUMB ban2 NUMB sila3 kašk-cheese ,
+n kuc gu NUMB ad gu$NUMB hides of oxen , NUMB carcasses of oxen ,
+im NUMBkam$ordNUMB tablet ;
+X NUMB udu im NUMBkam$NUMB sheep , ordNUMB tablet ;
+NUMB udu im NUMBkam$NUMB sheep , ordNUMB tablet ;
+NUMB ancelibir$NUMB donkey , “ old ” , … ,
+im NUMBkam$ordNUMB tablet ;
+pisan cuerata$from the basket of Šu-Erra
+idinera cu bati$Iddin-Erra received ;
+NUMB ce gur im NUMBkam$NUMB gur barley , ordNUMB tablet .
+NUMB gin igiNUMBgal NUMB ce kubabbar$NUMB shekels NUMB grains silver ,
+laia suga$deficit , repaid ,
+ki urnungal dumu erindata$from Ur-Ningal son of Erinda ,
+egala banku$into the palace brought ,
+giri urlamma$via Ur-Lamma ;
+iti cunumun$month : “ Harvest , ”
+mu usa amarsuen lugal$year after : “ Amar-Suen  king . ”
+pisanduba$Basket-of-tablets
+kicib daba a erinaka$sealed documents of daba , labor or troops ,
+abasaga nubandagu$Abba-saga , oxen manager ,
+iti NUMBkam$NUMB months ,
+igal$are here ;
+mu usa cusuen lugale bad martu muriqtidnim mudu$year following : “ Šū-Suen , the king , the Amorite wall muriq-tidnim erected . ”
+NUMB ce gur$NUMB gur of barley ,
+ce cuku anati$barley allotment of Anati ;
+NUMB ce gur$NUMB gur of barley ,
+X$of Nun-… ;
+cunigin NUMB ce gur$total : NUMB gur of barley ,
+ce cukura aca X UD gur$barley allotments from the field … ;
+iti kisikininazu$month : “ ki-siki of Ninazu , ”
+mu ma darabzuenki badu$year : “ The boat ‘ibex of absu-Enki’ was caulked . ”
+NUMB gukkal niga$NUMB fat-tailed sheep , grain-fed ,
+ki utamicaramta$from Uta-mišarram
+nalu$did Nalu
+idab$accept ;
+iti akiti$month "Akītu , ”
+mu enunugal inanna unu bahun$year : “ Enunugal Inanna in Uruk was installed ; ”
+NUMB$NUMB .
+NUMB gu NUMB ab$NUMB oxen , NUMB cow ,
+NUMB udu NUMB u$NUMB rams , NUMB ewes ,
+NUMB sila$NUMB lamb ,
+NUMB ud$NUMB nanny goats ,
+cugid emuhaldimce$šugid for the Kitchen ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+bazi$booked out ;
+iti ezemah$month : “ Grand Festival , ”
+mu amarsuen lugale urbilum muhul$year : “ King Amar-Sin Urbilum destroyed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+dub gida$long-tablets of
+urnance$of Ur-Nanše ,
+dumu luduga$son of Lu-Duga ,
+u lugina dumu urnintu$and of Lugina , son of Ur-Nintu ,
+igal$are here .
+mu harci kimac bahul$year : “ Ḫarši , Kimaš were destroyed . ”
+pisanduba$Basket-of-tablets
+ziga$credits ,
+kicib naramili$sealed documents of Naram-ilī ,
+ki abasaga$with Abbasaga ,
+iti macdaguta$from month “ Gazelle-Feast , ”
+iti cesagkuce$to month “ Harvest , ”
+iti NUMBkam$NUMB months ,
+mu amarsuen lugale urbilum bahul$year : “ Amar-Suen , the king , Urbilum destroyed . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+nasilim$Nasilim ,
+dumu X$son of Ur-… ,
+ARADzu$is your servant .
+NUMB gukkal$NUMB fat-tailed sheep ,
+NUMB macgal$NUMB billy goat , full grown ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+tahcatal$Tahiš-atal
+idab$accepted ;
+iti kisikininazu$month : “ kisiki of Ninazu , ”
+mu en nanna karzida bahun$year : “ The priest of Nanna of Karzida was installed ; ”
+NUMB udu$NUMB sheep .
+NUMB sila dabin$NUMB ban2 NUMB sila3 of dabin-flour ,
+u NUMBkam$ordNUMB day ;
+NUMB sila dabin$NUMB ban2 NUMB sila3 of dabin-flour
+u NUMBkam$ordNUMB day ;
+NUMB u NUMB la NUMBkam$NUMB ban2 NUMB sila3 , ordNUMB day ;
+NUMB zi sagi$NUMB ban2 of flour , cup-bearer ;
+ki ludingirata$from Lu-dingira ,
+kicib ensika$under seal of the governor ;
+iti sigicubagar$month : “ Laying bricks in the mold , ”
+mu usa cusuen lugal$year after : “ Šu-Suen  king . ”
+pisanduba$Basket-of-tablets
+nigkak$accounts of
+a buru$labor of harvest ,
+a ente$labor of wintertime ,
+cabrane$of the chief household administrators ,
+igal$are here ;
+mu cusuen lugal$year : “ Šu-Suen is king . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+utukalamana$Utu-kalamana ,
+dumu X$son of … ,
+X X$…
+X$… .
+NUMB kac dida saga$NUMB  wort , fine quality ,
+ki urhendursagta$from Ur-Ḫendursag ,
+erabani$did Erra-bani
+cu bati$receive ;
+iti ezembaba$month “ Festival-of-Baba . ”
+erabani$Erra-bani ,
+ARAD urbaba$servant of Ur-Baba .
+NUMB mac$NUMB billy goats ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+nalu$Nalu
+idab$accepted ;
+iti cesagku$month : “ Harvest , ”
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed ; ”
+NUMB$NUMB .
+ARADnanna cagina$ARAD-Nanna , general
+cimacgi u mada$of Šimašgi and the lands 
+kardaka$of Karda . 
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+kisu acaninura guba$at the threshing floor of the Ninurra field stationed ,
+ugula ceckala$the foreman : Šeškala ,
+kicib urculpae$under seal of Ur-Šulpa’e ;
+mu usa cusuen lugale bad martu mudu$year after : “ Šu-Suen , the king , the Martu Wall erected . ”
+urculpae$Ur-Šulpa’e ,
+dubsar$scribe ,
+dumu lugalkugani$son of Lugal-kugani .
+NUMB GAN ceba u kac NUMB gur$NUMB eše3 field area : barley rations and beer , NUMB gur ,
+lugalniglagare gudu$Lugal-nig-lagare , the gudu ;
+NUMB GAN NUMB dam akala$NUMB iku field area : NUMB barig , wife of Ayakalla ;
+NUMB GAN NUMB urlimu$NUMB bur3 NUMB iku field area : NUMB barig NUMB ban2 , Ur-limu ;
+NUMB GAN NUMB gur X$NUMB eše3 field area : NUMB gur … ,
+abagina X X$Abbagina … ;
+n GAN NUMB X X gur$… field area : NUMB gur NUMB barig NUMB ban2 … ;
+n n NUMB GAN lugal gur$… NUMB eše3 NUMB iku field area : NUMB gur royal ,
+NUMB GAN NUMB gur X$NUMB iku field area : NUMB gur … ;
+NUMB GAN NUMB gur urlugal$NUMB eše3 field area : NUMB gur NUMB barig NUMB ban2 , Ur-lugal ;
+NUMB GAN NUMB ermu mackim$NUMB iku field area : NUMB ban2 , Ermu , the enforcer ;
+NUMB GAN NUMB gur$NUMB iku field area : NUMB barig harvested
+aca X$at the field , …-new ;
+NUMB GAN NUMB daga$NUMB bur3 field area : NUMB , Da’aga ;
+NUMB GAN NUMB luduga$NUMB iku field area : NUMB , Lu-duga ;
+NUMB GAN NUMB igihuc$NUMB eše3 field area : NUMB barig , Igihuš ;
+NUMB GAN NUMB inzua igice habaluge$NUMB eše3 field area : NUMB , Inzua , in front of Ḫabaluge ;
+aca gaba X$field up against … ;
+apinlam$cultivation ;
+n GAN n X luduga$NUMB iku field area : … , Lu-duga
+gaba aca gusuhub$up against the field of Oxen-boot ;
+aca gida buru ca apisal$field measured , harvest-time in Apisal .
+mu cusuen lugale magurmah X ninlilra munedim$year : “ Šu-Suen , the king , had Great-barge for Enlil and Ninlil fashioned . ”
+NUMB udu$NUMB sheep ,
+NUMB ud$NUMB nanny goats ,
+cugid$šugid offerings ,
+u NUMBkam$the ordNUMB day ,
+ki tahicatalta$from Tahiš-atal ,
+NUMB gu NUMB ab$NUMB ox , NUMB cow ,
+u NUMBkam$the ordNUMB day ,
+ki intaeata$from Inta'ea ,
+duga idab$Duga accepted .
+iti akiti$Month “ Akitu , ”
+mu ma enki badim$year : “ The boat of Enki was fashioned . ”
+pisanduba$Basket-of-tablets
+laia ce$xxx
+mu guzata$xxx
+mu cacruce$xxx
+mu NUMBkam$xxx
+nigka pisan kabduga cabrane$xxx
+mu enmahgalana$xxx
+u ziga$xxx
+nigkata cu suba$xxx
+mu cacru$xxx
+pisanduba$Basket-of-tablets
+mu didli ceba$various years of barley rations ,
+ca girsu$in Girsu ,
+igal$are here ;
+mu enmahgalana bahun$year : “ Enmahgalana was hired . ”
+NUMB udu niga$NUMB sheep , barley-fed ,
+sadu gemenlila dumumunus ena$regular rations of Geme-Enlila , daughter of the high-priest ,
+u NUMBkam$the ordNUMB day ,
+ki naluta$from Nalu
+bazi$booked out ,
+ca nibru$in Nippur ,
+giri lunincubur dubsar$via Lu-Ninšubur , the scribe ;
+iti ezemcusuen$month : “ Festival of Šu-Sin , ”
+mu cusuen lugale bad martu muriqtidnim mudu$year : “ Šu-Suen , the king , the western wall ‘muriq-tidnim’ erected ; ”
+NUMB$NUMB .
+NUMB sar dih ku NUMB sarta$NUMB sar , cutting thorn weed at NUMB sar ,
+abi u NUMBkam$its labor : NUMB days ,
+aca ninudu$field “ Nin-nudu ; ”
+NUMB sar u ku NUMB sarta$NUMB sar , cutting grass at NUMB sar ,
+abi u NUMBkam$its labor : NUMB days ,
+aca dukusig u aca pusimu$field “ Gold-Mound ” and field “ Pusimu ; ”
+NUMB sar kici NUMB sarta$NUMB sar , thorn bushes at NUMB sar ,
+abi u NUMB nkam$its labor : NUMB days ,
+aca X$field “ … ” ;
+kicib inimcara$under seal of Inim-Šara ;
+mu en eridu bahun$Year : “ The high-priestess of Eridu was hired . ”
+inimcara$Inim-Šara
+dumu urnigar$son of Ur-nigar .
+NUMB gukkal NUMB udu alum$NUMB fat tailed sheep , NUMB ašlum-sheep ,
+NUMB macgal$NUMB large billy goats
+irdumartu$Irdu Martu ;
+NUMB sila lugalazida cabra$NUMB lamb : Lugal-azida , chief household manager ;
+NUMB sila ribhuti$NUMB lamb : Ribḫuti ;
+NUMB sila en inanna$NUMB lamb : high-priestess of Inanna ;
+u NUMBkam$ordNUMB day ,
+muku$delivery ,
+intaea$Intaea
+idab$received ;
+giri nannamaba dubsar$via Nanna-maba , scribe ;
+iti akiti$month : “ Akitu , ”
+mu cusuen lugal$year : “ Šu-Suen  king ; ”
+NUMB$NUMB .
+n X niga$NUMB grain-fed … ,
+X urdumuzida X |KI.AN|$… Ur-Dumuzida … in KI . AN
+e carakamta$from the household of Šarakam ;
+iti ezemculgi$the month : “ festival of Šulgi ” ,
+mu e cara badu$year : “ The house of Šara was erected ” .
+lugalazida$To Lugal-azida
+unadu$speak!
+NUMB sa gi$NUMB bundles of reed
+zantirum$to Zantirum ,
+NUMB sa gi$NUMB bundles of reed
+urgugu$to Ur-gugu—
+idume$they are doormen—
+henebcumu$may he give them .
+amarsuen$Amar-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four regions ;
+urlisi$Ur-Lisi ,
+ensi$governor
+umma$of Umma ,
+ARADzu$is your servant .
+NUMB gu$NUMB ox ,
+NUMB udu$NUMB sheep ,
+NUMB macgal$NUMB large billy goats ,
+NUMB sila$NUMB lambs ,
+u NUMBkam$the ordNUMB day ,
+cabita$Therefrom
+NUMB gugec X$NUMB ox for the plow … ,
+NUMB udu X X$NUMB sheep for Alla … ,
+ki intaeata$from Inta'ea
+duga idab$Duga accepted .
+iti ezemekigal$Month “ mekigal festival , ”
+mu madarabzu babdu$year : “ The boat ‘Ibex-of-Apsu’ was caulked . ”
+urnusku$Ur-Nusku
+igiNUMBgal$NUMB ,
+urutu$Ur-Utu ,
+X$x… of the ‘sesame’
+igiNUMBgal$NUMB ,
+lulu dumu X$Lullu , the son of x-alim
+igi NUMBgal$NUMB ,
+urekura$Ur-ekura
+igi NUMBgal$NUMB ,
+ARADdu$ARADdu
+igi NUMBgal$NUMB ,
+urcumah$Ur-Šumaḫ
+igi NUMBgal$NUMB ,
+urenlila$Ur-Enlila
+igi NUMBgal$NUMB ,
+damgarme$they are trade agents .
+iti sigata$In the month ‘of the bricks’
+u NUMB zala$from the end of the ordNUMB day ,
+ka bageUZec$… .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+dania$Danniya ,
+dubsar$scribe ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+nigkak$xxx
+idub$xxx
+giri luningirsu dumu ikala$xxx
+igal$xxx
+mu harci bahul$xxx
+pisanduba$Basket-of-tablets
+ceba niginba$rations , grand totals ,
+girsuta$from Girsu
+guabace$to Guabba ,
+igal$are here ;
+mu amarsuen lugal$year : “ Amar-Suen is king . ”
+pisanduba$Basket-of-tablets
+nigkak$accounts of
+nalu$Nalu ,
+iti macdagu$from month : “ Gazelle feast , ”
+mu ara NUMBkamac simurum bahulta$year : “ For the ordNUMB time Simurrum was destroyed , ”
+iti diri cesagku$to the month , extra : “ Harvest , ”
+mu usa e puzuricdagan badu mu usabice$year after : “ The house of Puzriš-Dagan was erected , ” year after that ;
+mu NUMBkam$of NUMB years ,
+caba iti diri NUMBam igal$therein NUMB extra months .
+pisanduba$Basket-of-tablets
+dub gida$long-tablets
+situm$debits
+lu nigdabakene$of the takers
+igal$are here ;
+mu amarsuen lugal$year : “ Amar-Suen is king . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+hazi$Ḫazi ,
+nubanda$nubanda ,
+ARADzu$is your servant .
+cusuen$Šū-Suen ,
+nibrua$in Nippur
+enlile$by Enlil
+mu pada$chosen ,
+sagus$headrest
+e enlilka$of the house of Enlil ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+adalal$Adalal
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+dub gida$long-tablets ,
+ce lu nigdabkene$barley of the takers ,
+igal$are here ;
+mu$year : “ … . ”
+NUMB ad udu$NUMB carcases , sheep ,
+mu agausene$on account of the soldiers ,
+ugula dukra$foreman : Dukra ;
+ki tura$from Turaya
+hums,u$did Humṣu
+cu bati$receive ;
+giri cuecdar$via Šū-Ištar ,
+dumu earabi$son of Ea-rabi ,
+ca nimzium$in Nimzi’um ,
+iti ezemculgi$month “ Festival-of-Šulgi , ”
+mu cacru bahul$year : “ Šašru was destroyed . ”
+AN X X X$…
+cu X$is not overturned .
+gidlamni$Her husband ,
+en nunamnire$lord Nunamnir ,
+nig al dugani$the thing she requested
+nuncibkecre$does not block .
+ninlil$Ninlil ,
+nun kurkura diriga$princess greater than all the lands ,
+nin kiag$beloved mistress
+cusuenake$of Šu-Sin ,
+u namti$when life ,
+zi X gal$the producing of long life ,
+aga men gidri u sura$a tiara and crown , a long-lasting scepter ,
+guza namlugal$a throne and kingship
+suhuc gina$with firm foundation ,
+mu hegala$years of abundance
+tukul amaru$a weapon - the flood
+ni gal mucub$which casts great fear ,
+ankar$the a'ankar weapon ,
+a me$the arm of battle ,
+a namursaga$the arm of heroism
+ni melambi$whose fearsomeness and divine radiance
+ane usa$reaches to the sky ,
+zapagbi$whose roar
+kibala duldulu$covers the rebellious land ,
+giri X$…
+ninlil X X$Ninlil …
+cusuen X X$for Šu-Sin …
+ki gidlamnata$from her spouse
+ninlil a X X$Ninlil …
+al imandu$did make a request for it .
+ninlil dam kiag$For Ninlil , beloved spouse
+enlila$of Enlil ,
+gidlamni en nunamnire$her husband lord Nunamnir
+galbi tumae$who has wrought greatly —
+cusuen$to Šu-Sin ,
+ARAD kiag$beloved servant
+enlila$of Enlil ,
+lugal enlile cagana$king whom Enlil in his heart
+inpa$did choose ,
+u an ubda limmuba$and of the four quarters ,
+lugal kalga lugal urima$mighty king , king of Ur ,
+lugal an ubda limmuba$king of the four world quarters ,
+ARAD kiaganir$her beloved servant ,
+munancuma$having given  to him —
+uba cimacki$at that time , Šimaški ,
+mada mada zabcali$the lands of Zabšali
+za ancanta$from the border of Anšan ,
+X X$…
+IM X$…
+alan X$a statue …
+PI X X X$…
+mudim$he fashioned ,
+ninlil$and to Ninlil ,
+ninanir$his mistress ,
+namtilanice$for his life
+a munaru$he dedicated it .
+pisanduba$Basket-of-tablets
+ekiciba$xxx
+sagnigurakam$xxx
+u X$xxx
+urtur X$xxx
+iti cueca$xxx
+mu enmahgalana en nanna bahunta$xxx
+iti cesagku$xxx
+mu enunugal inanna unu bahunce$xxx
+iti NUMBkam$xxx
+sag iti diri NUMBam$xxx
+X X X X$… , … ,
+X huhnuri X X$… , Huḫnuri , … ,
+X X cipara X X$… x-rini , Šipara ,
+cimacgi sabum X$Šimaški and also Sabum ,
+X X kimac duduli X$… , Kimaš , Duduli ,
+X mada ancan X$… , the land of Anšan , …
+X X X X X$… , …
+pisanduba$Basket-of-tablets
+nigkak$xxx
+lu nigdabkene$xxx
+igal$xxx
+mu kimac bahul$xxx
+NUMB udu niga$NUMB rams , barley-fed ,
+NUMB gukkal niga$NUMB fat-tailed rams , barley-fed ,
+NUMB u niga$NUMB ewes , barley-fed ,
+NUMB u gukkal niga$NUMB fat-tailed ewe , barley-fed ,
+NUMB macgal niga$NUMB full-grown billy goats , barley-fed ,
+sadu ninlila$regular offerings to Ninlil ;
+u NUMB la NUMBkam$ordNUMB day ;
+ca tumal$at Tummal ,
+ki X$from … ;
+iti X$month : “ … , ”
+mu X$year : “ … ; ”
+NUMB la NUMB$NUMB less NUMB .
+pisanduba$Basket-of-tablets
+gabari$copies
+nigur celebutum nubanda$of goods of Šelēbūtum , the supervisor ,
+u cumalik dumuni$and Šū-Mālik , his son ,
+im cu cuma$tablets of receipt ,
+cutia idlid$receipts of Idlid ,
+ikunsir cabra$Ikūn-sir , the chief household administrator ,
+dadabani engar$Dada-bani , the plowman ,
+cunana nagada$Šunana , the herdsman ;
+laia suga$deficits , repayments ,
+catsuen dumumunus uluhuri$of Šāt-Suen , daughter of Ulluḫ-ūri ,
+u ziga ibila NUMBaba$and credits of the NUMB elder sons ,
+caba igal$herein are ;
+nurili$Nūr-ilī
+u cukubum dumu cumalik$and Šukubum , son of Šū-Mālik ,
+cu bantiec$received ;
+giri ilimiti diku$via Ilī-miti , the judge ,
+u luduga diku$and Luduga , the judge ,
+ca nibru$in Nippur ,
+iti kisikininazu$month “ Wool center of Ninazu , ”
+mu usa ma darabzu enkika babdu$year following : “ The barge Dara-abzu of Enki was caulked . ”
+pisanduba$Basket-of-tablets
+dub gida$long-tablets
+luningirsu dumu bazi$of Lu-Ningirsu , son of Bazi ,
+igal$are here ;
+mu cacrum bahul$year : “ Šašrum was destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+igal$xxx
+mu e puzurdagan badu$xxx
+NUMB imtie$NUMB  Imti-e2 ? ,
+ARAD egal$slave of the palace ,
+mu NUMBam$for three years
+izaham$fled ;
+ianagare$Ya-nagar
+pag ize$shall cut the “ breath ; ”
+azida$To Azida
+bantumu$he shall bring him ;
+igi ensikace bagen$before the ensi it was confirmed .
+mu amarsuen lugale urbilum muhul$Year : “ Amar-Suen , the king , destroyed Urbilum . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+urnance$xxx
+dumu nabasa$xxx
+u lubimu$xxx
+gu i nigincedu$xxx
+igal$xxx
+mu kimac bahul$xxx
+NUMB sila$NUMB lamb ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+intaea$Intaea
+idab$accepted ;
+iti ezemninazu$month : “ Festival of Ninazu , ”
+mu cacru bahul$“ Šašru was destroyed ; ”
+NUMB$NUMB .
+NUMB GAN kiri$NUMB iku the surface  orchard ;
+NUMB gecimmar$NUMB date palms ;
+ugIL nukiri$UgIL the  orchardist ;
+arua lunanna dumu urur$ex-voto of Lu-Nanna son of Ur-ur ;
+ugula abagula$the foreman Abba-gula .
+NUMB GAN kaDU$NUMB iku the surface  irrigation-inlet-plot ;
+NUMB GAN kigal$NUMB iku the surface  uncultivated land ;
+NUMB gecimmar$NUMB date palms
+NUMB gecimmar u duga$NUMB date palms  beaten down ;
+gec'u NUMB u NUMB HARlam usuh$NUMB “ ḪARlam ” objects of pine trees ;
+NUMB HAR hachur$NUMB “ ḪAR ” objects of apple trees ;
+NUMB HAR pec$NUMB “ ḪAR ” objects of pear trees ;
+HAR cedu gid$… “ ḪAR ” objects of long junipers ;
+NUMB la NUMB mes gid$NUMB “ ḪAR ” objects of long boxwood trees ;
+NUMB gipar$NUMB mulberry trees ;
+NUMB HAR cinig gid$NUMB “ ḪAR ” objects of long tamarisk ;
+nimgirinimgina$Nimgir-KAgina ;
+kiri amarsunzida$orchard  Amar-sunzida .
+NUMB sar GAN gecimmar$NUMB sar the surface of date palms ;
+NUMB gecimmar$NUMB date palms ;
+lugirizal guzala$Lu-girizal , the throne-bearer ;
+kiri adiri ehegal unu$orchard Adiri  E-hegal , the herdsman ;
+ugula enlila$the foreman Enlila ;
+nanna$For Nanna ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+i nun$the Noble Canal ,
+i kiagni$his beloved canal ,
+munabal$he dug for him .
+pisanduba$Basket-of-tablets
+dub gida$long-tablets of
+urnance dumu luduga$Ur-Nanše , son of Lu-duga ,
+kimac$of Kimaš ,
+igal$are here ;
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+dub gida$xxx
+kuli dumu kiagmu$xxx
+igal$xxx
+urlamma$xxx
+ensi$xxx
+mu harci bahul$xxx
+NUMB ma NUMB gur$NUMB barges , NUMB gur ,
+NUMB ma NUMB inuda$NUMB barges , NUMB gur , for straw ;
+gaece$to Ga’eš ;
+giri bazi dumu dingira$via Bazi , son of Dingira ;
+iti ezemlisi u NUMB bazal$month : “ Festival of Lisi , ” ordNUMB day completed ,
+mu en eridu bahun$year : “ The high-priest at Eridu was installed . ”
+NUMB az$NUMB bear ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+ludingira$Lu-dingira
+idab$accepted ;
+iti ezemekigal$month : “ Festival of Mekigal , ”
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB$NUMB
+pisanduba$Basket-of-tablets
+sagnigur$debits ,
+mani$Mani ,
+ca girsu$in Girsu ,
+igal$are here ;
+mu kimac bahul$year : “ Kimaš was destroyed . ”
+lucara$Lu-Šara ,
+dubsar$scribe ,
+dumu  iribare$son of Iribare .
+ninlil$To Ninlil
+ninani$his mistress ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur ,
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+namtilanice$for his life
+a munaru$he dedicated  to her .
+pisanduba$Basket-of-tablets
+kin cukura iria gara$xxx
+NUMB GAN NUMB sarta$xxx
+girsuta$xxx
+guabace$xxx
+igal$xxx
+mu en inanna mace ipa$xxx
+NUMB ninda la NUMB cudua gid$NUMB ninda less NUMB “ fist ” , the length ;
+NUMB kuc dagal$NUMB cubits , the width ;
+NUMB ninda NUMB kuc NUMB cudua gid$NUMB ninda NUMB cubits NUMB “ fists ” , the length ;
+NUMB kuc NUMB cubad dagal$NUMB cubits NUMB “ open-hand ” , the width ;
+NUMB ninda NUMB kuc NUMB cudua gid$NUMB ninda NUMB cubits NUMB “ fist ” the length ;
+NUMB kuc NUMB cubad dagal$NUMB cubits NUMB “ open-hand ” , the width ;
+NUMB ninda du NUMB kuc gid$NUMB running ninda NUMB cubits the length ;
+NUMB kuc dagal$NUMB cubits the width ;
+NUMB kuc gid$NUMB cubits the length ;
+NUMB kuc dagal$NUMB cubits the width ;
+n gid$NUMB … the length ;
+n dagal$NUMB … the width ;
+NUMB kuc n gid$NUMB cubits … the length ;
+n dagal$NUMB … the width ;
+n gid$NUMB … the length ;
+n dagal$NUMB … the width ;
+n gid$NUMB … the length ;
+NUMB kuc dagal$NUMB cubits the width ;
+ningal$To Ningal
+ninanir$his mistress ,
+amarsuen$Amar-Suena ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+geparkugani e kiagani$her sacred Gipar , her beloved temple ,
+munadu$he built for her .
+namtilanice$For his life
+a munaru$he dedicated  to her .
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+gu apin daba$xxx
+nigkak a$xxx
+e dumuzi$xxx
+e nindara$xxx
+e ninmar$xxx
+e culgi$xxx
+e amarsuen$xxx
+u galme dubi$xxx
+igal$xxx
+mu cacrum bahul$xxx
+NUMB gin NUMB ce kubabbar$NUMB shekels , NUMB grains of silver ,
+laia suga cukuene$replaced deficit of the fishermen ,
+ki urcarata$from Ur-Šara ,
+akala$did Akalla
+cu bati$receive ;
+iti minec$month “ … ” ,
+mu en nanna mace ipa$year : “ The priestess of Nanna with a goat was determined ” .
+akala$Akalla ,
+dubsar$scribe ,
+dumu urnigar cuc$son of Ur-nigar , cattle manager .
+pisanduba$Basket-of-tablets
+ca dugan kac zi u igec$xxx
+giri kaskene$xxx
+iti GANmacta$xxx
+iti cesagkuce$xxx
+iti NUMBkam$xxx
+ca hurim$xxx
+igal$xxx
+mu harci hurti bahul$xxx
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+nindingir baba$xxx
+igal$xxx
+mu X X X$xxx
+pisanduba$Basket-of-tablets
+nigkak$xxx
+cabi suga ca ze$xxx
+igal$xxx
+mu naruamah badu$xxx
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur .
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents , … , of
+adu ugula ucbar$Adu , foreman of weavers ,
+mu ma enki u$year : “ The barge of Enki ” and
+mu simanum$year : “ Simanum , ”
+igal$are here .
+NUMB sila$NUMB lambs ,
+NUMB mac$NUMB billy goat ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+intaea$Intaea
+idab$accepted ;
+iti sesdagu$month : “ Piglet-feast , ”
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+ce erine cu tia$xxx
+lugina kaguru$xxx
+igal$xxx
+mu huhunuri bahul$xxx
+culgi$Šulgi ,
+X maticu$the god of his country ,
+danum$the mighty ,
+X uri$king of Ur
+X kibratim$and king of the world quarters
+arbaim$the four ,
+inu$when
+mat kimac$the countries of Kimaš
+u hurtim$and Hurtim
+uhaliquna$he obliterated ,
+hiritam$a ditch
+ickun$he created
+u birutam$and an embankment
+ibni$he built .
+NUMB gu niga NUMB udu niga gueusa$NUMB oxen , barley-fed , NUMB sheep , barley-fed , “ following oxen , ”
+NUMB udu NUMB sila$NUMB sheep , NUMB lamb ,
+NUMB mac NUMB amar macda$NUMB kid , NUMB gazelle fawns ,
+ensi umma muku akiti cesagkuka X$of the governor in Umma , delivery for the Akitu in the  “ Harvest ” … ;
+NUMB macgal NUMB sila$NUMB bucks , NUMB lamb ,
+nigarkidu$of Nigar-kidu
+n udu niga NUMB sila$NUMB sheep , barley-fed , NUMB lamb ,
+ensi apiak$of the governor of Apiak ;
+X X X$…
+X$…
+X$…
+iti macdagu$month : “ Gazelle feast , ”
+mu usa urbilum bahul$year after : “ Urbilum was destroyed ; ”
+u nkam$nth day .
+pisanduba$Basket-of-tablets
+ucgina kurucda$Ušgina , the fattener ,
+igal$are here ;
+NUMB guruc u NUMBce$NUMB male laborers for NUMB workdays ,
+ecitim guba$at the builder-house stationed ,
+emacka guba$at the …-house stationed ,
+ugula ukkene$foreman : Ukkene ,
+giri lugirizal$via Lu-girizal ,
+kicib biduga$under seal of Biduga ;
+mu kimac muhul$year : “ Kimaš was destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+u kicib dababi$xxx
+lusaga ugula$xxx
+mu enunugal inanna bahun$xxx
+pisanduba$Basket-of-tablets
+etum$xxx
+muku$xxx
+u ziga$xxx
+urtur sipa gu niga$xxx
+iti macdaguta$xxx
+iti cesagkuce$xxx
+iti NUMBce$xxx
+mu huhnuri bahul$xxx
+pisanduba$Basket-of-tablets
+ce gecea GANgu apinla$barley threshed of the oxen-fields , plough maintenance ,
+u nigkak$and accounts
+ARAD kaguru$of ARAD , the silo manager ,
+mu usa e puzurdagan badu$year following : “ The house of Puzriš-Dagan was built , ”
+igal$are here .
+NUMB mac babbar ca wadaltum$NUMB white kid , in wadaltum ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewes ,
+NUMB ud$NUMB nanny goats ,
+NUMB sila$NUMB lambs ,
+NUMB sila ga$NUMB suckling lambs ,
+bauc u NUMBkam$slaughtered , the ordNUMB day ,
+ki culgiamuta$from Šulgi-ayamu
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti cesagku$month : “ Harvest , ”
+mu enmahgalana en nanna bahun$year : “ Enmaḫgalana , the high-priestess of Nanna , was hired ; ”
+NUMB udu$NUMB small cattle .
+NUMB idgur i$NUMB idgur oil ,
+u NUMBkam$ordNUMB day ;
+cukubum agausgal$Sukubum , grand-soldier ,
+cuku dabde gena$the fisheries workers to seize gone ,
+iti ceila$month : “ Barley carried . ”
+NUMB gu$NUMB oxen ,
+NUMB udu$NUMB sheep ,
+NUMB macgal$NUMB billy goats , full grown ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+zubaga$Zubaga
+idab$accepted ;
+iti ubigu$month : “ Ubi-feast , ”
+mu en nanna karzida bahun$year : “ The priest of Nanna of Karzida was installed ; ”
+NUMB$NUMB .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lugalitida$Lugal-itida ,
+dubsar$scribe ,
+dumu urdumuzida$son of Ur-Dumuzida ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+nigka lu cuku daba balakene$Accounts of men accepting rations of the bala’s
+igal$are here ;
+mu cacru bahul$year : “ Šašru was destroyed . ”
+pisanduba$Basket-of-tablets
+dub gida$xxx
+ce gec ea$xxx
+alde$xxx
+igal$xxx
+mu cusuen lugal urimake magurmah enlil ninlilra munedim$xxx
+NUMB eme $NUMB jenny ,
+NUMB macgal adara $NUMB full-grown mountain goat ,
+NUMB acgar adara $NUMB young female mountain goat ,
+bauc u NUMBkam $slaughtered , ordNUMB day ;
+ki ludingirata $from Lu-dingira
+urnigar $did Ur-niĝar
+cu bati $receive ;
+iti ezemninazu $month : “ Festival of Ninazu , ”
+mu usa kimac hurti bahul $year after :  “ Kimaš  Ḫurti were destroyed . ”
+pisanduba$Basket-of-tablets :  
+im etum$documents of the ‘house , ’ 
+X$… 
+atu dumu lugalsaga$of Atu , son of Lugal-saga , 
+igal$are here . 
+bazi$To Bazi
+unadu$say
+NUMB GAN mur tirac$NUMB iku field , to the rear : Tira’aš ,
+gaba aca uludi gecgu$to the breast : the field of Uludi … ,
+akala cukuranim$of Ayakala it is his subsistence field ,
+ima habibgine$may he  confirm it on a tablet .
+X$Ur-… ,
+dubsar$the scribe ,
+dumu X$son of Ur-…
+nanna$For Nanna ,
+dumusag$the first-born son
+enlila$of Enlil ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+en unuga$the lord of Uruk ,
+lugal urima$king of Ur ,
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+etemenigur$the House With a Foundation Clad in Fearsomeness ,
+e kiagani$his beloved temple ,
+munadu$he built
+kibe munagi$and restored for him .
+cusuen$Šū-Sîn ,
+kiag enlila$the beloved of Enlil ,
+lugal enlile$the king whom Enlil
+X udu niga saga us$… grain-fed sheep , second quality ,
+X udu niga NUMBkam us$… grain-fed sheep , ordNUMB quality ,
+X$…
+NUMB udu niga NUMBkam us$NUMB grain-fed sheep , ordNUMB quality ,
+NUMB udu niga NUMBkam us$NUMB grain-fed sheep , ordNUMB quality ,
+NUMB macgal niga NUMBkam us$NUMB grain-fed adult billygoat , ordNUMB quality ,
+enlil$Enlil .
+NUMB ud niga X$NUMB grain-fed nanny goat , … ,
+NUMB X niga saga us$NUMB grain-fed … , fine , ordNUMB quality ,
+NUMB X niga NUMBkam us$NUMB grain-fed … , ordNUMB quality ,
+NUMB udu niga NUMBkam us$NUMB grain-fed sheep , ordNUMB quality ,
+enki$Enki
+X udu niga NUMBkam us$… grain-fed sheep , ordNUMB quality ,
+ninsun$Ninsun .
+NUMB udu niga NUMBkam us$NUMB grain-fed sheep , ordNUMB quality ,
+inanna$Inanna .
+X X X iti$… … …
+u NUMB la NUMB bazal$… the ordNUMB day having passed ,
+ki X$from …
+bazi$booked out .
+iti ezemah$Month : “ Great Festival ”
+mu cusuen lugale simanum muhul$Year : “ Šu-Suen the king destroyed Simanum ”
+cusuen$Šu-Suen ,
+lugal kalga$mighty king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urculpae$Ur-Šulpa'e
+dubsar$the scribe ,
+dumu urhaia$son of Ur-Haya ,
+ARADzu$is your servant .
+NUMB guruc$NUMB dependent workers ,
+u NUMBce$for NUMB days ,
+ma ce sukkalmah gida$barley barge of the sukkalma ? punted ,
+nibruce$to Nippur ,
+giri lutu$via Lu-Utu ;
+iti gurabimumu$month : “ … ” .
+lutu$Lu-Utu ,
+dubsar$scribe ,
+dumu nigbaba$son of Nig-Baba .
+pisanduba$Basket-of-tablets
+gun dea$tax delivered ,
+u enbi tare$and inquiries ,
+igal$are here ;
+mu NUMBkam$NUMB years .
+pisanduba$Basket-of-tablets
+gurum ak daba$xxx
+sipa caganakene$xxx
+girsuta$xxx
+guabace$xxx
+igal$xxx
+mu guza badim$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+kuli$Kuli ,
+X$…-il ,
+X$… ,
+X$… .
+pisanduba$Basket-of-tablets
+e ki sumuna apin$xxx
+cabrane$xxx
+igal$xxx
+mu usa en nanna karzida bahun$xxx
+pisanduba$Basket-of-tablets
+nigkak$accounts of
+ARADmu$ARADmu
+dumu lugalnemur$son of Lugal-nemur ,
+ca girsu$in Girsu ,
+igal$are here ;
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+dub gida$long-tablets of
+lumelam dumu ba$Lu-melam , son of Baya ,
+urigalim dubsar kas$Ur-Igalim , scribe of messengers ,
+u ARADmu dumu lugalnemur$and ARADmu , son of Lugal-nemur ,
+igal$are here ;
+mu en X ki X X en X X X$year : “ … . ”
+NUMB ceba gur$NUMB gur NUMB barig NUMB ban2 , ration barley ,
+kicib adudu$under seal of Adudu ;
+NUMB ceba gur kicib X$NUMB gur NUMB barig , ration barley , under seal of Lu-… ,
+NUMB ceba gur ki carakam$NUMB gur NUMB barig NUMB ban2 ? ration barley with Šara-kam
+NUMB urdumuzida dumu X$NUMB barig , Ur-Dumuzida , son of …
+NUMB sila gur X$NUMB gur NUMB ban2 NUMB sila3 , Luga…
+kisu dugubtemenata$from the threshing floor of Gabtena ;
+iti diri$month : “ Extra , ”
+mu cusuen lugale naruamah mudu$year : “ Šu-Suen , the king , erected the great-stele . ”
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+lu e ulmacituma$the man who the temple of Ulmašītum …
+NUMB udu mu uce$NUMB sheep , in place of ewes ,
+NUMB mac mu acgarce$NUMB billy goats , in place of female kids ,
+ki abasagata$from Abbasaga ,
+urninsaza$Ur-Ninsaza
+idab$received .
+iti cueca$Month : “ šu’ešša , ”
+mu en eridu bahun$year : “ The en-priest of Eridu was installed . ”
+ningal$For Ningal
+ninani$his mistress ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+gepar kugani$her sacred Gipar residence
+munadu$he built for her .
+nurili $Nūr-ilī ,
+dubsar $scribe ,
+dumu urdumuzi $son of Ur-Dumuzi ,
+dubsar $scribe .
+NUMB ud$NUMB jenny ,
+NUMB sila$NUMB lamb ,
+NUMB sila ga$NUMB sucking lamb ,
+bauc u NUMBkam$slaughtered on the ordNUMB day ,
+ki zubagata$from Zubaga
+culgirimu$Šulgi-irimu
+cu bati$received .
+iti macdagu$Month “ gazelle-eating , ”
+mu en nanna karzida bahun$year : “ The priest of Nanna of Karzida was installed . ”
+NUMB udu$NUMB sheep .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urickur$Ur-Iškur ,
+dubsar$scribe ,
+dumu lania$son of Laniya ,
+ARADzu$is your servant .
+NUMB macgal$NUMB billy goats ,
+NUMB sila ga$NUMB suckling lamb ,
+bauc$slaughtered ,
+u NUMBkam$ordNUMB day ;
+ki naluta$from Nalu
+urnigar$Ur-nigar
+cu bati$received ;
+iti ubigu$month : “ ubi feast , ”
+mu guza enlila badim$year : “ The throne of Enlil was fashioned . ”
+pisanduba$Basket-of-tablets
+nigkak$accounts
+cegeci gala$of sesame delivered ,
+ceba erin a$barley rations of the troops , labor ,
+X$…
+igal$are here ;
+mu usa X lugale urbilum muhul$year following : “ …-Suen the king Urbilum destroyed . ”
+NUMB sila dabin gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 semolina ;
+NUMB sila ce gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 barley ;
+ce ura$debt grain .
+NUMB sila ce gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 barley ;
+NUMB sila ziz gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 emmer ;
+NUMB sila gig$NUMB barig NUMB ban2 NUMB sila3 wheat ;
+laia ce ziga$grain credits in the carried over debits ;
+ce ura gibil$new loaned grain ;
+NUMB sila zi gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 flour ;
+NUMB sila ce gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 barley ;
+NUMB ce gur gur$NUMB gur NUMB barig NUMB ban2 harvest barley ;
+NUMB sila gig$NUMB gur NUMB barig NUMB ban2 NUMB sila3 wheat ;
+ce ura ca e cucuma$debt grain in the šušuma household .
+NUMB sila ce gur$NUMB gur NUMB ban2 NUMB sila3 barley ;
+NUMB ziz gur$NUMB gur NUMB ban2 emmer ;
+laia nigkak$deficit of the account ;
+n NUMB sila ce gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 barley ;
+X$… ;
+NUMB X X$NUMB gur …
+sadu X gida$offerings … ;
+NUMB X X$NUMB gur NUMB barig … ;
+NUMB n X X$NUMB gur … ;
+NUMB udu barsuga$NUMB fleece-less sheep ;
+NUMB acgar$NUMB female kids ;
+NUMB mana NUMB gin kusig$NUMB minas NUMB shekels of gold ;
+kicib lugalniglagare$under seal of Lugal-niglagare ;
+dumu urenun$son of Ur-enun .
+NUMB zi gur$NUMB gur NUMB barig NUMB ban2 flour ;
+NUMB ce gur$NUMB gur NUMB barig NUMB ban2 barley ;
+ce ura gibil$new loaned grains .
+NUMB sila zi gur$NUMB barig NUMB ban2 NUMB sila3 flour ;
+NUMB sila ce gur$NUMB gur NUMB barig NUMB ban2 NUMB ? sila3 barley ;
+NUMB zi gur$NUMB gur NUMB barig flour ;
+laia nigkak laia$deficit of the account ;
+ce ziga laia X$grain booked out , deficit …
+sagbi X$its head … ;
+ce X$barley … ;
+ca pisan mu usa bad martu badu$In the basket , year : “ The western wall was erected ; ”
+NUMB zi gur$NUMB gur NUMB barig NUMB ban2 flour ;
+NUMB ce gur gur$NUMB gur NUMB barig harvest barley ;
+NUMB ce ura mac nutuku gur$NUMB gur NUMB barig debt grain , no interest ;
+kicib egalesi$sealed by Egalesi ;
+NUMB zi gur$NUMB gur NUMB barig NUMB ban2 flour ;
+NUMB sila ce gur$NUMB ? gur NUMB barig NUMB ban2 NUMB sila3 barley ;
+laia X nigkak X X$deficit of the account … ;
+NUMB ce gur gur$NUMB gur NUMB barig harvest barley ;
+kicib gududu$under seal of Gududu .
+mu cusuen lugal urimake naruamah enlil ninlilra munedu$Year “ Šu-Suen , king of Ur , erected grand-stele for Enlil and Ninlil . ”
+gabari kicib ekicibaka ura$A copy of sealed documents in the sealed document house …
+pisanduba$Basket-of-tablets
+cenumun$xxx
+ugula kiri e ninmar$xxx
+X$… ,
+X X amanum$… ,
+X ceckala$… Šeškalla ;
+X X ur X$… ,
+X X X$… ,
+X X X$… ,
+NUMB gin cakuge dumu caraga$NUMB shekels for Šakuge , son of Šaraga ;
+NUMB gin urcara dumu ceckala$NUMB shekels for Ur-Šara , son of Šeškalla ;
+NUMB gin en X X$NUMB shekel for En-… son of … ;
+ ziga ca tumal$booked out , in Tummal ,
+X X X$… ,
+X X X$… .
+NUMB udu u$NUMB sheep , grass-fed ,
+enki$for Enki ,
+geckinti gula$big-workshop
+ki amu$with Ayamu
+giri eanaba$via E’e-anaba ;
+kicib lugalitida$under seal Lugal-itida ,
+X X$… ;
+iti ezemana$month : “ Festival of An , ”
+mu en nanna gaec bahun$year : “ The high-priestess of Nanna at Ga’eš was installed . ”
+cusuen$Šu-Suen
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four quarters
+X$… ,
+dubsar$scribe ,
+ARADzu$is your servant .
+carakam$Šara-kam ,
+urgunua$Ur-gu-nu’a ,
+minanene$the two of them ,
+NUMB mana kubabbarce$for NUMB mana silver ,
+gudaga$did Gudaga ,
+amanene$their mother ,
+mancumece$to Manšume
+incidu$release .
+mancume$Manšume ,
+kuba nubgigida$that to the silver he will not return ,
+mu lugalbi inpa$the royal name he invoked ;
+igi lugalebansace$before : Lugale-bansa ,
+igi lugalece$before : Lugal-e ,
+igi dingirsagace$before : Dingir-saga ,
+igi urgepar dumu suturce$before : Ur-gepar , son of Su-tur ,
+igi nigarkidu dumu dagu$before : Nigar-kidu , sone of Dagu ,
+igi lurcagace$before : Lu-uršaga ;
+iti eitiNUMB$month : “ Month-six , ”
+mu enunugalana inanna bahun$year : “ En-unugal-ana of Inanna was installed . ”
+pisanduba$Basket-of-tablets
+etum$xxx
+ce gecea$xxx
+u ma siga$xxx
+cabra sanga$xxx
+igal$xxx
+mu usa e puzuricdagan badu$xxx
+NUMB guruc u NUMBce$NUMB male laborer workdays ,
+kisu agu guba$at the threshing floor of Agu stationed ;
+NUMB guruc u NUMBce$NUMB male laborer workdays ,
+kisu aguta$from the threshing floor of Agu ,
+ce ma siga$barley in the boat loaded ,
+X X X kisurAC$…
+u nce ma bal$… boat unloaded ;
+ugula lugalnesage$foreman : Lugal-nesage ,
+kicib abagina$under seal of Abbagina ;
+mu huhunuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+lucara$Lu-Šara ,
+dubsar$scribe ,
+dumu ursaga$son of Ur-saga .
+pisanduba$Basket-of-tablets
+nig zizi$things for credits ,
+bala NUMBkam$ordNUMB bala ,
+idub$silos ,
+mu karhar ara NUMBkamac bahul$year : “ Karhar for the ordNUMB time was destroyed , ”
+u$and
+mu dumumunus lugal ensi ancana bantuku$year : “ The princess to the governor of Anšan was married . ”
+pisanduba$Basket-of-tablets
+kicib daba a erinaka$xxx
+urlugalmu$xxx
+iti NUMBkam$xxx
+igal$are here ;
+iti sigicubagarta$xxx
+iti dumuzice$xxx
+mu cusuen lugale mada zabcali muhul$year : “ xxx . ”
+NUMB geme NUMBta$NUMB female workers , NUMB barig NUMB ban2  each
+NUMB geme NUMBta$NUMB female workers , NUMB barig  each
+NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB la NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB la NUMB dumu NUMBta$NUMB children , NUMB ban2  each
+NUMB dumu NUMB silata$NUMB children , NUMB ban2 NUMB sila3  each
+NUMB dumu NUMBta$NUMB children , NUMB ban2  each
+NUMB geme cugi NUMBta$NUMB old female workers , NUMB ban2  each .
+cebi NUMB sila gur$Their barley : NUMB gur NUMB ban2 NUMB sila3
+geme ucbarme$They are female weavers .
+NUMB guruc NUMBta$NUMB male workers , NUMB barig  each
+NUMB guruc NUMBta$NUMB male workers , NUMB ban2  each
+NUMB guruc NUMBta$NUMB male workers , NUMB ban2  each
+cebi NUMB gur$Their barley : NUMB gur NUMB barig
+ugIL eucbarme$They are ug3-IL2 of the house of the weavers .
+ceba itida$Monthly barley rations .
+NUMB guruc NUMB gurta$NUMB male workers , NUMB gur each
+NUMB guruc NUMBta$NUMB male workers , NUMB gur NUMB barig each
+NUMB guruc NUMB gur$NUMB male worker , NUMB gur
+NUMB lu gu NUMBta$NUMB flax workers , NUMB gur NUMB barig each
+NUMB tugdu NUMB gur$NUMB braider , NUMB gur NUMB barig
+cebi NUMB gur$Their barley : NUMB gur .
+nudabme$They are not  holders .
+ceba zamuka$Annual barley rations
+ca girsu$at Girsu .
+NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB dumu NUMB$NUMB child , NUMB ban2
+NUMB dumu NUMB silata$NUMB children , NUMB ban2 NUMB sila3  each
+NUMB dumu NUMBta$NUMB children , NUMB ban2  each
+cebi NUMB gur$Their barley : NUMB gur NUMB barig NUMB ban2
+ca uru$at Uru .
+NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB dumu NUMBta$NUMB children , NUMB ban2  each
+NUMB dumu NUMB silata$NUMB children , NUMB ban2 NUMB sila3  each
+NUMB dumu NUMBta$NUMB children , NUMB ban2  each
+NUMB geme cugi NUMBta$NUMB old female workers , NUMB ban2  each
+cebi NUMB gur$Their barley : NUMB gur NUMB barig NUMB ban2
+geme ucbarme$They are female weavers .
+cebi n NUMB gur$Their barley : NUMB gur NUMB barig
+idu eucbarme$They are porters of the house of the weavers .
+ca lagac$at Lagaš .
+NUMB geme NUMB$NUMB female worker , NUMB barig NUMB ban2
+NUMB geme NUMBta$NUMB female workers , NUMB barig  each
+NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB dumu NUMBta$NUMB children , NUMB ban2  each
+NUMB dumu NUMB silata$NUMB children , NUMB ban2 NUMB sila3  each
+NUMB dumu NUMBta$NUMB children , NUMB ban2  each
+NUMB geme cugi NUMBta$NUMB old female workers , NUMB ban2  each
+cebi NUMB sila gur$Their barley : NUMB gur NUMB barig NUMB ban2 NUMB sila3
+geme ucbarme$They are female weavers .
+NUMB guruc NUMBta$NUMB male workers , NUMB barig  each
+NUMB guruc NUMB$NUMB male worker , NUMB ban2
+NUMB guruc NUMB$NUMB male worker , NUMB ban2
+NUMB dumu NUMB$NUMB child , NUMB ban2
+NUMB dumu NUMB silata$NUMB children , NUMB ban2 NUMB sila3  each
+NUMB dumu NUMB$NUMB child , NUMB ban2
+cebi n gur$Their barley : NUMB gur
+girisega eucbarme$They are personnel of the house of the weavers
+NUMB lu azlag X$NUMB fullers …
+cebi n gur$Their barley : NUMB gur .
+ceba zamukam$Annual barley rations .
+ca kinunir$at Kinunir
+NUMB geme NUMB$NUMB female worker , NUMB barig NUMB ban2
+NUMB geme NUMBta$NUMB female workers , NUMB barig  each
+NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB geme NUMBta$NUMB female workers , NUMB ban2  each
+NUMB la NUMB guruc NUMBta$NUMB male workers , NUMB ban2  each
+NUMB dumu NUMBta$NUMB children , NUMB ban2  each
+NUMB dumu NUMB silata$NUMB children , NUMB ban2 NUMB sila3  each
+NUMB la NUMB dumu NUMBta$NUMB children , NUMB ban2  each
+NUMB geme cugi NUMBta$NUMB old female workers , NUMB ban2  each
+cebi NUMB n NUMB gur$Their barley : 420+n+1 gur NUMB barig
+geme ucbarme$They are female weavers
+NUMB guruc NUMBta$NUMB male workers , NUMB barig  each
+NUMB guruc NUMBta$NUMB male workers , NUMB ban2  each
+NUMB guruc NUMBta$NUMB male workers , NUMB ban2  each
+ca guaba$at Gu-abba .
+cunigin NUMB geme NUMBta$Total : NUMB female workers , NUMB barig NUMB ban2  each
+cunigin NUMB la NUMB geme NUMBta$Total : NUMB female workers , NUMB barig  each
+cunigin NUMB la NUMB geme NUMBta$Total : NUMB female workers , NUMB ban2  each
+cunigin NUMB geme NUMBta$Total : NUMB female workers , NUMB ban2  each
+cunigin NUMB guruc NUMBta$Total : NUMB male workers , NUMB ban2  each
+cunigin NUMB geme NUMBta$Total : NUMB female workers , NUMB ban2  each
+cunigin NUMB guruc NUMBta$Total : NUMB male workers , NUMB ban2  each
+cunigin NUMB dumu NUMBta$Total : NUMB children , NUMB ban2  each
+cunigin NUMB dumu NUMB silata$Total : NUMB children , NUMB ban2 NUMB sila3  each
+cunigin NUMB dumu NUMBta$Total : NUMB children , NUMB ban2  each
+cunigin NUMB la NUMB geme  cugi NUMBta$Total : NUMB old female workers , NUMB ban2  each
+cunigin NUMB la NUMB guruc NUMBta$Total : NUMB male workers , NUMB barig  each
+cunigin NUMB guruc NUMBta$Total : NUMB male workers , NUMB ban2  each
+cunigin NUMB guruc NUMBta$Total : NUMB male workers , NUMB ban2  each
+cunigin NUMB la NUMB guruc NUMBta$Total : NUMB male workers , NUMB ban2  each
+cunigin NUMB dumu NUMBta$Total : NUMB children , NUMB ban2  each
+cunigin NUMB dumu NUMB silata$Total : NUMB children , NUMB ban2 NUMB sila3  each
+cunigin NUMB dumu NUMBta$Total : NUMB children , NUMB ban2  each
+cebi NUMB gur$Their barley : NUMB gur NUMB barig NUMB ban2
+girisega eucbarme$They are personnel of the house of the weavers .
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+ceba itida$Monthly barley rations .
+cunigin NUMB guruc NUMBta$Total : NUMB male workers , NUMB  each
+cunigin NUMB guruc NUMBta$Total : NUMB male workers , NUMB  NUMB barig each
+cunigin NUMB guruc NUMB$Total : NUMB male worker , NUMB  NUMB barig
+X idu X$x porters …
+lu azlag nudabme$fullers , they are not  holders
+NUMB gur X$NUMB gur …
+ceba zamuka$Annual barley rations .
+ceba niginba$Final account of barley rations ,
+geme ucbar lu azlag u girisega eucbar$female weavers , fullers and personnel of the house of the weavers ,
+girsuta$from Girsu
+guabace$to Gu-abba .
+mu harci hurti bahul$Year : “ Ḫarši and Hurti were destroyed . ”
+pisanduba$Basket-of-tablets
+mu didli ce erine cu tia$xxx
+ce gu udu gua$xxx
+ca dugana gargara$xxx
+mu en enki eridu bahun$xxx
+u ce gu udu gua$xxx
+mu madarabzu enkika babdu$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+sadu cara u kurucda didli$xxx
+igal$xxx
+mu usa simurum lulubum ara NUMB la NUMBkam bahul$xxx
+X$…
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur ,
+pisanduba$Basket-of-tablets
+luningirsu dumu bazi$xxx
+pisanduba$Basket-of-tablets
+kicib daba X$sealed documents of dab , Daga… ,
+X dumu abani u lugalkuzu nubanda$…kuge , son of Ayabbani , and Lugal-kuzu , manager ,
+kicib zire u kicibkicibce tum urculpae$sealed documents to be canceled , and to … carried , Ur-Šulpa’e ,
+kicibkicibce tum damgarne$… to be carried , the trade agents ,
+kicib tug cara kara ensika$sealed documents , garments of Šara , the harbor of the governor ,
+kicib tug kuc X inanna bizaka a X X$sealed documents , garments , leather , … Inanna … ,
+kicib X caduba u urnungal$sealed documents of Ur-… , the chief accountant , and of Ur-Nungal ,
+X X X apisal mucbiana$… Apisal , Mušbiana ;
+mu cusuen lugal X$year : “ Šū-Suen is king . ”
+pisanduba$Basket-of-tablets
+gurumak$inspections of
+sipa unu$shepherds and cowherds
+kinunir$in Kinunir ,
+nigin$Nigin ,
+guaba$and Guabba ;
+sipa cagan$of herders of equids
+sipa unu culgi$shepherds and cowherds of Šulgi ,
+u sagapin e ninhursag$and head-plowmen of the house of Ninḫursag ,
+igal$are here ;
+mu harci bahul$year : “ Ḫarsi was destroyed . ”
+NUMB guruc  u NUMBce$NUMB male laborer for NUMB days ,
+nibruce$to Nippur
+i ga e ucur X$butter oil and cheese … ;
+NUMB guruc  u NUMBce$NUMB male laborers for NUMB days ,
+nibruce$to Nippur
+inbulbul ila$…-straw carried ;
+ugula X$foreman : …-gala ;
+kicib lukala$under seal of Lukalla ;
+mu cusuen lugal$year : “ Šu-Suen is king . ”
+lukala$Lukalla ,
+dubsar$scribe ,
+dumu ure$son of Ur-E’e .
+pisanduba$Basket-of-tablets
+etum$xxx
+sagnigura$xxx
+u ziga$xxx
+urnanna$xxx
+iti cesagkuta$xxx
+iti ezemcusuence$xxx
+iti NUMBkam$xxx
+mu cusuen lugal urimake bad martu muriqtidnim mudu$xxx
+pisanduba$Basket-of-tablets
+gurumak$inspections of
+e guzala$the house of the chairholder ,
+e damgar$the house of the exchange agents ,
+nabasa NUMB$Nabasa … ,
+e kurucda$the house of the fatteners ,
+e lugaligi$the house of Lugal-igi ,
+u e urutu$and the house of Ur-Utu ,
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+ce GANgu$barley of the oxen-fields ,
+ce apinla$barley of the ploughs ,
+gurua muku$into the silo delivered ,
+idub$threshing center ,
+gurubice$for its silo ,
+da gal umma$… of Umma
+guedina mucbiana u apisala$Gu’edina , Mušbi’ana and Apisal ,
+ce geceabi$its threshed barley ,
+igal$are here .
+iti cunumun$month “ Sowing , ”
+mu guza ku enlila badim$year : “ The silver chair of Enlil was fashioned . ”
+enlil$For Enlil ,
+lugal kurkura$the king of all the lands ,
+lugalanir$his master ,
+amarsuen$Amar-Suena ,
+nibrua$whom in Nippur
+enlile$Enlil
+mu pada$nominated ,
+sagus$the constant supporter
+e enlilka$of the temple of Enlil ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+uc ku$the sacred foundation
+enlila$of Enlil ,
+ki ca hula$the place which makes the heart rejoice
+amarsuenkaka$of Amar-Suena ,
+munangub$he set up for him .
+NUMB udu niga$NUMB sheep , barley-fed ,
+sadu enkiura$offering of “ Suen of the roof , ”
+giri dudanum$via Dudanum ,
+ki lugalitida$from Lugal-itida ;
+iti ezemana$month : “ Festival of An , ”
+mu en nanna karzida bahun$“ The en-priestess of Nanna in Karzida was hired . ”
+amarsuen$Amar-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four quarters
+lugalitida$Lugal-iti-da ,
+dubsar$scribe ,
+dumu urdumuzida$son of Ur-Dumuzida ,
+ARADzu$your servant .
+NUMB X$NUMB … ,
+NUMB mac cugid$NUMB goat , šugid ,
+NUMB sila ga$NUMB suckling lamb ,
+bauc u NUMBkam$slaughtered , the ordNUMB day ,
+ki naluta$from Nalu
+urnigar$Ur-nigar
+cu bati$received ;
+iti ubigu$month : “ Ubi feast , ”
+mu simurum ara NUMB la NUMBkam bahul$year : “ Simurum for the ordNUMB time was destroyed . ”
+NUMB sila ce gur$NUMB gur NUMB ban2 NUMB sila3 barley ,
+cuku kuku$prebend of Kuku ;
+NUMB sila gur$NUMB gur NUMB ban2 NUMB sila3 ,
+cuku erabani$prebend of Era-bani ;
+NUMB sila gur$NUMB gur NUMB ban2 NUMB sila3 ,
+cuku adalal$prebend of Adalal ;
+NUMB sila gur$NUMB gur NUMB ban2 NUMB sila3 barley ,
+cuku urdumuzi$prebend of Ur-Dumuzi ;
+NUMB sila$NUMB gur NUMB barig NUMB sila3 barley ,
+cuku dingirbani$prebend of Ilī-bani ;
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 barley ,
+ce nudabme$of those not receiving barley ,
+culisi cu bati$did Šū-Lisi receive ;
+aca X$field SIG…gi ;
+mu ibisuen lugal urimake simurum muhul$year : “ Ibbi-Sîn , king of Ur , Simurum did destroy . ”
+culisi$Šū-Lisi ,
+dumu lammakal$son of … ,
+ragaba X$rider , … .
+NUMB gin geme u NUMBce$NUMB . NUMB female laborer days ,
+iti NUMBce$for NUMB months ,
+iti cesagkuta$from month “ Harvest ”
+iti dumuzice$to month “ Dumuzi , ”
+abi u NUMB$its labor : NUMB days ;
+NUMB geme u NUMBce abi u NUMB$NUMB female laborers for NUMB days , its labor : NUMB days
+geme barakara$female bara-kara-workers .
+NUMB geme u NUMBce abi u NUMB$NUMB female laborers for NUMB days , its labor : NUMB . NUMB days ,
+ki akalata$from Akalla ;
+NUMB geme u NUMBce$NUMB female laborer days
+ki urnumucdata$from Ur-Numušda .
+NUMB geme u NUMBce$NUMB female laborer days
+ki nabasata$from Nabasa .
+cunigin NUMB geme u NUMBce$Total : NUMB , NUMB . NUMB female laborer days
+sagnigurakam$are the debit .
+cabita$Therefrom
+NUMB zi sig gur$NUMB gur NUMB ban2 NUMB  rough flour ,
+NUMB sila eca$NUMB ban2 NUMB sila3 of eša ,
+NUMB zigu$NUMB gur NUMB ban2 of pea-flour ,
+NUMB sila zi baba ce X$NUMB ban2 NUMB sila3 of baba-flour ,
+NUMB sila zigu X gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 of x pea-flour flour ,
+NUMB sila dabin gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 of semolina ,
+NUMB sila nigara$NUMB barig NUMB ban2 NUMB sila3 of groats ,
+abi u NUMB$its labor : NUMB workdays
+nigka ceta$from the barley account ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+a zi ara sadu ensi$labor of flour-milling , rations for the governor ;
+NUMB geme u NUMBce kacdea sukkalmah$NUMB female laborer days , “ beer-pouring ” of the sukkalmaḫ ;
+NUMB geme u NUMBce kunzida dublautuka$NUMB female laborer days , at the weir of Dubla-Utu ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+a tug tukua$labor of weaving ;
+kicib NUMB gududu$NUMB sealed documents of Gududu .
+NUMB geme u NUMBce a zi ara ca nagabtum$NUMB female laborer days , labor of flour-milling , of the Nagabtum ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+ummata nagsuce dug cugan i egalce tuma gaga$from Umma to Nagsu šugan-pots of oil brought  and carried to the palace .
+NUMB$NUMB
+NUMB geme u NUMBce$NUMB female laborer days ,
+kisu karbara dugubtemenata ummace X$from threshing floor of outer quay Dugub-temen to Umma … .
+NUMB geme u NUMBce ummata X X X X ninda gaga$NUMB female laborer days , from Umma … bread carried ,
+X ninura$… Ninurra ;
+X guba$at … stationed ;
+X$… ; .
+n geme u NUMBce$NUMB female laborer days ,
+X ara$… ground ;
+X X X$… x ;
+X riga$… ,
+X enlila X$… for Enlil ;
+X$… ,
+X$from …
+X$…
+X$…
+X X X bariga$… ,
+X kamari$… Kamari ;
+X$…-ili ,
+X luculgira$Lu-Šulgira .
+NUMB geme u NUMBce$NUMB female laborer days ,
+NUMB$NUMB ;
+zar taba aca abagalenlilce$shocks gathered , the field Abagal-Enlil ;
+kicib X urnungal X$sealed documents … of Ur-Nungal x .
+geme u NUMBce aca carata emace gizi gaga$NUMB female laborer days , from field Šara to Emaš fodder-reed carried .
+kicib ada$sealed document of Adda .
+NUMB geme u nce X$NUMB female laborers for a period of NUMB days ,
+abi u n$its labor : 21×n days ;
+balace gena bala guba u$to the bala gone , stationed at the bala , and
+balata gura$from the bala returned ;
+cunigin NUMB X$total : NUMB …
+zigam$booked out ;
+laia n$the deficit : NUMB ;
+X$…
+nigkak X$account of … .
+iti dumuzi$month of …
+mu usa cusuen lugal$Year after : “ Šū-Suen is king . ”
+pisanduba$Basket-of-tablets
+edula ensika$estate of the governor
+u dumunene$and their children ,
+igal$are here ;
+mu guza enlila badim$year : “ The chair of Enlil was fashioned . ”
+n sa gi$NUMB reed bundles ,
+tium sa$… bundles ,
+kisu ece$for the threshing floor by the levee ,
+ki ceckalata$from Šeškalla ,
+kicib dingira$udner seal of Dingira ;
+iti cesagku$month : “ Harvest , ”
+mu enunugalana bahun$year : “ Enunugalana was hired . ”
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+NUMB kuc$NUMB cubits ;
+kuc izita$cubits per wall ;
+NUMB ninda NUMB kuc$NUMB ninda NUMB cubits ;
+NUMB ninda NUMB kuc$NUMB ninda NUMB cubit ;
+NUMB ce gur lugal$NUMB gur NUMB barig barley , royal ,
+cagal uduce$fodder of sheep x ,
+ki lunaruata$from Lu-Narua ,
+kicib cakuge$under seal of Šage ,
+e kikkenta$from the mill ;
+iti amarasi$month : “ Amar-ayasi . ”
+caninga$Ša-ninga ,
+dubsar$scribe ,
+dumu lugalucur$son of Lugal-ušur .
+pisanduba$Basket-of-tablets
+nigkak$xxx
+a cuku aba$xxx
+ugulane$xxx
+u ziga baBADbi$xxx
+mu urbilum bahulta$xxx
+mu huhunuri bahulce$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+dub gida$xxx
+ce madga$xxx
+giri urigalim$xxx
+bumu$xxx
+u nabasa$xxx
+igal$xxx
+mu kimac bahul$xxx
+lugal kalga$the mighty king ,
+lugal urima$king of Ur ,
+lugalinimgina$Lugal-inim-gina ,
+dumu urutu$son of Ur-Utu ,
+ARADdane$his servant ,
+a munaru$dedicated  to him .
+pisanduba$Basket-of-tablets
+gurumak$inspections ;
+girisega lugal$personnel of the king ,
+girisega ensika$personnel of the ensis ,
+sipa unu$shepherds , cattle herdsmen
+u erin diri lu didli zah ugula nutuku$and extra worktroops , various men , flown , lacking foremen ,
+igal$are here ;
+mu simurum lulubu ara nkamac bahul$year : “ Simurum and Lullubu for the nth time were destoyed . ”
+pisanduba$Basket-of-tablets
+gurum ak daba$xxx
+e gatumdu$xxx
+e bagara$xxx
+e uru$xxx
+e inanna$xxx
+e ninsun$xxx
+igal$xxx
+mu huhunuri bahul$xxx
+X X X$…
+abi u X$its labor : NUMB days ;
+NUMB GAN tugur X X gecura ara NUMB GANta$NUMB iku of tug-sag work … ,
+abi u NUMBkam$its labor : NUMB days ;
+NUMB GAN gecura ara NUMB GANta$NUMB bur3 of harrowing , NUMB times , at NUMB eše3 field area ,
+a erinabi u NUMB$the troops’ labor : NUMB days ;
+NUMB GAN gecura ara NUMB GANta GANta$NUMB bur3 of harrowing , NUMB times , at NUMB eše3 field area ,
+a erinabi u NUMB$the troops’ labor : NUMB days ;
+NUMB GAN gecura ara NUMB GANta$NUMB bur3 , NUMB eše3 NUMB iku of harrowing , NUMB times , at NUMB eše3 field area ,
+a erinabi u NUMB$the troops’ labor : NUMB days ;
+a gecura$labor of harrowing ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar nigul NUMB sarta$NUMB sar of pickaxing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar nigul NUMB sarta$NUMB sar of pickaxing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar nigul NUMB sarta$NUMB sar of pickaxing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+X NUMB guruc u nce$NUMB ? workers for … days ,
+lag absinta ririga$cleaning the furrows of clumps of earth and debris ;
+gurumak urgigir ugula acgab$inspection of Ur-gigir , the supervisor of leatherworkers .
+ugula urgigir nubandagu$The foreman  Ur-gigir , the oxen overseer ;
+kicib ceckala X$under seal of Šeškalla … ;
+aca kamari$Kamari field ;
+mu cacuru bahul$Year : “ Šaššuru was destroyed . ”
+lugalniglagare$Lugal-nig-lagar-e ,
+dubsar$scribe ,
+dumu dada$son of Dada ,
+inanna$To Inanna
+ninanir$his/her mistress ,
+namti$for the life of
+pisanduba$Basket-of-tablets
+sagnigura$debits ,
+cabi suga$therefroms , restitutions ,
+kas cuc$of Kas , the cattle administrator ,
+igal$are here .
+puzursuen$Puzur-Sîn ,
+engar daramuri$farmer of Tarām-Uram
+pisanduba$Basket-of-tablets
+niginba sikiba$grand totals , wool rations ,
+girsuta$from Girsu
+guabace$to Guabba ,
+igal$are here ;
+mu guza enlila badim$year : “ The chair of Enlil was fashioned . ”
+NUMB kicib abakala$NUMB  NUMB barig NUMB ban2 under seal of Abbakala ,
+nubanda urninbara$superintendent : Ur-ninbara ,
+NUMB kicib urnigar$NUMB  NUMB barig Ur-nigar ,
+nubanda dada$superintendent : Dada ,
+NUMB kicib cangu$NUMB  NUMB barig under seal of Šangu ,
+iti ceila$month “ Barley carried , ”
+lu gecime$sesame oil workers ;
+NUMB dubsar NUMBta$NUMB scribe , each with NUMB barig ,
+NUMB aigidu NUMBta$NUMB water inspector , each with NUMB barig ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+iti NUMBkam$of the ordNUMB month ,
+iti ezemculgita$from month “ Festival of Šulgi , ”
+iti ceilace$to month “ Barley carried , ”
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+iti NUMBkam$of the ordNUMB month ,
+dubsar aigidu gecgime$are scribes of water inspectors , wood and reed ;
+NUMB kicib urlugal$NUMB  NUMB barig Ur-lugal
+NUMB kicib lunance$NUMB barig under seal of Lu-Nanše ,
+cukume$are fishermen ;
+NUMB dubsar didlime$NUMB  NUMB barig NUMB ban2 , various scribes ,
+kicib lucgina$under seal of Lu-ušgina ,
+NUMB kiciburningeczida$NUMB barig Ur-Ningešzida ,
+NUMB kicib lugudea$NUMB barig Lu-Gudea ,
+giri urnungal$via Ur-Nungal ,
+dubsarme$are scribes ;
+X X$from … ;
+X X ceba hedab$… , barley rations  the captives ,
+iti X$from month . . ;
+iti X$to month . . ;
+cebi X X gur$its barley : … gur x ,
+iti X$of the nth month ,
+X X$. . ;
+mu urlamma dumu urnigce$in place of Ur-Lamma , son of Ur-nig ,
+kicib namzitara$under seal of Namzitara ,
+idub ambarsurata$from the depot ambar-sur-ra ,
+giri urnungal dumu ensi$via Ur-Nungal , son  the governor ;
+NUMB kicib urnungal$NUMB  under seal of Ur-Nungal ,
+idub kabdugagirnuntata$from the depot Kabduga-girnun ;
+NUMB gur$NUMB gur NUMB barig
+kicib luningirsu dumu urnance$under seal of Lu-Ningirsu , son  Ur-Nanše ,
+NUMB gur$NUMB gur NUMB barig ,
+ceba gabus udugukkal$barley rations  the fat-tailed sheep ,
+kicib luesukudra lu dugazida$under seal of Lu-esukudra , the man  Dugazida ,
+idub suganta$from the depot Sugan ,
+giri bazi$via Bazi ;
+NUMB sila gur$NUMB gur NUMB ban2 NUMB sila3
+kicib lunincubur$under seal of Lu-Ninšubur ? ,
+NUMB kicib urnintu$NUMB  ur-Nintu ? ,
+NUMB kicib lugaldam$NUMB  Lugal-dam ,
+NUMB gur$NUMB gur
+kicib ludingira$under seal of Lu-dingira
+u urgigir$and Ur-gigir ,
+NUMB gur$NUMB gur NUMB barig
+kicib urnance$under seal of Ur-Nanše ,
+NUMB cagal erin$NUMB  NUMB barig NUMB ban2 , food of the work-troops ,
+NUMB cenumun aca erin$seed for the fields of the work-troops ,
+kicibi NUMBam$its sealed tablets : NUMB ,
+kicib kuda nubanda$under seal of Kuda , the superintendent ,
+NUMB cagal erin$NUMB  NUMB barig , food of the work-troops ,
+NUMB cenumun aca erin$seed for the fields of the work-troops ,
+kicibi NUMBam$its sealed tablets : NUMB ,
+kicib lugalinimgina$under seal of Lugal-inimgina ,
+X tu$. . ;
+X tu$. . ;
+X X$. . ;
+giri luduga$via Luduga ,
+n NUMB gur$… NUMB gur NUMB barig
+kicib atu nubanda$under seal of Atu , the superintendent ,
+erin bala tuca$work-troops sitting out the corvée duty ;
+NUMB gur$NUMB gur NUMB ban2 ,
+kicibi NUMBam$its sealed tablets : NUMB ,
+kicib kuda nubanda$under seal of Kuda , the superintendent ,
+erin ce nutukume$work-troops , barley not receiving ;
+e ninmar$house of Ninmar ,
+iti ezemdumuzi$month “ Festival of Dumuzi , ”
+giri lugalsiskure$via Lugal-siskure
+u urebabbar$and Ur-Ebabbar ;
+NUMB gur$NUMB gur
+kicib urnance$under seal of Ur-Nanše ,
+giri bazi$via Bazi ,
+idub bimunurata$from the depot bi-munu-ra ;
+NUMB ceba hedab$NUMB gur NUMB barig , barley rations of the captives ,
+kicib sukkaldide$under seal of Sukkal-dide ,
+giri urnungal$via Ur-Nungal ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib luningirsu$under seal of Lu-Ningirsu ,
+idub edurunanceta$from the depot e2-duru5-Nanše ;
+NUMB kicib luningirsu$NUMB  Lu-Ningirsu ,
+giri bazi$via Bazi ,
+NUMB gur$NUMB gur NUMB barig
+kicib urnance$under seal of Ur-Nanše ,
+giri urnungal$via Ur-Nungal ,
+idub agulta$from the depot Agul ;
+NUMB n gur$NUMB … gur
+kicib uracnan$under seal of Ur-Ašnan
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib luningirsu$under seal of Lu-Ningirsu ,
+idub inimadingirta$from the depot Inima-dingir ;
+NUMB gur$NUMB gur NUMB ban2
+kicib didli$various sealed tablets ,
+NUMB gur$NUMB gur NUMB barig
+kicib atu nubanda$under seal of Atu , the superintendent ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib kuda nubanda$under seal of Kuda , the superintendent ,
+e ninmar$house of Ninmar ;
+NUMB gur ce ura citim$NUMB gur barley , interest-bearing , the builder ,
+kicib ureana$under seal of Ur-Eanna ,
+apin citim acagibil$plough ?  of New Field ,
+X gur$… gur … ,
+X X$. . ;
+ance apin$donkeys of the plough ,
+ki luba dumu amuta$from Lu-ba , son  Amu ;
+NUMB gur$NUMB gur
+lutu sipa$Lu-Utu , the shepherd ,
+NUMB ceba nimgirinimgina ugIL$NUMB , barley rations of Nimgir-inimgina , the porter ,
+NUMB gur$NUMB barig
+kicib urnungal dumu ensi$under seal of Ur-Nungal , son  the governor ,
+ki ceckala dumu pululuta$from Šeškala , son  Pululu ;
+NUMB gur$NUMB gur
+lugalsiskure$Lugal-siskure
+ki urgula dumu ganita$from Urgula , son  Gani ;
+NUMB gur$NUMB gur NUMB ? barig NUMB ban2
+ki abamu dumu badata$from Abbamu , son  Badda ;
+NUMB gur$NUMB gur
+ki lunamtarata$from Lu-namtara ;
+NUMB ceckala$NUMB  Šeškala ,
+dumu urbaba$son  Ur-Baba ,
+NUMB urningeczida$NUMB barig Ur-Ningešzida ,
+NUMB urala$NUMB barig Ur-Alla ,
+NUMB lugalgirizal$NUMB barig Lugal-girizal ,
+NUMB lubalasaga$NUMB barig Lu-balašaga ,
+NUMB lugalmelam$NUMB barig Lugal-melam ,
+NUMB lugudea$NUMB barig Lu-Gudea ,
+NUMB lugalanatum$NUMB barig Lugal-annatum ,
+NUMB luningirsu$NUMB barig Lu-Ningirsu ,
+NUMB urnance$NUMB barig NUMB ban2 Ur-Nanše ,
+NUMB ursaga dumu urgigir$NUMB barig Ur-gigir ,
+NUMB ursaga dumu bahar$NUMB barig Ur-saga son of Baḫar ,
+NUMB lueb$NUMB barig Lu-eb ,
+NUMB lunincubur$NUMB barig Lu-Ninšubur ,
+NUMB lugalcala dumu ludingira$NUMB barig Lugal-šala son of Lu-dingira
+NUMB ezimu$NUMB barig Ezimu ,
+dubsar gecgime$are scribes of the wood & reed ,
+idub edurualatumta$from the depot Eduru-Al-la-tum ;
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3
+kicib kuda nubanda$under seal of Kuda , the superintendent ,
+kicib X X$under seal of … ,
+iti X X X$month … ,
+NUMB gur$NUMB gur ,
+ceba ugIL$barley rations of the porter ,
+kicib bazige$under seal of Bazige ,
+ki lubimuta$from Lu-bimu ;
+NUMB cagal erina$NUMB gur , food of the work-troops ,
+NUMB cenumun aca erin$NUMB gur seed , field of the work-troops ,
+kicib bazige dumu ka$under seal of Bazige , son  Ka’a ,
+mu atu dumu lalace$in place of Atu , son  Lala ,
+iti X$month … ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2 ,
+ceba geme ucbar$barley rations ,
+kicib uracnan ugula$under seal of Ur-Ašnan ? , the foreman ? ,
+NUMB gur$NUMB gur
+kicib lunincubur munumu$under seal of Lu-Ninsun , the malster ,
+ki urnance dumu nabasata$from Ur-Nanše , son  Nabasa ;
+NUMB gur$NUMB gur
+idub aca ninamahta$from the depot of the field Nin-nammaḫ ;
+NUMB gur$NUMB gur NUMB barig
+idub aca ninigerimeta$from the depot of the field Nin-nigerime ;
+NUMB e ninmargugalta$NUMB gur , the house Ninmar-gugal ;
+NUMB gur$NUMB gur NUMB barig ,
+ceba gabus udugukkal$barley rations  the fat-tailed sheep ,
+kicib gudea dumu luenlila$under seal of Gudea , son  Lu-Enlila ,
+NUMB gur$NUMB gur NUMB barig ,
+ce ninda ura lu marsa$barley bread , interest-bearing ,  the shipyard people ,
+kicib magure$under seal of Magure ,
+cec guzana$the brother  Guzana ,
+ki manita$from Mani ;
+NUMB gur$NUMB gur ,
+ce urua$barley  Urua ,
+giri dadi guzala$via Dādī , the chair-bearer ;
+NUMB gur$NUMB gur
+ki urlamma X X X$from Ur-Lamma , … ;
+ceba X$. barley rations ?  . . ;
+ceba X$… ,
+mu usa simurum lulubu bahul$year after : “ Simurum and Lulubu were destroyed ; ”
+banazi$was booked out  for him ,
+labakura$;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib atu nubanda$under seal of Atu , the superintendent ,
+NUMB gur$NUMB gur
+mu atuce$in place of Atu ,
+kicib ureninnu dumu dudu$under seal of Ur-Eninnu , son of Dudu ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib kuda nubanda$under seal of Kuda , the superintendent ,
+ce erina$barley of the work-troops ,
+iti ezembaba$month “ Festival of Baba , ”
+ki urbagara kurucdata$from Ur-bagara , the animal fattener ;
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3
+gurua taka$in the granary left behind ,
+giri urnance$via Ur-Nanše ;
+cunigin NUMB guru NUMB sila gur$total : NUMB , NUMB gur NUMB ban2 NUMB sila3 ,
+sagnigurkam$it is debit ;
+cabita$therefrom
+X$house of … ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+gabra abme$the cowherdsman’s helpers ;
+NUMB gabra gu nagabtume$NUMB barig oxenherdsman’s helpers , nagabtum ;
+NUMB sila gur$NUMB gur NUMB sila3 ,
+ceba girisega gecgi$barley rations  wood & reed ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2 ,
+cuku gigid u cuku sukkalmah$the spear fishermen and fishermen of the sukkalmaḫ ;
+NUMB magin adkup cuku aba$NUMB barig NUMB ban2 , boat-builders , matters , sea fishermen ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+cuku arua marsa$;
+NUMB gur$NUMB gur NUMB ban2
+hedab tukule daba$seized by the weapons ;
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3
+geme kikken tukuledabame$the female millers seized by the weapons ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+amarku dumu ucbarme$the castrated children of the weavers ;
+NUMB n NUMB sila gur$NUMB … NUMB gur NUMB barig NUMB ban2 NUMB sila3
+geme ucbarme$the female weavers ;
+NUMB gur$NUMB gur NUMB ban2
+ludabme$the seized people ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+girisega e ucbar$the textile mill ;
+cunigin NUMB sila gur$total : NUMB gur NUMB ban2 NUMB sila3 ,
+iti NUMBkam$of the ordNUMB month ,
+iti GANmacta$from month “ GANmaš ”
+iti ceilace$to month “ Barley carried , ”
+cebi NUMB guru NUMB gur$its barley : NUMB , NUMB gur NUMB barig
+X X$…
+iti munuguta$from month “ Malt feast , ” ;
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3
+sila daba $seized on the street
+NUMB imetaka$NUMB barig NUMB ban2 ‘left on the tablet’
+iti cesagkuta$from month “ Harvest ” ;
+NUMB dumu egirtuda$NUMB ban2 , ‘born afterwards , ’
+iti ezemculgita$from month “ Festival of Šulgi ” ;
+iti ceilace$to month “ Barley carried , ”
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+iti NUMBkam$of the ordNUMB month ,
+nukiri gecgalgal$gardener big lumber ;
+NUMB dumu egirtuda$NUMB ban2 , ‘born afterwards , ’ ,
+iti ezemculgita$from month “ Festival of Šulgi ”
+iti ceilace$to month “ Barley carried , ”
+cebi NUMB$its barley : NUMB barig ,
+iti NUMBkam$of the ordNUMB month ,
+dumu lu marsa$children  the shipyard workers ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+iti cunumunta$from month “ Sowing ” ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+iti munuguta$from month “ Malt feast ” ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+iti ezemdumuzita$from month “ Festival of Dumuzi ”
+iti ceilace$to month “ Barley carried , ”
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+iti NUMB la NUMBkam$of the ordNUMB month ,
+hedab tukule daba$captive seized by the weapons ;
+X X X X$. . ;
+X X$. . ;
+dumu egirtuda$child
+iti X X$from month . . ;
+iti ceilace$to month “ Barley carried , ”
+cebi X$its barley : … ,
+iti NUMBkam$of the ordNUMB month ;
+NUMB X X X gur$NUMB … gur … ,
+ceba girisega$barley rations ,
+NUMB n gur$NUMB … gur … ,
+ceba gabus udugukkal$barley rations  the fat-tailed sheep ,
+ceba zamuka$barley rations of the new-year ;
+sadu ceba$regular provisions  barley rations ;
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 ,
+nigezema dingirene$festival material of the gods ,
+nigba zamuka$gift of the new-year ;
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3
+ma dua u ucurbar ninmarka$the caulked boat and the outer district of Ninmar ,
+mu NUMBa ara NUMBam$in three years for the first time ;
+NUMB X gur$NUMB … gur . . ;
+X X$. . ;
+X$. . ;
+X X$. . ;
+X X$. . ;
+X X$… ,
+iti X$month “ … , ”
+NUMB X gur$NUMB … gur . . ;
+ca hurim$in Ḫurim ,
+ca dugana$in leather bags ,
+giri kaskene$via the runners ,
+kicib urlamma dumu lubaba$under seal of Ur-Lamma  Lu-Baba ;
+NUMB amar X$NUMB … calves  … ,
+X$its barley : … ,
+iti ezemculgita$from month “ Festival of Šulgi , ”
+iti ceilace$to month “ Barley carried , ”
+cebi NUMB gur$its barley : NUMB gur NUMB barig ,
+iti NUMBkam$of the ordNUMB month ,
+dubsar aigidume$are scribes , water inspectors ,
+giri urnungal dumu ensi$via Ur-Nungal , son  the governor ;
+NUMB ce kac gur$NUMB gur NUMB barig barley for beer ,
+NUMB la NUMB sila gur$NUMB gur NUMB barig NUMB ban2 less NUMB sila3
+nigsiskura acaga$offerings of the fields
+kicib urlamma dumu lubaba$under seal of Ur-Lamma , son  Lu-Baba ;
+NUMB cagal amar gec nuzu$NUMB barig , food of the virgin young cattle ,
+kicib urkigula dumu X$under seal of Ur-kigula , son  Lugal-a2… ;
+NUMB ahua lu kas$NUMB barig NUMB ban2 Aḫua , the runner
+NUMB dumu X X$NUMB ban2 child of … ,
+giri X$via Ur-… ;
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 ,
+nig erine gua$material used by the work-troops ,
+giri X$via . . ;
+NUMB X gur$NUMB … gur … ;
+X X$… ;
+erin balatuca$the work-troops sitting out the corvée duty
+kicib atu nubanda$under seal of Atu , the superintendent ,
+NUMB erin balaguba$NUMB gur NUMB ban2 the work-troops performing the corvée duty ,
+kicibi NUMBam$its sealed tablets : NUMB ,
+kicib kuda nubanda$under seal of Kuda , the superintendent ,
+iti ezemdumuzi$month “ Festival of Dumuzi , ”
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+giri urebabbar$via Ur-Ebabbar
+u lugalsiskure$and Lugal-siskure ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib atu nubanda$under seal of Atu , the superintendent ,
+NUMB mu atuce$NUMB gur , in place of Atu ,
+kicib ureninnu dumu dudu$under seal of Ur-Eninnu , son of Dudu ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib kuda nubanda$under seal of Kuda , the superintendent ,
+iti ezembaba$month “ Festival of Baba , ”
+NUMB gur$NUMB gur
+giri lugalsuluhu$via Lugal-suluḫu ;
+NUMB kicib kuda nubanda$NUMB  under seal of Kuda , the superintendent ,
+iti$month … ,
+giri lubimu$via Lu-bimu ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib kuda nubanda$under seal of Kuda , the superintendent ,
+NUMB gur$NUMB gur NUMB barig
+kicib atu nubanda$under seal of Atu , the superintendent ,
+iti cesagku$month “ Harvest , ”
+NUMB gur$NUMB gur NUMB barig NUMB ban2 ,
+cagal erina$food of the work-troops ,
+NUMB cenumun aca erin$NUMB gur seed , fields of the work-troops ,
+kicib bi NUMBam$its sealed tablets : NUMB ,
+kicib kuda nubanda$under seal of Kuda , the superintendent ;
+NUMB gur$NUMB gur NUMB barig ,
+cagal erina$food of the work-troops ,
+NUMB cenumun aca erin$barley seed , fields of the work-troops ,
+kicibi NUMBam$its sealed tablets : NUMB ,
+kicib lugalinimgina$under seal of Lugal-inim-gina ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+urnance$Ur-Nanše ,
+dumu nabasa$son  Nabasa ,
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3
+kicib kuda nubanda$under seal of Kuda , the superintendent ,
+ki urmes guduta$from Ur-mes , the gudu4-priest ,
+giri dudu$via Dudu ;
+n NUMB sila gur$… NUMB gur NUMB barig NUMB ban2 NUMB sila3
+kicib X X X$under seal  of … ,
+X gur$… gur … ,
+erin balatuca$the work-troops sitting out the corvée duty
+kicib urlamma dumu namah$under seal of Ur-Lamma , son  Nammaḫ ,
+iti ceila$month “ Barley carried , ”
+NUMB gur$NUMB gur NUMB ban2
+erin balaguba$the work-troops performing the corvée duty
+kicib urnance$on the sealed tablet  Ur-Nanše ,
+dumu eabcaga$son  E-abšaga ,
+nubanda lugula$superintendent : Lu-gula ,
+NUMB gur$NUMB gur NUMB barig
+erin balatuca$the work-troops sitting out the corvée duty
+kicib lugalusasa$under seal of Lugal-lu-sasa ,
+iti amarasi$month “ Amar-ayasi , ”
+erin e nance$work-troops of the house of Nanše ,
+ce erina$barley of the work-troops ;
+NUMB gur$NUMB gur NUMB barig
+kicib abamu$under seal of Abbamu
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib urbaba dumu ugIL$under seal of Ur-Baba , son of UgIL ,
+ce X X X$barley … ;
+X X X$. . ;
+X erin balatuca$…  the work-troops sitting out the corvée duty
+kicib namah nubanda$under seal of Nammaḫ , the superintendent ,
+NUMB erin balaguba$NUMB gur NUMB barig NUMB ban2 the work-troops performing the corvée duty
+kicib X X X X$under seal of … ,
+X X X$. . ;
+ugu mani gagadam$it is to be placed ;
+X gur$… gur … ,
+X$. . ;
+X$. . ;
+X$. . ;
+X X X X$. . ;
+n NUMB gur$… NUMB gur NUMB barig
+kicib urninmar$under seal of Ur-Ninmar ;
+X NUMB X NUMB gur$,
+kicib bi NUMBam$its sealed tablets : NUMB ,
+kicib nigurani$under seal of Niggurani ,
+ceba ugIL$barley rations ,
+ugu urnance dumu nabasa gagadam$it is to be placed  Nabasa ;
+NUMB gin la NUMB ce kubabbar$NUMB shekels less NUMB grains silver ,
+cebi NUMB sila gur$its barley : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ,
+luna dumu calasu$Šalasu ,
+sanga cu bati$the household manager received ,
+ugua gaga$debit account ;
+NUMB gur$NUMB gur NUMB barig
+urlamma dumu namah$Nammaḫ ,
+NUMB urlamma dumu urnig$NUMB  NUMB barig , Ur-Lamma , son of Ur-nig ,
+NUMB urcucbaba$NUMB  Ur-Šuš-Baba ,
+NUMB mu urcucbabace$NUMB  in place of Ur-Šuš-Baba
+kicib aba nubandagu$under seal of A’abba , the supervisor of oxen ,
+e ninmar$house of Ninmar ;
+NUMB gur$NUMB gur
+kicib urbaba cec lugalzagesi$under seal of Ur-Baba , the brother  Lugal-zagesi ,
+e ninmar$house of Ninmar ;
+NUMB mu urbabace$NUMB ,
+kicib X ka X$under seal of Lu-… ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+erin X X$the work-troops … ,
+giri X$via … ,
+a lu hunga$wages ,
+NUMB ceba X$NUMB , barley rations ? of … ,
+urcugalama dumu namah$Ur-šugalama , son of Nammaḫ ;
+NUMB lunu$NUMB  Lu-Unu ,
+e culgira$house  Šulgi ;
+NUMB urbaba sanga ningirsu$Ur-Baba , the household manager of Ningirsu ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+cabra sangane$sanga administrators ;
+NUMB lumagura dumu X$NUMB  Lu-Magura , son of Ur-… ;
+NUMB gur$NUMB gur
+X X$. . ;
+X X$… ;
+NUMB zi sig$NUMB barig fine flour ,
+ce balabi NUMB$its bala barley : NUMB barig ,
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3
+urgigir kaguru$Ur-gigir , the chief of the granary ;
+NUMB gur$NUMB gur NUMB barig
+X$. . ;
+ugu idub ambarsura bagar$placed  the debit account of the depot Ambar-sur-ra ;
+ugua bagar$debit accounts ;
+X X X$. . ;
+X$. . ;
+ugua gaga$,
+NUMB X gur$NUMB … gur . . ;
+kicib urlamma dumu namah$under seal of Ur-Lamma , son  Nammaḫ ,
+NUMB kicib lugirizal nubandagu$NUMB barig NUMB ban2 , under seal of Lu-girizal , supervisor of oxen ,
+NUMB kicib ada nubandagu$NUMB barig NUMB ban2 under seal of Adda , supervisor of oxen ,
+NUMB dumu daba$NUMB , children-at-its-side ,
+kicib urlamma dumu sidu$under seal of Ur-Lamma , son  Sidu ,
+NUMB kicib lugirizal$NUMB barig NUMB ban2 , Lu-girizal ,
+NUMB urlamma dumu namah$NUMB ban2 , Ur-Lamma , son of Nammaḫ ,
+NUMB kicib urningeczida$NUMB  under seal of Ur-Ningešzida ,
+cec urcucbaba$the brother  Ur-Šuš-Baba ,
+NUMB kicib nagu dumu iriana$NUMB  NUMB barig under seal of Nagu , son of Iri-ana ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib aba dumu uda$under seal of A’abba , son  Uda ,
+NUMB kicib eninakal nubandagu$NUMB barig NUMB ban2 under seal of En-innakal , supervisor of oxen ,
+NUMB dumu daba$NUMB , ‘children-at-its-side’
+kicib urlamma dumu sidu$under seal of Ur-Lamma , son  Sidu ,
+NUMB kicib lunarua nubandagu$NUMB barig NUMB ban2 Lu-Narua , supervisor of oxen ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib lugalsaga$under seal of Lugalsaga
+mu luirisagce$in place of Lu-Irisag ,
+NUMB urcucbaba$NUMB ban2 Ur-Šuš-Baba ,
+NUMB gur$NUMB gur
+kicib urlamma dumu urnig$under seal of Ur-Lamma , son  Ur-nig ,
+NUMB kicib urlamma dumu ursaga$NUMB barig NUMB ban2 under seal of Ur-Lamma , son of Ursaga ,
+NUMB kicib ala nubandagu$NUMB barig NUMB ban2 , under seal of Alla , supervisor of oxen ,
+NUMB kicib duganizi nubandagu$NUMB  under seal of Duganizi , supervisor of oxen ,
+e ninmar$house of Ninmar ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib urcugalama$under seal of Ur-šugalama ,
+NUMB kicib urlamma dumu namah$NUMB  NUMB barig , under seal of Ur-Lamma , son of Nammaḫ ,
+NUMB kicib urningeczida nubanda$NUMB  NUMB barig , under seal of Ur-Ningešzida , the superintendent ,
+NUMB mu urcugalamace$NUMB  in place of Ur-šugalama
+kicib urningeczida nubanda$under seal of Ur-Ningešzida , the superintendent ,
+ugula urcugalama$foreman : Ur-šugalama ,
+NUMB gur$NUMB gur
+kicib lunu$under seal of Lu-Unu ,
+NUMB kicib lugalnigince$NUMB  under seal of Lugal-Niginše ,
+ugula lugalnigince$foreman : lugal-Niginše ,
+e culgi$house  Šulgi ;
+NUMB kicib urninmar$NUMB , under seal of Ur-Ninmar ,
+NUMB mu urninmarce$NUMB  NUMB barig in place of Ur-Ninmar
+kicib urmama$under seal of Ur-Mama ,
+ugula urninmar$foreman : Ur-Ninmar ,
+NUMB X gur$NUMB gur NUMB barig . . ;
+kicib X X$under seal of Lugal-… ,
+ugula X X$foreman : Lugal-… ,
+e ninmar$house of Ninmar ;
+NUMB n NUMB gur$NUMB gur … NUMB ban2
+kicib akala$under seal of Akalla ,
+ugula akala$foreman : Akalla ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib mancum$under seal of Manšum ,
+NUMB mancum$NUMB ban2 Manšum ,
+e namhani$household of Namḫani ;
+NUMB gur$NUMB gur NUMB ban2
+kicib ureninnu$under seal of Ur-Eninnu ,
+NUMB ureninnu$NUMB ban2 , Ur-Eninnu ,
+NUMB kicib nigurum$NUMB  NUMB ban2 Nig-urum ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+mu nigurumce$in place of Nig-urum
+kicib ureninnu$under seal of Ur-Eninnu ,
+NUMB nigurum$NUMB ban2 Nig-urum ,
+e nance$house of Nanše ;
+NUMB kicib urbaba$NUMB barig , under seal of Ur-Baba ,
+NUMB kicib urigalim dumu dada$NUMB  NUMB ban2 under seal of Ur-Igalim , son of Dada ,
+NUMB kicib luningirsu nubandagu$NUMB  Lu-Ningirsu , supervisor of oxen ,
+NUMB urbaba$NUMB ban2 Ur-Baba ,
+NUMB gur$NUMB gur NUMB barig NUMB ban2
+kicib lulagac$under seal of Lu-Lagaš
+NUMB lulagac$NUMB ban2 , Lu-Lagaš ,
+e ningirsu$the house of Ningirsu ;
+NUMB gur$NUMB gur NUMB barig NUMB ban2 ,
+ce ura engar$barley , interest-bearing ,  the plowmen ;
+NUMB dubsar didli$NUMB  NUMB barig NUMB ban2 , for various scribes
+kicib lucgina$under seal of Lu-ušgina ,
+NUMB kicib urningeczida$NUMB barig under seal of Ur-Ningešzida
+NUMB kicib lugudea$NUMB barig , under seal of Lu-Gudea ,
+giri urnungal$via Ur-Nungal ;
+NUMB ceckala dumu urbaba$NUMB , Šeškalla , son of Ur-Baba ,
+NUMB urningeczida$NUMB barig , Ur-Ningešzida ,
+NUMB urala$NUMB barig , Ur-Alla ,
+NUMB lugalgirizal$NUMB barig , Lugal-girizal ,
+NUMB lubalasaga$NUMB barig , Lu-balasaga ,
+NUMB lugalmelam$NUMB barig , Lugal-melam ,
+NUMB lugudea$NUMB barig , Lu-Gudea ,
+NUMB lugalanatum$NUMB barig , Lugal-annatum ,
+NUMB luningirsu$NUMB barig , Lu-Ningirsu ,
+NUMB urnance$NUMB barig NUMB ban2 , Ur-Nanše ,
+NUMB ursaga dumu urgigir$NUMB barig , Ursaga , son of Ur-gigir ,
+NUMB ursaga dumu bahar$NUMB barig , Ursaga , son of Baḫar ,
+NUMB lueb$NUMB barig , Lu-eb ,
+NUMB lunincubur$NUMB barig , Lu-Ninšubur ,
+NUMB lugalcala dumu ludingira$NUMB barig , Lugal-šala , son of Lu-dingira
+NUMB ezimu$NUMB barig , Ezimu ,
+dubsarme$are scribes ;
+giri dudu$via Dudu ;
+NUMB kicibi NUMB$NUMB  NUMB barig , its sealed tablets : NUMB ,
+kicib cangu$under seal of Šangu ,
+NUMB kicib bi NUMB$NUMB  NUMB barig , its sealed tablets : NUMB ,
+kicib dada dumu urgigir$sealed tablets  Ur-gigir ,
+iti amarasi$month “ Amar-ayasi ” ;
+NUMB kicib urbagara$NUMB  NUMB barig , under seal of Ur-bagara ,
+dumu cangu$son  Šangu ;
+NUMB kicib urnigar$NUMB  NUMB barig Ur-nigar ,
+nubanda dada$superintendent : Dada ,
+iti cesagku$month “ Harvest ” ;
+NUMB kicib abakala$NUMB barig NUMB ban2 , under seal of Abbakala ,
+nubanda urninbara$superintendent : Ur-Ninbara ,
+NUMB kicib urnigar$NUMB  NUMB barig , Ur-nigar ,
+nubanda dada$superintendent : Dada ;
+NUMB kicib cangu$NUMB  NUMB barig , under seal of Šangu ,
+iti ceila$month “ Barley carried ” ;
+NUMB gur$NUMB gur NUMB ban2 ,
+giri urnungal$via Ur-Nungal ;
+NUMB gudu barasiga$NUMB  NUMB barig the gudu4 priest of barasiga ;
+NUMB lugalezem$NUMB ban2 , Lugal-ezem
+kicib urnance cec kamu$under seal of Ur-Nanše , brother  Ka’amu ,
+giri atukala$via Atukalla ;
+lu gecime$are sesame oil people ;
+NUMB kicib urlugal$NUMB  NUMB barig Ur-lugal
+NUMB kicib lunance$NUMB barig , under seal of Lu-Nanše ,
+cukume$are fishermen ;
+iti ceila$month “ Barley carried ” ,
+giri urnungal dumu ensi$via Ur-Nungal , son  the governor ;
+NUMB kicib urningirsu dumu urbaba$NUMB , Ur-Ningirsu , son of Ur-Baba ;
+NUMB gur$NUMB gur NUMB barig
+kicib urnungal dumu ensi$under seal of Ur-Nungal , son  the governor ;
+NUMB gur$NUMB gur
+lugalsiskure$Lugal-siskure ;
+NUMB gur$NUMB gur
+lutu sipa$Lu-utu , the shepherd ;
+NUMB gur$NUMB gur ,
+ce ura citim$barley , interest-bering , ,
+kicib ureana$under seal of Ur-Eanna ,
+engar citim aca gibil$plowmen  of New-field ;
+NUMB gur$NUMB  NUMB barig ,
+ce ura lu marsa$barley , interest-bering ,  the shipyard people ,
+kicib magure cec guzana$under seal of Magure , brother  Guzana ;
+cunigin NUMB sila gur$total : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ,
+nigezema zamuka$festival material of New year ;
+cunigin NUMB sila gur$total : NUMB gur NUMB barig NUMB ban2 NUMB sila3
+ma dua u ucurbar ninmar$Ninmar ,
+mu NUMBa ara NUMBam$in NUMB years , the first time ;
+cunigin NUMB sila gur$total : NUMB gur NUMB ban2 NUMB sila3
+ca dugana giri kaskene$in leather bags , via the runners ;
+cunigin NUMB amar$total : NUMB young cattle ,
+cebi NUMB gur$its barley : NUMB gur ,
+amar dua guba$young cattle that serve for breeding ,
+kicib urningirsu u urmes unu$under seal of Ur-Ningirsu  Ur-mes , the cattle herdsmen ;
+cunigin NUMB amardaba NUMBta$total : NUMB young cattle assistants , NUMB barig each ,
+cebi NUMB gur$its barley : NUMB  NUMB barig ,
+kicib urmes u lugalnigzu$the under seal of Ur-mes and Lugal-nigzu ;
+cunigin NUMB gur$total : NUMB gur
+gugu aigidu gecgi$Gu’ugu , water inspector , wood & reed ,
+mu aca nudabace$in place of the not seized field ;
+cunigin NUMB cagal amarku ugnimce gena$total : NUMB barig the castrated ? men that have gone to the army ;
+cunigin NUMB gur$total : NUMB gur NUMB barig
+dubsar aigidu gecgi guba ce nutukume$the scribes , water inspectors , wood & reed , stationed , barley not receiving ;
+cunigin NUMB la NUMB sila gur$total : NUMB gur NUMB barig NUMB ban2 less NUMB sila3
+nigsiskura acaga$offerings of the fields ;
+cunigin NUMB sila gur$total : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ,
+nig erine gua$bread consumed by the work-troops ;
+cunigin NUMB cagal amar gec nuzu$total : NUMB barig , food of the virgin young cattle ;
+cunigin NUMB luhubu$total : NUMB barig Lu-ḫubu ;
+cunigin NUMB gur$total : NUMB gur NUMB barig ,
+giri urnungal$via Ur-Nungal ;
+cunigin NUMB gur$total : NUMB gur NUMB barig NUMB ban2 ,
+giri urebabbar$via Ur-Ebabbar
+u lugalsiskure$and Lugal-siskure ;
+cunigin NUMB gur$total : NUMB gur ,
+giri lugalsuluhu$via Lugal-suluḫu ;
+cunigin NUMB gur$total : NUMB gur ,
+giri lubimu$via Lu-bimu ;
+cunigin X X$total : … ,
+girisega$the standing personnel ;
+cunigin n NUMB gur$total : … NUMB gur NUMB barig NUMB ban2 ,
+lubimu$Lu-bimu ;
+cunigin NUMB gur$total : NUMB gur NUMB barig NUMB ban2 ,
+mani$Mani ;
+cunigin NUMB gur$total : NUMB gur NUMB barig ,
+urtur dumu ursaga$Ur-tur , son of Ursaga ;
+cunigin NUMB gur$total : NUMB gur NUMB barig NUMB ban2 ,
+urnance dumu nabasa$Ur-Nanše , son of Nabasa ;
+cunigin NUMB gin la NUMB ce kubabbar$total : NUMB shekels less NUMB grain silver ,
+cebi NUMB sila gur$its barley : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ,
+sanga cu bati$the household manager received ;
+ugua bagar$on  debit account placed ;
+cunigin NUMB gur$total : NUMB gur NUMB barig NUMB ban2 ,
+cabra sangane$sanga administrators ;
+cunigin NUMB gur$total : NUMB gur ,
+lumagura$Lu-magura ;
+cunigin NUMB gur$total : NUMB gur ,
+ugua bagar$on the debit account placed ,
+cunigin NUMB sila gur$total : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ,
+ugua gaga$to be placed on the debit account ,
+lutu dumu bazi$Bazi ;
+cunigin NUMB zisig$total : NUMB barig fine flour ,
+ce balabi NUMB$its bala barley : NUMB barig ;
+cunigin NUMB sila gur$total : NUMB gur NUMB barig NUMB ban2 NUMB sila3
+urgigir kaguru$Ur-gigir , the chief of the granary ;
+cunigin NUMB gur$total : NUMB gur NUMB barig ,
+ugu idub ambarsura bagar$the debit account of the depot Ambarsura placed ;
+ugua bagar$debit accounts ;
+cunigin NUMB gur$total : NUMB gur NUMB barig NUMB ban2 ,
+ce ura engar$barley , interest-bearing ,  the plowmen ;
+cunigin NUMB gur$total : NUMB gur NUMB barig NUMB ban2 ,
+dubsarme$the scribes ,
+giri dudu$via Dudu ;
+cunigin NUMB gur$total : NUMB gur NUMB ban2 ,
+giri urnungal$via Ur-Nungal ;
+cunigin NUMB gur$total : NUMB gur ,
+lugalsiskure$lugal-siskure ;
+cunigin NUMB gur$total : NUMB gur ,
+lutu sipa$Lu-Utu , the shepherd ;
+cunigin NUMB gur$total : NUMB gur
+citime$the builders ;
+cunigin NUMB gur$total : NUMB gur NUMB barig
+lumarsame$the people of the shipyard ;
+ce ura susu$barley , interest-bearing , to be replaced ;
+cunigin NUMB guru NUMB la NUMB sila gur$total total : NUMB gur NUMB barig NUMB ban2 less NUMB sila3 ,
+ziga$booked out ;
+laia NUMB sila gur$deficit : NUMB gur NUMB barig NUMB ban2 NUMB sila3 ;
+urnance dumu luduga$Ur-Nanše , son of Luduga ;
+laia NUMB sila gur$deficit : NUMB gur NUMB ban2 NUMB sila3
+ludingira$Lu-dingira ,
+dumu lubaba$son  Lu-Baba ;
+nigkak$account
+urnance dumu luduga$Luduga ,
+ca guaba$in Gu’abba ,
+iti GANmacta$from month “ GANmaš ”
+iti ceilace$to month “ Barley carried , ”
+iti NUMBkam$it is NUMB months ;
+urlamma$Ur-Lamma ,
+ensi$governor ;
+mu culgi nita kalga lugal urima lugal an ubda limmubake urbilum simurum lulubu u karhara NUMBece sagdubi cubura imira$year : “ Sulgi , strong man , king of Ur , king of the four regions , the heads of Urbilum , Simurrum , Lullubu and Karḫar in a single campaign did smash . ”
+urculpae$Ur-Šulpa’e ,
+dumu urictaran$son of Ur-Ištaran ,
+lu udu niga$man of fat-sheep .
+pisanduba$Basket-of-tablets
+kicib daba$xxx
+lugalmumag ugula$xxx
+igal$xxx
+mu amarsuen lugal urbilum muhul$xxx
+nita kalga$the strong man ,
+lugal kiengi kiuri$king of Sumer and Akkad
+lugal an ubda limmuba$and king of the four world quarters ,
+ganun X$the … storehouse ,
+e zi X X$his/her house of … flour
+munadu$he built for him/her .
+NUMB udu niga$NUMB sheep , barley-fed ,
+NUMB X$NUMB … ,
+X$of Šulgi-… ;
+NUMB sila X$NUMB lamb of Šarru-… ;
+NUMB amar macda nita$NUMB male calf of a gazelle
+ibniculgi$of Ibni-Šulgi ;
+u NUMBkam$the ordNUMB day ,
+muku lugal$delivery for the king ,
+intaea$Inta’e’a
+idab$accepted ;
+giri nursuen$via Nūr-Suen .
+iti cesagku$month : “ Harvest , ”
+mu usa cusuen lugale simanum muhul$year after : “ Šu-Sin , the king , Simanum destroyed ; ”
+NUMB udu NUMB macda$NUMB small cattle , NUMB gazelle .
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+s,ali $for Ṣalli ;
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+dania $for Danniya ;
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+suenkal $for Suen-kal ;
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+abakala $for Abbakalla ;
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+qurdilum $for Qurdī-ilum ;
+cunigin NUMB sila kac NUMB sila ninda NUMB sila NUMB gin cum $total : NUMB ban2 NUMB sila3 beer ; NUMB ban2 NUMB sila3 bread ; NUMB sila3 NUMB shekels onions ;
+cunigin NUMB gin i NUMB gin naga $total : NUMB shekels oil ; NUMB shekels alkali-plant ;
+X $…
+u NUMBkam $ordNUMB day ,
+iti sigicubgar $month : “ Bricks cast in molds , ”
+mu usa $year following .
+pisanduba$Basket-of-tablets
+kicib namDU$sealed documents , …
+lu nigdabakene$men of assignments ,
+igal$are here .
+pisanduba$Basket-of-tablets
+ab ud daba$cows and nannies … ,
+ca girsu$within Girsu
+e kurucda ensi$the fattening house of the governor
+X X$…
+igal$are here ;
+mu usa kimac mu usabi$year after : “ Kimaš , ” year after that .
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urimakace$king of Ur ,
+X$Hazi-…
+munadim$fashioned  for him/her .
+NUMB udu niga NUMB macgal $NUMB sheep , barley-fed ; NUMB mature goat ,
+NUMB sila $NUMB lamb ,
+u NUMBkam $ordNUMB day ;
+ki abasagata $from Abba-saga
+endingirmu idab $did En-dingirmu accept ;
+iti ezemah $month : “ Great festival , ”
+mu guza ca hula enlila badim $year : “ Throne , joy of Enlil , was fashioned . ”
+NUMB $NUMB .
+NUMB kuc gar$NUMB leather stoppers ,
+ka dug baba saga kecde$the mouths of jugs of fine baba  to bind ,
+ki akalata$from Akalla ,
+kicib lubalasaga$under seal of Lu-bala-saga ;
+iti diri$month : “ Extra , ”
+mu usa kimac bahul$year after : “ Kimaš was destroyed . ”
+lubalasaga$Lu-bala-saga ,
+dubsar$scribe ,
+dumu mama$son of Mama .
+NUMB mana NUMB gin la NUMB ce kubabbar$NUMB mana NUMB shekels less NUMB grains silver ,
+situm nigkak$remainder of the account ,
+hubidam damgar$against Ḫubidam , the trade agent ,
+indagal$exists , ;
+susudam$it is to be repaid ;
+giri kituclu dubsar$via Ki-tušlu , the scribe
+u sipainimgina$and Sipa-inimgina ;
+mu usa ara NUMBkam simurum bahul$year : “ For the ordNUMB time Simuurrum was destroyed . ”
+NUMB udu$NUMB sheep
+itita u NUMB barazal$of the month day NUMB elapsed ;
+NUMB udu$NUMB sheep
+itita u NUMB barazal$of the month day NUMB elapsed ;
+NUMB macgal niga$NUMB bucks , barley-fed ,
+NUMB udu$NUMB sheep ,
+itita u NUMB barazal$of the month day NUMB elapsed ;
+ki acneuta$from Ašne’u
+beliarik$Belī-arik
+cu bati$received ;
+iti akiti$month : “ Akitu , ”
+mu en nanna mace ipa$year : “ The high-priestess of Nanna by means of extispicy was chosen . ”
+pisanduba$Basket-of-tablets
+etum$‘chambers’ of
+ab etur$cows of the stall
+u guapin$and plow-oxen ,
+mu guza badim$year : “ The chair was fashioned . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+culgili$Šulgi-ilī ,
+agausgal$great-soldier ,
+dumu nazida$son of Nazida ,
+nubanda$nubanda ,
+ARADzu$is your servant .
+enlil$For Enlil ,
+lugal kurkura$the king of all the lands ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+eani$his temple
+munadu$he built for him ,
+i enerinun$and the Enerinnun canal ,
+i nidbakani$his canal of  offerings ,
+munabal$he dug for him .
+nintiuga$For Nintinuga ,
+nin cimu gal enlilara$the great lady herbalist of Enlil ,
+e amer ku$in the sacred … house ,
+e i gula$the big oil house
+enlilaka$of Enlil ,
+e dumusag$the Dumusag temple
+munanidu$he built for her .
+cim eringalgal$Great aromatic cedars
+X nin kib$… the lady …
+urnamma$Ur-Namma ,
+lugal$king
+enlile$whom Enlil
+kiagra$for  beloved
+X$…
+X X$which is of … ,
+cusag$…
+anguba NUMB$Seven tutelary deities .
+pisanduba$Basket-of-tablets
+di tila$xxx
+igal$xxx
+giri gudea abairi$xxx
+u urictaran$xxx
+mu huhnuri bahul$xxx
+X$…
+nibrua$in Nippur
+enlile$one whom Enlil
+mu pada$nominated ,
+sagus$the constant supporter
+e enlilka$of the temple of Enlil ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+pisanduba$Basket-of-tablets
+nigur$xxx
+ningirsukaisa kurucda$xxx
+sila gala$xxx
+kicib lu didline$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+dub nurickur cabra$xxx
+ca nibru$xxx
+mu cusuen lugal urimake madarabzu enkika bindu$xxx
+igal$xxx
+NUMB gu niga NUMB udu$NUMB oxen , grain-fed , NUMB rams ,
+kucara ensi icimculgi$Ku-Šara , governor of Išim-Šulgi ;
+NUMB gu niga NUMB udu$NUMB ox , grain-fed , NUMB rams ,
+nisabandul cabra$Nisaba-andul , chief household administrator ;
+cu la$… ,
+kicib nutuku$unsealed ,
+inim carakamta$by order of Šarakam ,
+ki abasagata bazi$from  Abba-saga booked out ,
+kicib lubine$under seal of Lu-bine ;
+carakame$by Šarakam
+tumdam$to be transported ;
+iti ezemculgi$month : “ Festival-of-Šulgi , ”
+mu en nanna bahun$year : “ The lord of Nanna was installed . ”
+NUMB gu niga NUMB udu kucara ensi icimculgi$NUMB oxen , grain-fed , NUMB rams ,  Ku-Šara , governor of Išim-Šulgi ;
+NUMB gu niga NUMB udu nisabandul cabra$NUMB ox , grain-fed , NUMB rams ,  Nisaba-andul , chief household administrator ;
+cu la$… ,
+kicib nutuku$unsealed ,
+inim carakamta$by order of Šarakam ,
+ki abasagata bazi$from  Abba-saga booked out ,
+kicib lubine$under seal of Lu-bine ;
+carakame$by Šarakam
+tumdam$to be transported ;
+iti ezemculgi$month : “ Festival-of-Šulgi , ”
+mu en nanna bahun$year : “ The lord of Nanna was installed . ”
+ludingira$Lu-dingira ,
+dubsar$scribe ,
+dumu ursaga$son of Ur-saga .
+lugal kiengi kiurike X$king of Sumer and Akkad ,
+enlil$For Enlil ,
+lugal kurkura$king of all the lands ,
+lugalanir$his master ,
+cusuen$Šū-Sîn ,
+mu pada$chosen by name
+ana$by An ,
+kiag$beloved
+enlila$by Enlil ,
+lugal enlile$the king whom Enlil
+cagana$in his heart
+inpa$did choose
+sipa kalama$as the shepherd of the country
+u an ubda limmubace$and of the four world quarters ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubara$and king of the four world quarters —
+u enlile$When Enlil
+namti$life
+zisugal$and longevity ,
+aga men$crown and tiara ,
+gidri u sura$a scepter of long days ,
+guza namlugal$the throne of kingship
+suhuc gina$with a secure foundation ,
+mu hegala$years of abundance ,
+tukul amaru$a flood of weapons
+ni gal mucub$which cast forth great fearsomeness ,
+ankar$the royal ankara-weapon
+a me$the weapon of war ,
+a namursaga$the weapon of heroism ,
+ni melambi$whose fearsomeness and divine radiance
+ane usa$reaches up to heaven ,
+zapagbi$whose roar
+ki bala duldula$covers the rebel lands
+balari$from across
+aba sigata$the Lower Sea
+aba iginimace$to the Upper Sea ,
+i X$the river …
+hursag galgal$All the great mountain ranges ,
+kur ki sura$the distant mountain places ,
+namlu$the peoples ,
+enen barabarabi$all their lords and enthroned ones ,
+cusuen$to Šū-Sîn ,
+lugal mu pada anara$the king nominated by An ,
+girine cu gurgure$bowing down at his feet ,
+enlil$when Enlil ,
+en dugana$the lord through whose command
+sag dudue$all is created ,
+cusuen$to Šū-Sîn ,
+lugal ca kuge padanir$his king chosen by  sacred heart ,
+munancuma$had given  to him —
+uba$At that time
+cimacgi$Šimaški ,
+mada mada$the territories
+zabcali$of Zabšali ,
+za ancanta$from the borders of Anšan
+aba iginimace$to the Lower Sea
+burugin zigabi$those having risen up like locusts ,
+nibulmat$Nibulmat ,
+X X X$… ,
+sigric$Sigriš ,
+alumidatim$Alumidatim ,
+garta$Garta ,
+azahar$Azaḫar ,
+bulma$Bulma ,
+nucucmar$Nušušmar ,
+nucganelum$Nušganelum ,
+zizirtum$Zizirtum ,
+arahir$Araḫir ,
+catilu$Šatilu ,
+tirmium$Tirmium ,
+u$and
+X$…
+X$…
+X$…
+X$against …
+imadaec$came forth .
+lugalbi$Their kings
+me cencenba$with their war and battle
+gaba munadariec$confronted him .
+cusuen$Šū-Sîn ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+a enlil$by the power of Enlil
+lugalnata$his master ,
+inim ninlil$and by the command of Ninlil ,
+nin kiaganata$his beloved mistress ,
+me cencenba$in those wars and battles
+agakar binsese$he was repeatedly victorious .
+sagursagbe$Their head warriors
+gugur bindu$he mowed down .
+dutukubi$Their runners
+cusiga bindu$he weakened .
+kalga sigabi$Their strong and weak
+urec mug$he killed like dogs .
+sagzi saglulbi$The heads of their righteous and treacherous ones
+numunec mugargar$he strewed like seeds .
+ad namlubi$Their human corpses
+zarec mududu$he piled up like sheaves .
+enen barabarabi$All their lords and enthroned ones
+caga minindabdab$he took into capitivity .
+ensi galgal$All the great governors
+mada mada$of the territories
+zabcali$of Zabšali
+u$and
+ensiensi$all the governors
+iriri$of the cites
+mea mudangureca$whom he had brought back from the wars ,
+enen barabarabi$their governors and enthroned ones
+caga minindabdabana$when he had taken them prisoner ,
+X$…
+X$…
+igi enlil$before Enlil
+ninlilace$and Ninlil
+X$he did …
+namguruc$The young men
+cu meta$who from the grasp of battle
+imatacubuca$had fallen out ,
+iriribice$and to their cities
+mucengin zibi babdea$like  birds had saved their lives ,
+cuni labatae$did not escape his hand .
+iriribice$Towards their cities
+anzugin ane$like an Anzu-eagle he himself
+ce bingi$screeched .
+iri adam kigargarabi$Their settled cities and towns
+dudura miningar$he made into ruined mounds ,
+badbi$and their walls
+mugulgul$he demolished .
+namguruc iririba$The young men of their cities
+sa baninduga$which he had conquered
+igibi imandudu$he removed their eyes ,
+kiri enlil$and in the orchards of Enlil
+ninlila$and Ninlil
+u$and
+kiri dingir galgaleneka$in the orchards of the great gods
+girice iminse$he made them into domestic servants .
+u namgeme$Further , the young women
+iririba$of those cities
+sa banininduga$which he had conquered
+e ucbar$in the weaving-houses
+enlil$of Enlil
+ninlila$and Ninlil
+u$and
+e dingir galgaleneka$the temples of the great gods
+sagce iminrig$he offered as gifts .
+gu udu mac ancebi$Their cattle , sheep , goats and donkeys
+munlaha$which he brought in
+e enlil$and in the temples of Enlil
+ninlil$and Ninlil
+u$and
+e dingir galgaleneka$the temples of the great gods
+gec imanintag$he sacrificed them .
+kusig kubabbar$Gold and silver
+nig dima$and things fashioned
+|| galgala$into big sacks
+mininsisi$he filled .
+uruda$Copper ,
+naggabi$and tin ,
+zabar$bronze ,
+nigdimabi$and things fashioned from them
+ance bare binlala$he tied onto the backs of donkeys ,
+e enlil$and for the temples of Enlil ,
+ninlila$Ninlil ,
+u$and
+e dingir galgaleneke$the temples of the great gods
+gilsac$into treasures
+iminak$he made them .
+cusuen$Šū-Sîn ,
+lugal mu pada anake$the king nominated by An ,
+a mah cuma$given supreme power
+enlilake$by Enlil ,
+uda egirbice$that from this day foreward
+arbi$the praise of them
+kata nucubude$should not fall from the lips ,
+cua balaede$but should  be handed down -
+bulma$Bulma ,
+mada cimacgika$in the land of Šimaški ,
+udabec$like …
+X$he cast down .
+namlu$The population ,
+munus nita$females and males ,
+zigal mu tukubi$those living beings having names
+X tukul X$he … with weapons .
+X iminpada$He having revealed it to …
+kigal ara$for the …
+namkalga$that his might
+namirani$and power
+cu uliac$shall unto distant times
+nurura$not be erased ,
+zaba X$he … it to their farthest reaches .
+X X X habura$… Habūra
+u$and
+mardaman$Mardama
+cusuen$Šū-Sîn ,
+lugal sipa sagegake$the king and shepherd of the Black-Headed Folk
+X$…
+banizi$he raised there
+tugba bidul$and covered them with the garment of it .
+kusig kubabbar$Gold and silver
+balede$to mine
+imatangar$he set them .
+uba$At that time ,
+cusuen$Šū-Sîn ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+kusig$the gold
+mada mada$of the territories
+cimacgika$of Šimaški ,
+namrac akni$which he had made into booty ,
+alananice$into  stone figure of himself
+mudim$he fashioned ,
+enlil$and to Enlil ,
+lugalanir$his master ,
+namtilanice$for his life
+a munaru$he dedicated it .
+lu a nighuldima$A person who an order of wickedness
+ibciagea$shall issue against it ,
+musaraba$and this inscription
+cu biburura$shall erase
+muni$and his own name
+bibsarea$shall write upon it ,
+nigdimamu$or that which I have fashioned
+ibzirea$he shall destroy ,
+luba$that person
+enlil$may Enlil ,
+lugal kurkurake$the king of all the lands ,
+ninlil$and Ninlil ,
+nin dingireneke$the queen of the gods ,
+nam habandakurene$curse .
+ninurta$May Ninurta ,
+ursag kalga$the mighty warrior
+enlila$of Enlil ,
+mackimbi hea$be the bailiff of this .
+musara$Inscription
+kigalba$on its socle .
+cusuen$Šū-Sîn ,
+kiag$beloved
+enlila$of Enlil ,
+lugal enlile$king whom Enlil
+cagane$by his heart
+inpa$did choose
+sipa kalama$to be the shepherd of the country
+u an ubda limmubace$and of the four world quarters ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters .
+musara girina$Inscription on his foot .
+ziringu$Ziringu ,
+ensi$the governor
+mada$of the land
+zabcali$of Zabšali .
+musara$Inscription
+za ziringu$on the shoulder of Ziringu
+lugal caga$the captive king .
+dub musara$A tablet of the inscriptions
+NUMB dub alan$of three tablets of statues
+cusuen$of Šū-Sîn
+u kigal NUMBbi$and their two socles .
+NUMB guruc$NUMB laborers ,
+ugula ludingira$foreman : Lu-dingira ;
+NUMB guruc ugula lugalgirizal$NUMB laborers , foreman : Lugal-girizal ;
+NUMB guruc ugula lusaga$NUMB laborers , foreman : Lu-saga ;
+NUMB guruc ugula ludaia$NUMB laborers , foreman : Lu-Daya ;
+NUMB guruc ugula urgigir$NUMB laborers , foreman : Ur-gigir ;
+NUMB guruc ugula lugalmagure$NUMB laborers , foreman : Lugal-magure ;
+NUMB guruc NUMB guruc tura$NUMB laborers , NUMB laborers , sick ,
+ugula lugalmumag$foreman : Lugal-mumag ,
+gubam$are stationed ,
+ca bala$within the bala ;
+iti lisi$month : “ Lisi , ”
+mu cacrum bahul$year : “ Šašrum was destroyed . ”
+pisanduba$Basket-of-tablets
+udu gukkal guba$xxx
+girsuta$xxx
+guabace$xxx
+igal$xxx
+mu cusuen lugal urimake simanum muhul$xxx
+pisanduba$Basket-of-tablets
+gabari kicib lu nigdabkene$copies , sealed documents , men of the takes ,
+ugua gagade$in the debits to be placed’s
+kicibi urnungal$the sealed documents of Ur-Nungal ,
+X X X$…
+X X X X$…
+igal$are here ;
+giri X$via …-Baba ,
+u X X$and …-zi ,
+iti ezemcusuen$month “ Festival-of-Šu-Suen , ”
+mu X$year : “ … . ”
+NUMB ce gur lugal$NUMB gur NUMB ban2 barley , royal ,
+ku NUMB gina NUMB ce gur lugal$silver , in NUMB shekel NUMB gur royal ,
+kubi NUMB mana NUMB gin NUMB ce$its silver : NUMB mana NUMB shekels NUMB grains ,
+ki ARADmu dumu lugalpirigbandata$from ARAD2-mu , son of Lugal-pirigbanda ;
+sagnigurakam$are the debits ;
+cabita$therefrom
+NUMB esir EA gur$NUMB gur EA-bitumen ,
+ku NUMB gina NUMB esir EA lugalta$silver , in NUMB shekel NUMB barig EA-bitumen , royal ,
+NUMB sila esir EA gur NUMBta$NUMB gur NUMB barig NUMB ban2 NUMB sila EA-bitumen at NUMB barig NUMB ban2 each ,
+kubi NUMB gin la NUMB ce$its silver : NUMB  NUMB shekels less NUMB grains ;
+NUMB zahadin NUMB silata$NUMB barig leeks at NUMB sila each ,
+kubi NUMB gin$its silver : NUMB shekels ;
+NUMB cumsikil NUMBta$NUMB barig NUMB ban2 garlic at NUMB barig NUMB ban2 each ,
+kubi NUMB gin$its silver : NUMB shekels ;
+NUMB sila cum gaz NUMBta$NUMB barig NUMB ban2 NUMB sila onion , ground , at NUMB barig NUMB ban2 each ,
+kubi NUMB gin igiNUMBgal la NUMB ce$its silver : NUMB shekels less NUMB grains ,
+NUMB sila naga gur NUMB gurta$NUMB gur NUMB barig NUMB ban2 NUMB sila alkali-plant at NUMB gur NUMB barig NUMB ban2 each ,
+kubi NUMB gin igiNUMBgal NUMB ce$its silver : NUMB shekels NUMB grains ,
+NUMB sila mun gur NUMB gurta$NUMB gur NUMB barig NUMB ban2 NUMB sila salt at NUMB gur each ,
+kubi (|NINDA la NUMB ce$its silver : NUMB shekels less NUMB grains ;
+NUMB usuh gec ecumta$NUMB pines , lumber from the slaughterhouse ,
+kubi igiNUMBgal$its silver : NUMB shekel ;
+NUMB pec duru NUMB gurta$NUMB barig figs , fresh , at NUMB gur NUMB barig each ,
+kubi igiNUMBgal NUMB ce$its silver : NUMB shekel NUMB grains ,
+NUMB sila zulum NUMB gurta$NUMB ban2 NUMB sila dates at NUMB gur each ,
+kubi NUMB ce ku$its silver : NUMB grains of silver ;
+NUMB gu NUMB mana esir had NUMB guta$NUMB talent NUMB mana bitumen , dried , at NUMB talents each ,
+kubi igiNUMBgal$its silver : NUMB shekel ;
+cunigin NUMB mana NUMB gin NUMB ce kubabbar$total : NUMB mana NUMB shekels NUMB grains of silver ,
+ziga$booked out ;
+laia NUMB ce kubabbar$deficit : NUMB grains of silver ;
+nigkak$account of
+urculpae damgar$Ur-Šulpa’e , the merchant ,
+ca urima$in Ur .
+iti ezemceila iti GANmac$month : “ Festival-grain-lifted ” and month “ GANmaš ” ;
+iti NUMBkam$of two months ;
+balabi NUMBam$its bala : NUMB ;
+urlamma ensi$Ur-Lamma , the governor ;
+mu simurum lulubum ara NUMBkamac bahul$year : “ Simurrum , Lullubum , for the ordNUMB time were destroyed . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur
+abaenlilgin$Aba-Enlil-gin ,
+dumu luinanna kurucda$son of Lu-Inanna , fattener ,
+ARADzu$is your servant .
+inanna$For Inanna ,
+nin eana$the queen of the Eanna temple ,
+ninani$his mistress ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+i enurigal$the Iturungal canal ,
+i kiagani$his beloved canal ,
+munabal$he dug for him .
+baba$To Baba
+ninanir$his mistress ,
+namti$for the life
+ibisuenkace$of Ibbi-Sîn ,
+emanili$'Aman-ilī ,
+dam ARADnanna$the wife of Ir-Nanna ,
+ensi$the governor
+lagackake$of Lagaš ,
+a munaru$dedicated  to him .
+NUMB amar gu ga$NUMB bull calves , suckling ,
+NUMB sila ga$NUMB lambs , suckling ,
+NUMB kir ga$NUMB female lambs , suckling ,
+utuda$newborns ;
+ca nagabtum$in Nagabtum ;
+u NUMBkam$ordNUMB day ,
+culgiamu idab$Šulgi-ayamu accepted ;
+iti ezemana$month : “ Festival of An , ”
+mu en nanna bahun$year : “ The en-priestess of Nanna was installed ; ”
+NUMB gu NUMB udu$NUMB oxen , NUMB sheep .
+pisanduba$Basket-of-tablets
+gurumak daba$inspections , seized ,
+gabra lu marsa$herding assistants , harbor workers ,
+mu$year : “ … . ”
+adahucu$Atta-ḫušu , 
+sipa incucinak$shepherd of Inšušinak , 
+dumu nin silhaha$son of the sister of Silḫaḫa , 
+e narute$the house of Narunte , 
+badu$built ; 
+namtilanice$for his life . 
+gatumdu$To Gatumdug ,
+ninani$his mistress ,
+namtiNI$for the life
+ibisuen$of Ibbi-Sîn ,
+ehegal$Ehegal ,
+dumu anza$the son of Anza ,
+a munaru$dedicated  to her .
+NUMB sila kac NUMB sila ninda$NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga$NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum$NUMB bundel onions
+cumama kausa$Šu-Mama , the ka’usa ;
+NUMB sila kac NUMB sila ninda$NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga$NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum$NUMB bundel onions
+habad gabata$Habad , the gaba-ta ;
+NUMB sila kac NUMB sila ninda$NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga$NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum$NUMB bundel onions
+kurbilak kausa$Kurbilak , the ka’usa ;
+cunigin NUMB la NUMB sila kac cunigin NUMB sila ninda$total : NUMB ban2 less NUMB sila3 beer , total : NUMB sila3 bread ,
+cunigin NUMB gin i cunigin NUMB gin naga$total : NUMB ban2 less NUMB sila3 beer , total : NUMB shekels alkali-plant ,
+cunigin NUMB sa cum$total : NUMB bundles onions ;
+u NUMBkam$ordNUMB day ,
+iti cesagku$month : “ Harvest , ”
+mu usa bad martu badu$year after : “ Martu-Wall was erected . ”
+pisanduba$Basket-of-tablets
+ce erine cutia$grain by the troops received ,
+erin engar cagu$troops , plowmen , those of oxen ,
+u erin girsu$and troops of Girsu
+igal$are here ;
+mu cusuen lugal urima naruamah enlil ninlilra munedu$year : “ Šu-Suen , the king of Ur , Great-Stele for Enlil and Ninlil erected . ”
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+urmeme$Urmeme ,
+candana enlila$š . of Enlil ,
+dumu nigdugani$son of Nigdugani ,
+candana enlilaka$š . of Enlil ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+lugina$xxx
+urenlila$xxx
+namhani$xxx
+lucgina$xxx
+guzala nigea$xxx
+igal$xxx
+mu en nanna karzida bahun$xxx
+NUMB gu niga sagu$NUMB oxen , barley-fed , top grade ,
+NUMB gu niga X$NUMB oxen , barley-fed , … ,
+siskur NENEgar$siskur-offerings of “ NENEgar ”
+u ecec e u NUMB$and ešeš-celebration , “ House Day NUMB ; ”
+iti u NUMB bazal$of the month day NUMB elapsed ,
+ki culgiamuta$from Šulgi-ayamu ,
+nasa idab$Nasa accepted .
+iti ezemninazu$month : “ Festival of Ninazu , ”
+mu simurum u lulubu ara NUMB la NUMBkamac bahul$year : “ Simurum and Lulubu for the ordNUMB time were destroyed . ”
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+lugula $for Lu-Gula ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+dingirbani $for Ilī-bani ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+utumancum $for Utu-manšum ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+puzurutu $for Puzriš-Utu ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+ARADnanna $for ARAD-Nanna ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+lubanda $for Lu-banda ;
+cunigin NUMB sila kac NUMB sila ninda NUMB sa cum $total : NUMB ban2 NUMB sila3 beer ; NUMB ban2 NUMB sila3 bread ; NUMB bundles onions ;
+NUMB gin i NUMB gin naga $NUMB shekels oil ; NUMB shekels alkali-plant ;
+u NUMBkam $ordNUMB day ,
+iti cesagku $month : “ Harvest . ”
+NUMB udu $NUMB sheep ,
+bauc $slaughtered ;
+u NUMBkam $ordNUMB day
+ca tumal $in Tummal ,
+ki endingirmuta $from Endingirĝu
+culgirimu $Šulgi-iriĝu
+cu bati $received ;
+iti cueca $month “ Šuešša , ”
+mu guza enlila badim $year : “ The throne of Enlil was crafted . ”
+NUMB cudul kuc siga$NUMB wooden yokes covered  leather ;
+NUMB adtab kuc siga$NUMB bridles covered  leather ,
+kilabi NUMB mana$its weight : NUMB mana ;
+NUMB usan guba$NUMB whips ;
+NUMB sagkec$NUMB rein ;
+NUMB nag$;
+gu diri cudua$extra oxen , implements ,
+ki akala acgabta$from Akalla , the leather worker ,
+kicib dagi$under seal of Da’agi ;
+iti cunumun$month “ Sowing , ”
+mu cusuen lugal$year “ Šu-Suen is king . ”
+dagi$Da’agi ,
+dubsar$the scribe .
+X$For … ,
+X kalga$the strong … ,
+lugal urimakace$king of Ur ,
+X agazi$x-agazi ,
+X sar$…
+pisanduba$Basket-of-tablets
+nuzu ki guzalaeneta$xxx
+pisan abasagace bacigur$xxx
+giri intaea$xxx
+mu guza enlila badim$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+dadaga$Dadaga ,
+ensi$governor
+umma$of Umma ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+kicib daba a hunga$xxx
+lugalebansa dubsar$xxx
+mu harci kimac bahul$xxx
+NUMB sila kac X$one quart … beer ,
+NUMB X X$ten …
+NUMB udu niga saga us$NUMB sheep , barley-fed , of ordNUMB grade ,
+NUMB udu niga NUMBkam us$NUMB sheep of ordNUMB grade ,
+NUMB udu audu hursag niga NUMBkam us$NUMB hybrid mouflon , barley-fed , of ordNUMB grade ,
+NUMB macgal adara niga enlil$NUMB hybrid buck , barley-fed , for Enlil ;
+NUMB udu niga saga us$NUMB sheep , barley-fed , of ordNUMB grade ,
+NUMB udu niga NUMBkam us$NUMB sheep of ordNUMB grade ,
+NUMB udu audu hursag niga NUMBkam us$NUMB hybird mouflon , barley-fed , ordNUMB grade ,
+NUMB macgal adara niga$NUMB hybrid buck , barley-fed ,
+ninlil$for Ninlil ;
+NUMB udu niga NUMBkam us$NUMB sheep , barley-fed , of ordNUMB grade ,
+NUMB udu niga NUMBkam us$NUMB sheep , barley-fed , of ordNUMB grade ,
+n acgar X$NUMB female kids … ,
+ecec e u NUMBce$for the ešeš-celebration of the ordNUMB day ,
+lugal kura$at the king’s entry ;
+iti u NUMB la NUMB bazal$of the month , day NUMB elapsed ,
+ki tahicatalta bazi$booked out from Tahiš-atal ;
+iti ezemah$month : “ Grand Festival , ”
+mu ma darabzu babdu$year : “ The boat called ‘ibex of the Absu’ was caulked . ”
+ninegal$For Ninegal
+ninani$his mistress ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiuri$and king of Sumer and Akkad ,
+eani$her temple
+munadu$he built for her .
+NUMB mana uruda$NUMB minas of copper ,
+kila gur sumun NUMBkam$weight of NUMB old sickles ,
+ki kulita$from Kuli ;
+NUMB mana uruda$NUMB mina of copper ,
+kila gur sumun NUMBkam$weight of NUMB old sickles ,
+ki luginata$from Lugina ;
+NUMB mana uruda$NUMB minas of copper ,
+kila gur sumun NUMBkam$weight of NUMB old sickles ,
+ki X$from …-lu ;
+n gin uruda$NUMB shekels of copper ,
+kila gur sumun NUMBkam$weight of NUMB old sickles ,
+ki X$from …-idim ;
+ekicibace$to the warehouse
+banku$brought ;
+mu usa kimac bahul$year after : “ Kimaš was destroyed . ”
+NUMB gemelugal dumu nana$NUMB ban2 : Geme-lugal , child of Na-na-a ;
+NUMB luninura dumuni$NUMB ban2 : Lu-Ninura , her child ;
+NUMB nincecanasidu$NUMB ban2 : Nin-šeš-ana-sidu ;
+X gura$from … returned ;
+ca ucbar ki urnintu$of weavers , with Ur-nin-tu ;
+uc NUMB gemegigir$dead , NUMB ban2 : Geme-gigir ;
+iti cekargala$month : “ Barley at the quay . ”
+NUMB gu niga$NUMB ox , grain-feden ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+ahuwer$Aḫu-wer
+idab$accepted ;
+iti cueca$month : “ Šu-eša , ”
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed ; ”
+NUMB$: NUMB .
+pisanduba$Basket-of-tablets
+ab ance udu$cows , donkeys , sheep of
+ecucuma$the house of consignments
+niginke$of Nigin ,
+guabake$Guabba ,
+igal$are here ;
+mu guza enlila badim$year : “ The chair of Enlil was fashioned ”
+pisanduba$Basket-of-tablets
+gurumak$inspections
+dumu daba$of the dumu-daba
+ca girsu$in Girsu
+igal$are here ;
+mu X X X bahul$year : “ … was destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak ce$accounts of grain
+lu nigdabkene$of the requisitioners
+girsuta$from Girsu
+guabace$to Guabba ;
+iti X$from month “ … . ”
+iti X$to month “ … , ”
+igal$are here .
+mu huhnuri bahul$year : “ … was destroyed . ”
+meslamtaea$To Meslamtaea ,
+dingiranir$his  god ,
+X$x-kubum ,
+dumu X$son of … ,
+namti$for the life
+ibisuen$of Ibbi-Sîn ,
+pisanduba$Basket-of-tablets
+sagnigura u ziga$xxx
+cabi suga$xxx
+ucmu dubsar kurucda$xxx
+mu NUMB iti NUMBkam$xxx
+igal$xxx
+iti dumuzi$xxx
+mu en eridu bahunta$xxx
+iti dumuzi$xxx
+mu en nanna karzida bahunce$xxx
+pisanduba$Basket-of-tablets
+dub gida$long-tablets of
+gur$scicles
+habuda u uruda$axes and copper ,
+igal$are here ;
+mu en eridu bahun$year : “ The en of Eridu was hired . ”
+n NUMB gamun ge$… NUMB ban2 black cumin ,
+gurdubi NUMBam$its gurdub : NUMB ;
+NUMB mana sikiud$NUMB mana goat hair ,
+gurbi NUMBam$its gur : NUMB ;
+NUMB celu$NUMB barig coriander ,
+dugNUMBbi NUMBam$its vessels of NUMB ban2 : NUMB ;
+NUMB sila igec$NUMB barig NUMB ban2 NUMB sila3 sesame oil ,
+dugbi NUMBam$its vessels : NUMB ;
+NUMB ummu$NUMB water skins ,
+dugbi NUMBam$its vessels : NUMB ;
+ki cabra$from the household manager ;
+NUMB sila NUMB gin icah$NUMB barig NUMB ban2 NUMB sila3 NUMB shekels lard ,
+dugbi NUMBam$its vessels : NUMB ,
+laia ka dug NUMBba NUMB sila$the deficit of the mouth  these NUMB vessels : NUMB sila3 ,
+ki buzuata$from Buzua ;
+ekicibaka banku$brought into the warehouse ;
+ca kargectinka$in Kar-geštin
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+NUMB dusunita$NUMB male equid ,
+bauc u NUMB la NUMBkam$slaughtered , the ordNUMB day ,
+ki cuidimta$from Šu-Idim
+urnigar$Ur-nigar
+cu bati$received ;
+iti ezemana$month : “ Festival of An , ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destroyed , ”
+pisanduba$Basket-of-tablets
+kicib didli$various sealed documents ,
+X bi ec$…
+X$…
+igal$are here .
+pisanduba$Basket-of-tablets
+kabduga$done appraisals
+zulum gectin$of dates , grapes ,
+pec hachur$figs , apples ,
+girsuta$from Girsu
+guabace$to Guabba ,
+igal$are here .
+mu cusuen lugal urimake naruamah enlil ninlilra munedu$year : “ Šū-Suen , king of Ur , Big-stele for Enlil and Ninlil erected . ”
+cusuen$…
+naram enlil$beloved of Enlil ,
+carum$king
+danum$strong ,
+car uri$king or Ur
+u car kibratim$and king of the world quarters
+arbaim$the four .
+NUMB sila$NUMB lamb ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+intaea$Intaea
+idab$accepted ;
+iti sesdagu$month : “ Piglet-feast , ”
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB$NUMB .
+ningal$For Ningal ,
+ninani$his mistress ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+lugalusasa$xxx
+urgigir dumu ginimu$xxx
+lubuluga dumu duga$xxx
+lubaba dumu kibasa$xxx
+urbagara dumu luigisasa$xxx
+lubaba dumu X$xxx
+urbaba dumu urnance$xxx
+lulagac dumu sidu$xxx
+u ninana dumu lugula$xxx
+igal$xxx
+mu enmahgalana en nanna bahun$xxx
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiuri$and king of Sumer and Akkad .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+X$Ur-… ,
+dubsar$scribe ,
+dumu X$son of … ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+ce cukura LAGAB$xxx
+ingal$xxx
+e en nanna$xxx
+karzidaka$xxx
+lukala$Lukalla ,
+dubsar$scribe ,
+dumu ure cuc$son of Ur-E’e , cattle manager .
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents , seized ,
+ca ze$in …
+u X$and …
+luhaia$of Lu-Ḫaya
+igal$are here ;
+mu en inanna unu mace ipa$year : “ The en of Inanna in Uruk by the goat was found . ”
+NUMB dug dida NUMB sila kac saga$NUMB jug wort beer , NUMB sila3 fine beer ,
+NUMB ninda NUMB gin i NUMB gin naga$NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali ,
+NUMB ku NUMB sa cum$NUMB fish , NUMB bundles of garlic
+kurbilak gabac$Kurbilak , off to Persia ;
+NUMB dug dida NUMB sila kac saga$NUMB jug wort beer , NUMB sila3 fine beer ,
+NUMB ninda NUMB gin i NUMB gin naga$NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali ,
+NUMB ku NUMB sa cum$NUMB fish , NUMB bundles of garlic
+urmami sukkal gabac$Ur-Mami , the messenger , off to Persia ;
+NUMB kac NUMB ninda NUMB sila i$NUMB ban2 beer , NUMB ban2 bread , NUMB sila3 oil ,
+cagal kas gabac bala$fodder of the courriers off to Persia , in bala ,
+giri urmami sukkal$via Ur-Mami , the messenger ;
+cunigin NUMB dug dida du NUMB$total : NUMB jugs regular wort beer , NUMB ban2 ,
+cunigin NUMB kac saga cunigin NUMB kac du$total : NUMB ban2 fine beer , total : NUMB ban2 regular beer ,
+cunigin NUMB ninda cunigin NUMB sila NUMB gin i$total : NUMB barrage bread , total : NUMB sila3 NUMB shekels oil ,
+cunigin NUMB gin naga$total : NUMB shekels alkali ,
+cunigin NUMB ku cunigin NUMB sa cum$total : NUMB fish , total : NUMB bundles of garlic ;
+u NUMBkam$ordNUMB day ,
+iti lisi$month “ Lisi , ”
+mu en eridu bahun$year : “ The lord of Eridu was installed . ”
+pisanduba$Basket-of-tablets
+kicib didli$xxx
+X lusaga$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+gurumak daba$xxx
+erin sagapin$xxx
+u ugIL$xxx
+e culgi$xxx
+igal$xxx
+mu cacrum bahul$xxx
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+a uda$xxx
+egu nibru$xxx
+igal$xxx
+mu en eridu bahun$xxx
+NUMB sar al ak NUMB sarta$NUMB sar hoed at NUMB sar each ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar kul kura NUMB sarta$NUMB sar kul-grass cut at NUMB sar each ,
+abi u NUMBkam$its labor : NUMB days ;
+a cagu$labor of the oxen men ,
+aca nuna$field of Prince ,
+ugula lugalkugani$foreman : Lugal-kugani ,
+kicib lugalinimgina$seal of Lugal-inimgina
+mu ma enki babdu$year : “ The boat of Enki was caulked . ”
+lugalinimgina dubsar$Lugal-inimgina
+dumu lugalnesage$son of Lugal-nesage .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+gur habuda$xxx
+urningeczida$xxx
+nabasa$xxx
+u urcugalama$xxx
+mu cusuen lugal urimake bad martu muriqtidnim mudu$xxx
+NUMB kid cerum$NUMB šerrum reed-mats ,
+kilabi NUMB sar$their size is NUMB sar .
+NUMB kid$NUMB reed-mats ,
+kilabi NUMB sar$their size is NUMB sar .
+NUMB gur NUMBta esir suba$NUMB bitumen-coated gur-baskets ,  NUMB barig each .
+ki aguta$From Agu .
+kicib ludingira$Sealed document of Lu-dingira .
+ma ninda ma zi badul$Covering the bread boat and the flour boat .
+mu enmahgalana bahun$Year : “ Enmahgalana was installed ” .
+ludingira$Lu-dingira ,
+dubsar$the scribe ,
+dumu anduru$son of A’anduru .
+urmes$Ur-mes ,
+dumu lana kurucda$son of Lana , fattener .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+lubimu$xxx
+dumu urigalim$xxx
+igal$xxx
+mu kimac bahul$xxx
+ababacti$Ti'āmat-bāštī ,
+X X$the beloved lukur-priestess
+cusuen$of Šū-Sîn ,
+X urimaka$king of Ur .
+NUMB ce gur lugal$NUMB gur NUMB barig NUMB ban2 barley , ,
+ki urdamuta$from Ur-Damu ;
+NUMB ki urlamma dumu lusuenta$NUMB gur NUMB barig NUMB ban2 from Ur-Lamma , son of Lu-Suen ;
+cunigin NUMB ce gur$total : NUMB gur NUMB ban2 barley ;
+cabita$therefrom
+NUMB GAN NUMBta$NUMB bur3 NUMB eše3 NUMB iku field area ;
+NUMB GAN NUMB silata$NUMB bur3 NUMB eše3 NUMB iku field area ;
+NUMB GAN NUMBta$NUMB bur’u , NUMB bur3 NUMB eše3 NUMB iku field area .
+cebi NUMB sila gur$the barley : NUMB gur NUMB barig NUMB sila ;
+muku$delivery ;
+X X$Lu-… ,
+dada dumu urgula$Dada , son of Ur-gula ;
+acamah$Great-Field ;
+nigkak$running account ,
+mu amarsuen lugal$year : “ Amar-Suen is king . ”
+pisanduba$Basket-of-tablets
+ce udu gua$xxx
+ca nibru$xxx
+igal$xxx
+bala egir$xxx
+mu simurum bahul$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urculgira$Ur-Šulgira ,
+dubsar$scribe ,
+dumu X$son of Ur-… ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+girisega gu apinlace$xxx
+ugula abakala$xxx
+u urnumucda$xxx
+e gatumdu$xxx
+e bagara$xxx
+u e uru$xxx
+igal$xxx
+mu guza enlila badim$xxx
+pisanduba$Basket-of-tablets
+gurumak sipa unu$inspections of shepherds , cowherds
+ca kinunir$in Kinunir ,
+kiesa$Ki’eša ,
+kiesa$Ki’eša ,
+e dingirene$houses of the gods ,
+e dingirene$houses of the gods ,
+ca ec sadu$in the shrine of offerings
+culgi kinunir$of Šulgi in Kinunir ,
+igal$are here ;
+mu urbilum bahul$year : “ Urbilum was destroyed . ”
+gec gi$Lumber , reed ,
+u dusu$and wooden containers ,
+muku$delivery ,
+ca emace$to the midst of the goat-house ,
+igal$are here ;
+ecucuma$house-of-receipt
+ca emacka$in the midst of the goat-house ,
+muku e anzagar$delivery , house of tower ;
+pisanduba$basket-of-tablets
+cagal udu niga saga$fodder of rams , grain-fed , fine ,
+u HARrasun udu$and … rams ,
+igal$are here .
+lugal kalga$the strong man/king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+NUMB mana$NUMB minas ,
+ekiciba nanna gara$Nanna's Established Sealed-items Storeroom ,
+munagin$he standardized for him .
+NUMB sila gi$NUMB male lamb ,
+NUMB sila ga gi$NUMB male suckling lamb ,
+ca wadaltum$in Wadaltum ;
+NUMB sila$NUMB male lambs ,
+NUMB sila ga$NUMB male suckling lambs ,
+bauc u NUMBkam$slaughtered , ordNUMB day ;
+ki culgiamuta$from Šulgi-ayamu
+urnigar$Ur-nigar
+cu bati$received ;
+iti ezemninazu$month : “ Festival of Nin-azu , ”
+mu amarsuen lugale urbilum muhul$year : Amar-Suen , the king , Urbilum destroyed ;
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+niginba ziga lugal$xxx
+gabari kicibaka$xxx
+mu huhunuri bahulta$xxx
+mu en nanna karzida bahunce$xxx
+inanna$To Inanna
+ninani$her mistress ,
+namti$for the life
+culgi$of Šulgi ,
+nita kalga$the mighty man ,
+lugal urimakace$king of Ur ,
+diritum$Diritum ,
+X X ni$his … ,
+pisanduba$Basket-of-tablets
+nigkak$accounts ,
+situm ce sumun$debits , old barley ,
+X egara laia X$… , debts , … ,
+igal$are here ;
+mu en nanna ipa$year : “ The en of Nanna was found . ”
+pisanduba$Basket-of-tablets
+dub gida$long-tablets
+ce cukura ensi$barley allocations of the governor
+giri urnigar$via Ur-Nigar ,
+dumu urigalim$son of Ur-Igalim ,
+igal$are here ;
+mu usa kimac bahul$year following : “ Kimaš was destroyed . ”
+pisanduba$Basket-of-tablets
+kicib daba ceckala nubandagu$xxx
+iti NUMBkam igal$xxx
+iti cesagku$xxx
+mu cusuen lugal urimake naruamah enlil ninlilra muneduta$xxx
+iti cesagku$xxx
+mu cusuen lugal urimake mada zabcali muhulce$xxx
+NUMB mac$NUMB goats ,
+mac ucima$pastured goats ;
+NUMB u gukkal$NUMB fat-tailed ewes ,
+bauc$slaughtered ;
+giri ningirsukaisa$via Ningirsuka-isa ,
+ziga$booked out ;
+iti ceila$month : “ Barley transported , ”
+mu cacrum bahul$year : “ Šašrum was destroyed . ”
+pisanduba$Basket-of-tablets
+kicib ceba bala$xxx
+ki ARADta$xxx
+kicib urcara$xxx
+mu lugirizalce$xxx
+mu urbilum bahul$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+dugan cabi suga$pouches , therefroms , restitiutions ,
+lu nigdabakene$of the men of nigdab ,
+mu NUMBkam$NUMB years ;
+igal$are here ;
+mu usa ara NUMBkam simurum bahulta$from the year following : “ For the ordNUMB time Simurum was destroyed ”
+mu nanna karzidace$to the year : “ Nanna of Karzida . ”
+NUMB mana gina$NUMB verified mina
+lunincubur$Lu-Ninšubur
+NUMB udu u$NUMB sheep , grass-fed ,
+NUMB macgal u$NUMB bucks , grass-fed ,
+NUMB sila$NUMB lambs ,
+NUMB mac$NUMB kids ,
+bauc u NUMBkam$slaughtered , the ordNUMB day ,
+ki urkununata$from Ur-kununa
+culgirimu$Šulgi-irimu
+cu bati$received ;
+giri nannamaba$via Nanna-maba
+u lucalim$and Lu-šalim ;
+iti ezemana$month : “ Festival of An , ”
+mu cusuen lugal urimake e cara ummaka mudu$year : “ Šu-Suen , king of Ur , the house of Šara in Umma erected ; ”
+NUMB udu$NUMB small cattle .
+pisanduba$Basket-of-tablets
+ce gec ea$barley threshed ,
+GANgu$oxen fields ,
+u ce apinlada ba$and barley plowed distributed ,
+igal$are here ;
+mu usa cusuen lugale bad martu mudu$year following : “ Šu-Suen , the king , the Amorite wall erected . ”
+egir buruce$After the harvest ,
+laia i$the oil deficit
+ahit,abe$Aḫi-ṭāb
+gabsu bindu$declared , “ I will replace it! ”
+mu lugalbi inpa$He swore by the royal name ;
+tukumbi nunsu$If he has not replaced it ,
+cerdam$it is a capital crime ;
+NUMB iniminannace$one Inim-Inanna-še ,
+NUMB lugalitida$one Lugal-itida ,
+NUMB lugina$one Lu-gina ,
+NUMB ursaga$one Ur-saga ,
+NUMB urkununa$one Ur-kununa ,
+luinimabime$are the witnesses ;
+iti cesagku$month : “ Harvest , ”
+mu urbilum bahul$year : “ Urbilum was destroyed . ”
+X$…
+NUMB X$NUMB ban2…
+NUMB X$NUMB ban2…
+nubandagu X$oxen-manager …
+NUMB X$NUMB ban2 …
+NUMB X$NUMB ban2 …
+NUMB sila X$NUMB ban2 NUMB sila3 : …
+nubandagu X$the oxen-manager …-x
+NUMB dumu lunincubur$NUMB ban2 NUMB : the son of Lu-Ninšubur ;
+NUMB dumu urmami$NUMB ban2 : the son of Ur-Mami ;
+NUMB dumu urnamana$NUMB ban2 NUMB : the son of Ur-nam-anna ,
+nubandagu ceckala dumu gudun$oxen-manager of Šeškalla , son of Gu-dun ;
+NUMB dumu urama$NUMB ban2 : son of Uramma ,
+nubandagu lugalnesage$the oxen-manager of Lugal-nesage ;
+NUMB dumu urgigir$NUMB ban2 NUMB : son of Ur-gigir ,
+nubandagu ceckala dumu dada$the oxen driver of Šeškalla , son of Dada ;
+NUMB dumu adaga$NUMB ban2 NUMB : son of Adaga ,
+nubandagu urlugal$the oxen-manager of Ur-lugal ;
+cunigin NUMB sila ce sumun gur$total : NUMB barig NUMB ban2 NUMB sila3 old grain ,
+ceba dumu cagu$barley rations of sons of oxen-drivers
+kisu aca ninurata$from the threshing floor of the field Nin-ura ;
+iti dumuzi$month : “ Dumuzi , ”
+mu mada zabcali bahul$year : “ the lands of Zabašali were destroyed . ”
+lucalim$Lu-salim ,
+dumu X$son of Lugal-… .
+NUMB ce gur lugal$NUMB gur NUMB barig barley ,
+ceba zamukace$for the barley ration of the new year ,
+ekikkenta$from the millhouse ,
+gabus aria$the assistant herder …
+ninagsukake$did Nin-Nagsuka
+cu bati$receive ;
+iti dal$month “ Flight , ”
+mu usa en eridu bahun$year following “ The lord of Eridu was installed . ”
+pisanduba$Basket-of-tablets
+mu didli$xxx
+gurua taka$xxx
+ca kinunir nigin$xxx
+u guaba$xxx
+igal$xxx
+mu urbilum bahul$xxx
+NUMB acgar euzga$NUMB female kid , in the uzga-house ,
+ARADnanna muhaldim mackim$Arad-Nanna , the cook , was enforcer ;
+NUMB udu niga NUMB sila$NUMB sheep , grain-fed , NUMB lamb ,
+bizua$Bizua ;
+NUMB udu niga NUMBkam us$NUMB sheep , grain-fed , ordNUMB grade ,
+NUMB udu niga NUMBkam us$NUMB sheep , grain-fed , ordNUMB grade ,
+dada gala$Dada , castrate ;
+NUMB udu niga NUMBkam us$NUMB sheep , grain-fed , ordNUMB grade ,
+NUMB udu niga NUMBkam us$NUMB sheep , grain-fed , ordNUMB grade ,
+urningubalag nar$Ur-Ningubalag , the cantor ;
+ca mukurata$from among the deliveries ;
+u NUMB la NUMBkam$the ordNUMB day ,
+ki intaeata bazi$from Intaea booked out ;
+giri nannamaba dubsar$via Nanna-maba , the scribe ;
+iti ezemculgi$month : “ Festival of Šulgi , ”
+mu cusuen lugal$year : “ Šu-Suen is king ; ”
+NUMB la NUMB udu$NUMB sheep .
+pisanduba$Basket-of-tablets
+sadu kecra$regular rations of … ,
+e nindingir baba$house of the priestesses of Baba ,
+kicib inimbaba cabra$sealed documents of Inim-Baba , chief house administrator .
+pisanduba$Basket-of-tablets
+nigkak cas,e$accounts of …
+igal$are here ;
+mu guzata$from the year : “ The chair ”
+mu enmahgalanace$to the year : “ Enmaḫgalanna . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+culgirimu sukkal$Šulgi-irimu , courrier ,
+ragaba$rider ,
+ARADzu$is your servant .
+ibisuen$Ibbi-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+luningirsu$Lu-Ningirsu ,
+dubsar$scribe ,
+dumu lubaba$son of Lu-Baba ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+gurum ak girisega$xxx
+sag engar erin ugIL$xxx
+girisega gu nigakam$xxx
+e ningirsu$xxx
+igal$xxx
+mu madarabzu babdu$xxx
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents , … ,
+kicib namcatam$sealed documents , official ,
+X nam aca apisal$… of the fields of Apisal
+u gudena$and Gu’edina
+u mucbiana$and Mušbiana ,
+igal$are here ;
+mu amarsuen lugalam$year : “ Amar-Suen is king . ”
+NUMB ab a am mu NUMB$NUMB cow , seed of wild bull , third year ;
+NUMB sila$NUMB lamb ;
+bauc u NUMBkam$slaughtered , ordNUMB day ;
+ki zubagata$from Zubaga
+culgirimu$did Šulgi-irimu
+cu bati$receive ;
+iti sesdagu$month : “ Piglet-feast , ”
+mu en nanna karzida bahun$year : “ Lord of Nanna in Karzida installed , ”
+NUMB gu NUMB udu$NUMB ox , NUMB sheep .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lusuen$Lu-Suen ,
+dumu X$son of A-… ,
+ARADzu$is your servant .
+NUMB dug dida NUMB sila kac saga $NUMB jug wort , NUMB sila3 fine beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ,
+urnigar sukkal gabac $for Ur-nigar , the messenger , to the frontier ;
+NUMB dug dida NUMB sila kac $NUMB jug wort , NUMB sila3 beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ;
+cutu gabac $for Šū-Utu , to the frontier ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundle onions ,
+culgikiursa kausa $for Šulgi-ki’ursa , the ka’usa ;
+cunigin NUMB dug dida du NUMB $total : NUMB jugs of common wort , NUMB ban2 ;
+cunigin NUMB sila kac saga cunigin NUMB sila kac $total : NUMB sila3 fine beer ; total : NUMB sila3 beer ;
+cunigin NUMB sila ninda cunigin NUMB gin i $total : NUMB ban2 NUMB sila3 bread ; total : NUMB shekels oil ;
+cunigin NUMB gin naga $total : NUMB shekels alkali-plant ;
+cunigin NUMB sa cum $total : NUMB bundles onions ;
+u NUMBkam $ordNUMB day ,
+iti diri $month : “ Extra , ”
+mu simanum bahul $year : “ Simanum was destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+ipalis dubsar gur habuda$xxx
+igal$xxx
+iti ezemculgi$xxx
+mu huhnuri bahulta$xxx
+iti cugargal$xxx
+mu en nanna karzida bahunce$xxx
+mubi mu NUMBam$xxx
+pisanduba$Basket-of-tablets
+a uda$xxx
+e cusuen lugal$xxx
+igal$xxx
+giri lugudea$xxx
+mu madarabzu enki babdu$xxx
+n X ki X$…
+NUMB n X ki X$NUMB …
+NUMB sila ki X$NUMB lambs from …
+NUMB sila ki X$NUMB lambs from …
+NUMB sila ki acqudumta$NUMB lambs from Ašqudum
+NUMB udu ki X$NUMB sheep from …
+NUMB udu muku X$NUMB sheep delivery of …
+NUMB sila ki latenicta$NUMB lamb from Lateniš ,
+NUMB$NUMB .
+cabita$Therefrom
+NUMB udu sadu$NUMB sheep , the regular offerings
+NUMB sila ninkununa$NUMB lambs for Ninkununa
+NUMB sila X$NUMB lamb for …
+NUMB sila lugaluda$NUMB lambs for Lugaluda
+NUMB la NUMB$NUMB
+ziga lugal$booked out for the king ;
+NUMB udu ca egalce acqudanum$NUMB sheep into the palace …
+n udu ka nanna$NUMB sheep of the gate of Nanna ?
+NUMB udu X dam alamu$NUMB sheep , … the wife ? of Alamu ;
+NUMB udu laia alamu$NUMB sheep , deficit of Alamu
+NUMB$NUMB
+NUMB X da X guba$NUMB …
+NUMB X$NUMB …
+NUMB udu X$NUMB sheep …
+NUMB X cabra X$NUMB sheep … for the chief administrator .
+X$…
+pisanduba$Basket-of-tablets
+ce zida$of barley and flour ,
+kicib urzu$sealed documents of Urzu
+u kicib ugula kikkenakene$and sealed documents of the foremen of the millworks ,
+igal$are here ;
+mu kimac bahul$year : “ Kimaš was destroyed . ”
+akala$Akalla ,
+dubsar$scribe ,
+dumu urnigar cuc$son of Ur-nigar , cattle manager .
+egalesi$Egalesi ,
+dubsar$scribe ,
+dumu lucara$son of Lu-Šara ,
+saduka$chief surveyor .
+pisanduba$Basket-of-tablets
+gurumak$inspections ;
+lu marsa$shipyard laborers
+ca girsu$in Girsu ,
+mu en nanna$year : “ The en of Nanna ; ”
+lu marsa$shipyard laborers ,
+ca nigin$in Nigin ,
+mu usa e puzuricdagan badua$year following : “ The house of Puzris-daga was erected ; ”
+lu marsa$shipyard laborers ,
+madga$of Madga ,
+lu marsa$shipyard laborers ,
+ca guaba$in Guabba
+mu X$year : “ … . ”
+kubatum$Kubātum ,
+lukur kiag$the beloved lukur-woman
+cusuen$of Šū-Sîn .
+nanna$To Nanna
+lugalani$his master ,
+namti$for the life
+X$of …
+pisanduba$Basket-of-tablets
+kia cuku dudua$… allocation …
+e nance$of the house of Nanše
+u e nindara$and the house of Nindara
+igal$are here ;
+mu$year : “ … . ”
+NUMB geme u NUMBce$NUMB female laborer workdays ,
+a ide uca$water to the river , … ;
+ugula kugani$foreman : Kugani ,
+mu usa ancan bahul$year after : “ Anšan was destroyed . ”
+akala$Akalla ,
+dubsar$scribe ,
+dumu X$son of …
+X$…
+ninani$his mistress ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur ,
+X X X$…
+pisanduba$Basket-of-tablets
+etum$xxx
+gurum ak$xxx
+giri X$xxx
+igal$xxx
+mu simurum lulubu$xxx
+NUMB udu cugid$NUMB šugid-sheep ,
+NUMB u cugid$NUMB šugid-ewes
+X sila gaba lugal$NUMB semi-weaned lamb ,
+NUMB mac cugid$NUMB bucks ,
+euNUMB NUMB$for “ House Day NUMB ” ;
+iti u NUMB bazal$of the month day NUMB elapsed ,
+ki naluta$from Nalu ,
+nasa idab$Nasa accepted .
+iti ezemninazu$month : “ Festival of Ninazu , ”
+mu simurum u lulubu ara NUMB la NUMBkam bahul$year : “ Simurum and Lulubu for the ordNUMB time were destroyed . ”
+n dug dida saga NUMB$NUMB jugs of good quality wort , each NUMB ban2 ,
+n dug dida du NUMB$NUMB jugs of ordinary wort , each NUMB ban2 ,
+NUMB zigu saga$NUMB ban2 good quality pea-flour ,
+NUMB dabin NUMB zulum$NUMB barig semolina , NUMB barig dates ,
+NUMB udu NUMB mac$NUMB rams , NUMB billy ,
+NUMB sila igec duga$NUMB sila3 good sesame oil ,
+NUMB sila igec$NUMB sila3 sesame oil ,
+NUMB gurdub$NUMB gurdub ,
+nuhilum elam$Nuḫi-ilum of Elam ,
+cu bati$received ;
+iti dumuzi$month : “ Dumuzi , ”
+mu usa cusuen lugale bad martu mudu$year after : “ Šu-Suen , the king , the Amorite wall erected . ”
+pisanduba$Basket-of-tablets
+gurumak$inspections
+NUMB gin kubabbar$NUMB shekels silver ,
+a X$labor of Ur-dukuga ,
+mu NUMBam anaDU$in one year … ,
+ki PAuta$from PA’u
+urdukugake$did Ur-dukuga
+cu bati$recieve ;
+tukumbi$if
+u NUMBam gala indag$for NUMB day he does not work ,
+ce NUMBta ageda$that NUMB ban2 barley for each  will be weighed out ,
+mu lugalbi inpa$the royal name he invoked ;
+NUMB PAda$NUMB PAda ,
+NUMB urtumal sadu$NUMB Ur-Tummal , chief surveyor ,
+NUMB ceckala dumu dudu$NUMB Šeškalla , son of Dudu ,
+luinimabime$are the witnesses ;
+iti NENEgar u NUMB bazalta$from month : “ NENEgar , ” the ordNUMB day completed ,
+mu simurum bahul$year : “ Simurrum was destroyed . ”
+pisanduba$Basket-of-tablets
+gurumak$inspections
+giri aga$via Aga
+malah X X X X$boatmen … ,
+lu marsakene$harbor laborers ,
+u burbi$and …
+girsuta$from Girsu
+guabace$to Guabba ,
+igal$are here ;
+mu guza enlila badim$year : “ The chair of Enlil was fashioned . ”
+NUMB udu niga$NUMB sheep , barley-fed ,
+inanna$for Inanna ;
+NUMB udu niga gula$NUMB sheep , barley-fed , for Gula ,
+nanceGIRgal mackim$Nanše-GIRgal , responsible official ;
+iti u NUMB bazal$of the month , day NUMB elapsed ,
+ziga$booked out
+ca unu$in Uruk ,
+ki nalu$from Nalu ;
+iti ezemninazu$month : “ Festival of Ninazu , ”
+mu kimac bahul$year : “ Kimaš was destroyed . ”
+pisanduba$Basket-of-tablets
+im nig kacdea lugal$xxx
+giri urnungal$xxx
+mu amarsuen lugale urbilum muhul$xxx
+n NUMB mer hi$… NUMB , north , averaged ,
+n NUMB kur hi$… NUMB , east , averaged ,
+n GAN bar NUMB ki$… surface , outside , NUMB eše3 NUMB iku , inside ;
+aca NUMB X NUMB GAN$field : NUMB bur3 … NUMB iku , surface ;
+NUMB X GAN NUMB$NUMB eše3 NUMB iku … surface , NUMB  NUMB barig ;
+NUMB GAN NUMB$NUMB eše3 NUMB iku surface , NUMB  NUMB ban2 ;
+NUMB GAN NUMB$NUMB eše3 NUMB iku surface , NUMB ;
+NUMB GAN NUMB$NUMB eše3 NUMB iku surface , NUMB  NUMB barig ;
+n NUMB GAN su$… NUMB iku surface , fallow ;
+cebi X$its barley : … ;
+ludingira engar$Lu-dingira , the ploughman ;
+GANgu ka$oxen-field of Fox ;
+NUMB mer hi$NUMB , north , averaged ,
+NUMB kur hi$NUMB , east , averaged ;
+NUMB GAN bar NUMB ki$NUMB eše3 NUMB iku surface outside , NUMB eše3 NUMB iku inside ;
+aca NUMB GAN$field : NUMB bur3 NUMB iku surface ;
+NUMB X GAN X$NUMB bur3 NUMB eše3 … surface … ;
+NUMB GAN X$NUMB bur3 NUMB iku surface … ;
+NUMB GAN X$NUMB bur3 NUMB iku surface … ;
+X X X$…
+GAN kabduga$surface , inspected ;
+aca X$field Bur… ,
+giri X$via … ;
+mu usa X X lulubum ara NUMB la NUMBkamac bahul$year after : “ … Lullubum for the ordNUMB time destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak a hedab$xxx
+mu madarabzu$xxx
+mu simanum$xxx
+urbaba$xxx
+X tu bad$xxx
+X X$xxx
+X mah$xxx
+X du$xxx
+X ursuen$xxx
+mu naruamah$xxx
+duganizi$xxx
+u dub gidabi$xxx
+igal$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urnungal$Ur-Nungal ,
+dubsar$scribe ,
+dumu urcara$son of Ur-Šara ,
+ARADzu$is your servant .
+NUMB udu cimacgi gecdu u$NUMB sheep , Šimaškian , breeder , grass-fed ,
+ribagada$Ribagada ,
+ca mukurata$from the delivery ,
+u NUMBkam$on the ordNUMB day ,
+ki intaeata bazi$out of  Intaea was booked ;
+giri nursuen dubsar$via Nur-Suen , scribe ;
+iti ezemcusuen$month : “ festival of Šu-Suen , ”
+mu cusuen lugal urimake mada zabcali muhul$year : “ Šu-Suen , king of Ur , destroyed the land of Zabšali . ”
+NUMB udu$NUMB sheep .
+NUMB sila cecdada sanga$NUMB lambs , Šeš-dada , household administrator ;
+NUMB sila ensi nibru$NUMB lambs , governor of Nippur ;
+NUMB sila zabardab$NUMB lambs , the zabardab ;
+NUMB sila lunanna$NUMB lamb , Lu-Nanna ;
+NUMB mac zige nubanda$NUMB male goat , Zige , the manager ;
+NUMB mac mealam nubanda$NUMB male goat , Mealam2 , the manager ;
+NUMB gu niga NUMB la NUMB udu$NUMB ox , grain-fed , NUMB less NUMB sheep ,
+NUMB macgal NUMB mac$NUMB full-grown male goat , NUMB male goat ,
+culgihamati$Šulgi-ḫamati ;
+NUMB X X$NUMB … ;
+NUMB X X$NUMB … ;
+NUMB sila itrakili$NUMB lamb , Itraq-ilī ;
+NUMB sila nada$NUMB lamb , Nada ;
+muku$delivery ;
+iti cesagku$month : “ Harvest , ”
+mu kimac u hurti bahul$year : “ Kimaš and Hurti were destroyed ; ”
+u NUMBkam$ordNUMB day .
+pisanduba$Basket-of-tablets
+adea gec bala dea$Irrigation , … ,
+cabrane$of the chief household administrators
+niginba bara kar$grand totals of barakara ,
+girsuta$from Girsu
+guabace$to Guabba ,
+nigkak erin gizi$accounts of troops of fodder-reed ,
+igal$are here ;
+mu lugale cacrum muhul$year : “ The king Šašrum destroyed . ”
+pisanduba$Basket-of-tablets
+dub gida$long-tablets ,
+udu ceta sa$sheep with grain exchanged ,
+igal$are here ;
+pisanduba$Basket-of-tablets
+gu sila engarene$oxen … of the plowmen ,
+gu sila unude$oxen … of the cattle herdsmen ,
+udu namena$rams of lordship ,
+gabari im egala kura$copies of tablets , into the palace delivered ;
+mu amarsuen lugal u mu amarsuen lugale urbilum muhul$year : “ Amar-Suen is king ” and year : “ Amar-Suen , the king , Urbilum destroyed ”
+caba ingal$herein are .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+sagnigura$xxx
+lubaba dumu utubara$xxx
+urbadkura$xxx
+urningirsu sukkal kas$xxx
+u akala dumu$xxx
+ursaga$xxx
+igal$xxx
+mu en inanna$xxx
+mace ipa$xxx
+pisanduba$Basket-of-tablets
+kicib daba$xxx
+agu dubsar gacam$xxx
+igal$xxx
+mu cusuen$xxx
+lugal urima$for the king of Ur
+lugal kiengi kiurikace$and king of Sumer and Akkad ,
+urmes$Urmes ,
+dumu ilamlamuma$the son of Ilamlammuma
+a munaru$dedicated  to him .
+NUMB udu niga$NUMB sheep , barley-fed ,
+siskur dingirne$siskur-offering ofs ;
+NUMB macgal$NUMB buck
+kac nagce$for “ beer-drinking , ”
+giri ninhamati$via Ninḫamati ;
+NUMB gu niga bauc$NUMB ox , barley-fed , slaughtered ;
+ziga ki kalamhenagita$booked out from Kalam-ḫenagi ,
+itita u NUMB barazal$of the month , day NUMB elapsed ;
+iti cesagku$month : “ Harvest , ”
+mu usa kimac u hurti bahul$year after : “ Kimaš and Ḫurti were destroyed . ”
+NUMB udu$NUMB sheep
+siskur kisu aca GANmah$for the threshing-floor sacrifice of the field GAN-maḫ ,
+ki urhalmucata$from Ur-Ḫalmuša ,
+kicib luhaia$under seal of Lu-Ḫaya ;
+mu cusuen lugale magurmah enlil ninlilra munedu$year : “ Šu-Suen the king built the great-barge for Enlil and Ninlil . ”
+luhaia$Lu-Ḫaya ,
+dubsar$scribe ,
+dumu ure cuc$son of Ur-e’e , cattle manager .
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents , taken ,
+lugalsaga ugula ucbar$Lugal-saga , foreman of weavers ,
+mu NUMBkam$NUMB years ;
+igal$are here .
+nanna$For Nanna ,
+dumu sag$the first-born son
+enlila$of Enlil ,
+lugal kiaganir$his beloved master ,
+cusuen$Šū-Sîn ,
+kiag nanna$the beloved of Nanna ,
+lugal enlile$the king whom Enlil
+cagana$in his heart
+inpa$did choose
+sipa kalama$as the shepherd of the country
+u an ubda limmubace$and of the four world quarters ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+e murianabak$the Murianabak Temple ,
+e kiagani$his beloved temple ,
+munadu$he built for him .
+NUMB ziz gur lugal$NUMB gur NUMB ,
+NUMB X gig gur lugal$,
+ki luigimaceta$from  Lu-igimaše ,
+kicib urlamma dumu urbaba$under seal of Ur-Lamma , son  Ur-Baba ,
+idub aca arcatianindarata$;
+iti ezemculgi$month “ Festival of Šulgi , ”
+mu simurum u lulubum ara NUMB la NUMBkamac bahula$year “ Simurum and Lullubum for the ordNUMB time were destroyed . ”
+urlamma$Ur-Lamma ,
+dubsar$scribe ,
+dumu urbaba$son  Ur-Baba .
+pisanduba$Basket-of-tablets
+kicib daba urama nubandaguka$xxx
+iti NUMBkam igal$xxx
+iti cesagku$xxx
+mu cusuen lugal urimake naruamah enlil ninlilra muneduta$xxx
+iti cesagku$xxx
+mu cusuen lugal mada zabcali muhulce$xxx
+X X X$… ,
+lugal urima$the king of Ur ,
+pisanduba$Basket-of-tablets
+dub gida$long-tablets
+lu nigdabkene$of the requisitioners
+igal$are here ;
+mu cacrum bahul$year : “ Šašrum was destroyed . "
+pisanduba$Basket-of-tablets
+X X daba$xxx
+X$xxx
+X X$xxx
+X X$xxx
+X sila gal$xxx
+X ance$xxx
+X tug X$xxx
+igal$xxx
+mu kimac$xxx
+NUMB udu$NUMB ram ,
+bauc u NUMBkam$slaughtered , ordNUMB day ;
+ki tahicatalta$from Tahiš-atal
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti sesdagu$month : “ Piglet feast , ”
+mu cusuen lugale madara abzu enkika bindim$year : “ Šu-Suen , the king , the boat “ Ibex-of-apsû ” of Enki fashioned ; ”
+NUMB$NUMB .
+nanna$For Nanna ,
+lugalani$his master ,
+culgi$did Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur ,
+lugal an ubda limmubake$king of the four world quarters ,
+NUMB mana$NUMB mina
+munagin$standardize .
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+babati$to Babati ,
+dubsar$scribe ,
+ARADzu$is your servant .
+NUMB sila kac NUMB sila ninda$NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i$NUMB shekels oil ,
+abuni lu zah dabde gena$Abuni , gone away to capture runaways ;
+NUMB sila kac NUMB sila ninda$NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin iudu$NUMB shekels oil , NUMB shekels tallow ,
+idizu lu tukulgula$Idizu , big-gendarme ;
+NUMB sila kac NUMB sila ninda$NUMB sila3 beer , NUMB sila3 <bread> ,
+NUMB gin i$NUMB shekels oil ,
+cuera$Šu-Erra ;
+ziga u NUMB$booked out , ordNUMB day ,
+iti ceila$month : “ Grain lifted ” .
+lugalanir$for his master ,
+cusuen$Šū-Sîn ,
+kiag enlila$the beloved of Enlil ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+pisanduba$Basket-of-tablets
+dugan cabi suga$xxx
+kac zi i$xxx
+ekas$xxx
+ca girsu$xxx
+ca guaba$xxx
+u ceba gua ca girsu$xxx
+igal$xxx
+mu enamgalana en inanna unu bahun$xxx
+pisanduba$Basket-of-tablets
+dubgida$long-tablets ,
+lu nigdab ca ugnimakene$men of seizures of Ugnim ,
+mu didli ce erine gua$various years , barley to the troops fed ,
+egalka$in the palace ,
+igal$are here ;
+iti diri cesagkuta$from extra month “ Harvest , ”
+iti ceilace$to month “ Barley-lifted , ”
+iti NUMBkam$of NUMB months ,
+iti diribi NUMBam$its extra month NUMB ;
+mu usa en nanna mace ipa$year following : “ The en of Nanna by the goat was found . ”
+pisanduba$Basket-of-tablets
+X X GAN$xxx
+X gec X dugec$xxx
+X$xxx
+X karzida$xxx
+igal$xxx
+iti ezemculgita$xxx
+iti ezemekigalce$xxx
+itibi NUMBam$xxx
+mu culgi$xxx
+nita kalga$xxx
+lugal urima$xxx
+lugal an ubda limmubake$xxx
+bad mada$xxx
+mudua$xxx
+nanna$For Nanna
+karzida$of Karzida ,
+lugal kiaganir$his beloved master ,
+amarsuen$Amar-Suena ,
+enlile$whom Enlil
+nibrua$in Nippur
+mu pada$chose by name ,
+sagus$the constant supporter
+e enlilka$of the temple of Enlil ,
+dingir zi$true god ,
+utu kalamana$the Utu of his land ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+karzida$in Karzida ,
+u uliata$where since ancient times
+geparbi nuduam$its Gipar residence had not been built ,
+en nuntilam$and no en-priestess had lived therein ,
+amarsuen$Amar-Suena ,
+kiag nannake$the beloved of Nanna ,
+gepar kugani$his sacred Gipar
+munadu$he built for him ,
+en kiagani$and his beloved en-priestess
+munaniku$he made enter it for him .
+amarsuenke$Amar-Suena
+u imdabsure$shall therewith prolong his days .
+namtilanice$For his life
+a munaru$he dedicated it to him .
+NUMB ce gur lugal$NUMB gur , NUMB barig NUMB ban2 barley ,
+NUMB ziz gur$NUMB gur emmer ,
+NUMB gig gur$NUMB gur , NUMB barig NUMB ban2 wheat ,
+ki ARADta$from ARAD ;
+NUMB ce gur$NUMB gur barley ,
+laia suga bida$deficit restored by Bida ;
+cunigin cebi NUMB gur$total , barley involved : NUMB gur , NUMB barig NUMB ban2 ;
+NUMB geme NUMB$NUMB female laborers , ,
+iti nesag$from month “ First-offering , ”
+mu harci kimac bahulta$year “ Harši and Kimaš were destroyed , ”
+iti dumuzi u NUMBam zalac$to month “ Dumuzi ” , the completed day NUMB ,
+abi NUMBkam$labor involved : NUMB ;
+sagnigurakam$it is the debit ;
+cabita$Therefrom
+NUMB geme u NUMBce$NUMB female laborer workdays ,
+a geme udua$labor of the female laborers , “ free ” days ;
+NUMB sila dabin gur$NUMB gur , NUMB barig NUMB sila3 dabin flour
+NUMB sila dabin gur$NUMB gur , NUMB barig NUMB ban2 NUMB sila3 dabin flour
+biguce ea siga$for the loss  into the household filled ;
+NUMB zi sig gur$NUMB gur , NUMB ban2 rough ground flour ,
+NUMB sila zi gaz gur$NUMB gur , NUMB barig NUMB sila3 “ pounded ” flour ,
+NUMB sila ce gur$NUMB gur , NUMB barig NUMB sila3 barley ,
+abi NUMB geme u NUMBce$labor involved : NUMB female laborer workdays ,
+kicib ludingira$under seal of Lu-dingira ;
+NUMB sar sahar$NUMB sar of soil ,
+ale NUMB ginta$per “ hoe ” NUMB ,
+abi u NUMBkam$labor involved : NUMB days ;
+kicib urnamnunka$under seal of Ur-Namnunka ;
+NUMB geme u NUMBce$NUMB female laborer workdays ,
+geme ce ziga$female laborers who lifted barley ,
+kicibi NUMBam$sealed tablets involved : NUMB ,
+kicib ARAD$under seal of ARAD ;
+NUMB geme u NUMBce$NUMB female laborer workdays ,
+inu gaga$straw carried
+e culgirace$to the house of Šulgi ,
+kicib akala nubanda$under seal of Akalla , the nubanda ;
+NUMB geme u NUMBce$NUMB female laborer workdays ,
+geme arzanace$female laborers for arzana-flour ,
+kicib lugalniglagare$under seal of Lugal-nig-lagare ;
+cunigin NUMB sila dabin gur$total : NUMB gur , NUMB ban2 NUMB sila3 flour ,
+cunigin NUMB sila zi sig gur$total : NUMB gur , NUMB barig NUMB ban2 NUMB sila3 sig-flour
+cunigin NUMB sila ce gur$total : NUMB gur , NUMB barig NUMB sila3 barley
+cebi NUMB gur$barley involved : NUMB gur , NUMB barig NUMB ban2
+cunigin NUMB geme u NUMBce$total : NUMB female laborer workdays
+zigam$booked out ;
+laia NUMB ce gur$the deficit : NUMB gur , NUMB barig NUMB ban2 barley ,
+NUMB la NUMB geme u NUMBce$NUMB minus NUMB female laborer workdays ,
+laiam$are the deficit ;
+nigkak$account of
+dingiraka$Dingira ,
+a gemeka$labor of the female laborers ;
+iti dumuzi$Month : “ Dumuzi ” ,
+mu harci kimac bahul$year : “ Harši and Kimaš were destroyed . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+meictaran$Me-Ištaran ,
+nin kiagani$his beloved sister ,
+ickurillat$Adda-illat ,
+dumu abia$child of Abiya ,
+ARADzu$is your servant ;
+dubsar$scribe .
+nanna amar banda ana$To Nanna , the impetuous calf of An ,
+en dumu sag enlila$the lord , the first-born son of Enlil ,
+lugalanir$his master ,
+ibisuen$Ibbi-Sîn ,
+dingir kalamana$the god of his country ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+ur guna meluha$his speckled Meluḫḫa 'dog' ,
+marhacita$from Marḫaši
+gunce munabtumani$brought by them as tribute ,
+damcilumbi$a replica of it
+mudim$he fashioned ,
+namtilanice$and for his life
+a munaru$he dedicated it to him .
+ur gunaba$Of that speckled dog
+hedab$Grab Him!
+mubim$is its name .
+pisanduba$Basket-of-tablets
+gu udu bauc$xxx
+ziga$xxx
+sipa unuene$xxx
+kicib naramili$xxx
+mu ara NUMBkamac simurum bahulta$xxx
+mu usa bad mada baduce$xxx
+mu NUMBkam$xxx
+pisanduba$Basket-of-tablets
+nigkak$xxx
+ce siki$xxx
+geme ucbar$xxx
+ca guaba$xxx
+pisanduba$Basket-of-tablets
+nigkak$xxx
+a cuku aba$xxx
+la$xxx
+u gudea$xxx
+dumu mukagedu$xxx
+mu amarsuen lugalta$xxx
+mu huhunuri bahul$xxx
+igal$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+meictaran$Me-Ištaran ,
+nin kiagani$his beloved sister ,
+ickurillat$Adda-illat ,
+dumu abia$child of Abiya ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+ziga$credits
+kicib ac uzu$sealed documents of … ,
+iti akiti u NUMB la NUMB bazalta$from month “ Akiti , ” day NUMB passed ,
+iti X$month “ … , ”
+mu cusuen lugal$year : “ Šū-Suen is king , ”
+igal$are here .
+dada$To Dada ,
+unadu$say
+NUMB sa gi izi$“ NUMB bundles of fire-reeds ,
+girinisara$to Girini-isa ,
+henabcumu$let him give . ”
+culgi$Šulgi ,
+nita kalga$strong man ,
+lugal urima$the king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urlisi$Ur-Lisi ,
+ensi$governor ,
+umma$of Umma ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+zulum kabduga$xxx
+pec pec gectin$xxx
+X cida$xxx
+e cara$xxx
+e ninura$xxx
+ec didli ca umma u iribara$xxx
+igal$xxx
+mu ara NUMBkam karhar bahul$xxx
+u$xxx
+mu ara NUMBkam simurum bahul$xxx
+nincubur$To Ninšubur ,
+dingiranir$his/her god ,
+namti$for the life
+ibisuen$of Ibbi-Sîn ,
+dingir kalamanakace$the god of his country ,
+mu pada$the one nominated by him ,
+sagus$the constant supporter
+e enlilka$of the temple of Enlil ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+e temenigur$the Etemeniguru ,
+e kiagani$his beloved temple
+urima$in Ur ,
+munadu$he built for him .
+pisanduba$Basket-of-tablets
+nigkak$accounts
+lu nigdabkene$of the requisitioners
+igal$are here ;
+mu simurum lulubu bahul$year : “ Simurum Lulubu were destroyed ”
+NUMB guruc u NUMBce$NUMB workmen for NUMB days
+abi NUMB guruc$its labor : NUMB worker ;
+a guruc uduabi NUMB u NUMBce$its labor of workmen , free days : NUMB days ;
+kunzida i pariktuma$to the reservoir of the transversal canal
+aca dalbana kun zude bagi$the area outlets to explore , sent back ;
+ki kulita$out of Kuli
+bazi$booked ;
+X$… ,
+mu usa X X ti X$year after : “ … ” .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four quarters
+waqartum$Waqartum ,
+ninani$his sister .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+kunanna$Ku-Nanna ,
+dumu lunanna$son of Lu-Nanna ,
+kurucda$fattener ,
+ARADzu$is your servant .
+laia suga NUMB sila dabin$Repaid arrears : NUMB barig NUMB sila3 of dabin-flour
+lugalurani$Lugal-urani ;
+NUMB sila urgigir dumu asilu$NUMB barig NUMB sila3 : Ur-gigir , son of E’asilu ;
+NUMB sila urictaran$NUMB sila3 : Ur-Ištaran ;
+NUMB sila lugalazida dumu aburu$NUMB sila3 : Lugal-azida , son of Abu-ru ;
+NUMB sila lucara dumu adalal$NUMB sila3 : Lu-Šara , son of Adalal ;
+cunigin NUMB sila zi$total : NUMB barig NUMB ban2 NUMB sila3 of flour ,
+guna gur sila gal$taxes “ being on the street ” ;
+ki ikalata$from Ikalla ,
+kicib lugalurani$under seal of Lugal-urani ;
+mu ma enki babdu$year : “ The boat of Enki was caulked ; ”
+pisanduba$Basket-of-tablets
+ce gecea GANgu$threshed barley of the oxen-field ;
+apinla egala kuku$a . into the palace household to be brought ;
+apinla cukuce hala$a . for prebend doled out ;
+nigka ku mac acaga$accounts of silver of interest of the fields ;
+cim didlibi$…
+igal$are here ;
+mu simanum bahul$year : “ Simanum was destroyed . ”
+NUMB mac $NUMB goat
+lugalazidake $from Lugalazida .
+NUMB amar gu ga$NUMB bull calf , suckling ;
+NUMB gukkal niga saga$NUMB fat-tailed sheep , grain-fed , fine quality ;
+NUMB udu niga$NUMB sheep , grain-fed ;
+NUMB macgal niga$NUMB full-grown billy , grain-fed ;
+NUMB sila$NUMB lambs
+bauc u NUMBkam$slaughtered , ordNUMB day ;
+ki ahuwerta$from Aḫu-wer ,
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti ezemana$month : “ Festival of An , ”
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB gu NUMB udu$NUMB ox , NUMB sheep .
+pisanduba$Basket-of-tablets
+nigkak gi$xxx
+lugalgue$xxx
+igal$xxx
+mu enunugal bahun$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+ureana$Ur-Eanna ,
+X$… ,
+X$… .
+NUMB sila$NUMB lamb ,
+ensi girsu$of the governor of Girsu ;
+NUMB sila$NUMB lamb ,
+idninsuen$of Idnin-Suen ;
+u NUMBkam$ordNUMB day .
+NUMB gu beli nubanda$One ox  Bēlī , the overseer ,
+NUMB gu KA ikala$one ox … Ikalla ,
+gu abilum$oxen from Apilum ,
+kiba banagar$in its place put for him ,
+giri luenki$bvia Lu-Enki ;
+X X X$xxx
+n ab NUMB udu X$NUMB cows , NUMB … sheep ,
+NUMB udu NUMB ud X$NUMB sheep , NUMB goats … ,
+bauc emuhaldimce$slaughtered for the kitchen ,
+mu agausenece$for the soldiers ,
+u NUMBkam$ordNUMB day ;
+ki dugata bazi$booked out of  Duga ,
+giri nurickur dubsar$via Nur-Adad , the scribe ;
+iti cueca$month : šu’ešša ,
+mu ma darabzu babdu$year : “ The boat  ‘Ibex-of-Abzu’ was caulked ; ”
+NUMB gu ab NUMB udu$NUMB oxen and cows , NUMB small cattle .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lutu$Lu-Utu ,
+dumu uracgi$son of Ur-Ašgi ,
+ensi$governor
+adab$of Adab ,
+ARADzu$is your servant .
+NUMB guruc cagu$NUMB male laborers , plowmen ,
+acage a duga$field irrigation done ,
+aca latur$field Latur ;
+ugula urgigir$foreman : Ur-gigir ;
+kicib ururbartab$under seal of Ur-Urbartab ;
+mu simanum bahul$year : “ Simanum was destroyed . ”
+ururbartab$Ur-Urbartab ,
+dumu lugalazida$son of Lugal-azida ,
+gudu emah$gudu of the Emaḫ .
+pisanduba$Basket-of-tablets
+nigkak$accounts of
+lubaba$Lu-Baba ,
+dumu lutu$son of Lu-Utu ,
+gu ance nagabtum$oxen and donkeys of nagabtum
+e udu guapinta$from the house of sheep and plow-oxen ,
+nigina guzala$grand totals , chairholders ,
+laia$debts ,
+e duabi$… ,
+sipa nagabtum$shepherds of nagabtum
+udu siskur udu siskura$sheep , sacrifice , sheep of sacrifice ,
+igal$are here ;
+mu$year : “ … . ”
+NUMB GAN gecura$NUMB bur3 , harrowed
+ara NUMB GANta$NUMB time , NUMB iku each ,
+a erinabi u NUMB$the labor of its team : NUMB days ;
+aca ninura$field of Nin-ura ,
+ugula urama$foreman : Ur-ama ;
+kicib cecani$under seal of Šešani ;
+mu cusuen lugale narua mah enlil ninlilra munedu$year : “ Šū-Suen , king , erected Big Stele for Enlil and Ninlil . ”
+cecani$Šešani ,
+dubsar$scribe ,
+dumu dada$son of Dada .
+lugal kiengi X$king of Sumer and Akkad ,
+NUMB ce gur lugal$NUMB gur NUMB barig barley , royal ,
+ce ura dumu dab X$barley of interest of dumudab of … ;
+idub eduru urlikata$from the depot of the village Urli ,
+ki bazita$from Bazi
+urdumuzi$Ur-Dumuzi
+cu bati$received ;
+iti cesagku$month : “ Harvest , ”
+mu urbilum bahul$year : “ Urbilum was destroyed . ”
+NUMB guruc$NUMB male laborers ,
+NUMB guruc a NUMB$NUMB male laborer , NUMB ,
+NUMB guruc a NUMB$NUMB male laborers , NUMB ,
+iti NUMBce$for NUMB months ,
+abi NUMB u NUMBce$the labor : NUMB workdays ;
+NUMB mumu bahar$NUMB : Mumu , the potter ,
+iti NUMBce$for NUMB months ,
+abi u NUMB$the labor : NUMB days ;
+NUMB mana kubabbar$NUMB mana silver ,
+abi NUMB u NUMBce$the labor : NUMB workdays ;
+NUMB ce gur$NUMB gur barley ,
+abi NUMB u NUMBce$the labor : NUMB workdays ;
+nigkak lugalezem$account of Lugal-ezem ,
+ki urcarata$from Ur-Šara ;
+mu nanna karzida$year : “ Nanna of Karzida . ”
+NUMB gu NUMB mana NUMB gin siki$NUMB talents , NUMB mina , NUMB shekels of wool
+ki sipa akala$from the shepherd of Akalla ,
+ensika$of the governor ,
+egibilta$from new-house ,
+gudada$Gudada
+cu bati$received .
+mu cusuen lugal urima magurmah enlil ninlilra munedim$year : “ Šu-Suen , king of Ur , had the great-barge built for Enlil and Ninlil . ”
+NUMB udu niga$NUMB grain-fed ram ,
+NUMB sila ga$NUMB male suckling lamb ,
+bauc u NUMBkam$slaughtered , ordNUMB day ;
+ki igienlilceta$from Igi-Enlilše
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti macdagu$month : “ Gazelle feast , ”
+mu usa en eridu bahun$year after : “ The high-priestess of Eridu was hired . ”
+NUMB udu$NUMB sheep .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+luigalim$Lu-Igalim ,
+dubsar$scribe ,
+dumu urkigula$son of Ur-kigula ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+dub gida$long tablets
+luningirsu dumu bazi$of Lu-Ningirsu , son of Bazi ,
+igal$are here ;
+mu enunugal inanna$year : “ Enunugal of Inanna . ”
+pisanduba$Basket-of-tablets
+gurumak$inspections
+citimene$of carpenters ,
+nubanda nigbaba$overseer Nig-Baba
+X dada dubsar$… Dada , the scribe ;
+gabari ekiciba$copies of the storage house ,
+igal$are here .
+mu guza enlila badim$year : “ The chair of Enlil was fashioned ”
+pisanduba$Basket-of-tablets
+dub gida$xxx
+suga$xxx
+nig namcatam$xxx
+igal$xxx
+mu e cara umma badu$xxx
+pisanduba$Basket-of-tablets
+im ludingira$xxx
+dumu kusaga$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+gurumak$inspections
+girisega gu apin NUMBkam$personnel of plow oxen … of
+e culgi$the house of Šulgi ,
+ugula urcugalama$foreman Ur-šugalama
+u ala$and Alla ,
+igal$are here ;
+mu guza enlila badim$year : “ The chair of Enlil was fashioned . ”
+urningirsu $Ur-Ningirsu ,
+enmeziana $Enmeziana ,
+cennu $the šennu-priest
+en kiag nance $and the beloved en-priest of Nanše .
+urnamma$Ur-Namma ,
+lugal urima$king of Ur ,
+lu e$the person who the temple
+enki$of Enki
+eriduga$in Eridu
+indua$built .
+luculgira$To Lu-Šulgi
+unadu$speak!
+NUMB udu urickur idab$NUMB ram did Ur-Iškur receive ;
+urhendursagra$to Ur-Ḫendursag
+cena cu hamunabare$in his barley may he release!
+NUMB tug u X$NUMB u garment … ,
+hili dumu X$Ḫili , son of … ,
+ki X$from Ur-… ;
+NUMB tug u ge X$NUMB black u garment … ,
+adudu dumu X$Adudu , son of … ,
+ki ursagata$from Ursag ;
+NUMB tug u X$NUMB u garment … ,
+X$Šara-… ,
+dumu iginida adkup$son of Igi-nida’a , the basket weaver ,
+ki ARAD ugulata$from ARAD the foreman ;
+NUMB tug u ge kal nubanda dumu cakuge dumu zuzani nigba$NUMB fine black u garment , Nubanda , son of Šakuge , son of Zuzani : ration .
+NUMB tug u kal girinidab$NUMB fine u garment , Girini-idab ,
+dumu ahuni$son of Aḫuni ,
+tukule daba$under armed guard ;
+tugba ca enuga$clothing ration in the prison
+u NI X$and … ;
+mu usa cusuen lugal bad martu mudu$year after : “ Šu-Suen , the king , the Amorite wall erected . ”
+lugalnirgal$Lugal-nirgal ,
+magin$boat-builder ,
+ARAD cara$servant of Šara .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+pisanduba$Basket-of-tablets
+gurum ak daba$xxx
+gala$xxx
+damgar gargara$xxx
+u etum damgar gargara$xxx
+igal$xxx
+mu en nanna mace ipa$xxx
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+caramu engar$Šara-amu , plowman ,
+dubsar$scribe ,
+dumu X$son of … ,
+X X X X$… .
+pisanduba$Basket-of-tablets
+nigkak$accounts
+candanakene$of the tanners ,
+mu NUMBkam$NUMB years ;
+igal$are here .
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur ,
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urnance$Ur-Nanše ,
+dubsar$scribe ,
+dumu urebabbar$son of Ur-Ebabbar ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+etum$‘chambers’ of
+ka zusika$… of ivory ,
+u tagtaga$and weaving ,
+udu gukkal$sheep , fat-tailed sheep ,
+igal$are here .
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destoyed . ”
+nanna$For Nanna ,
+lugal kiaganir$his beloved master -
+dubla mah$the Dublamah ,
+u uliata$since ancient days
+kicutag$though not an offering place
+cuku u cuba$where daily rations had been withdrawn
+imeanana$having become ,
+ebi nuduam$since its temple had not been rebuilt
+amarsuen$Amar-Suena ,
+kiag nanna$beloved by Nanna ,
+nibrua$whom , in Nippur ,
+enlile$Enlil
+mu pada$chose by name ,
+sagus$the constant supporter
+e enlilka$of the temple of Enlil ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+dubla mah$the Dublamah ,
+e udikalama$the temple which is the wonder of the country ,
+ki dikudani$his place of judgment ,
+sabarani$where from his net
+luerim$the enemies
+amarsuenka$of Amar-Suena
+nue$do not escape ,
+ebi munadu$that temple he rebuilt
+pa munane$and made resplendent for him .
+kusig kubabbar na zagina$With gold , silver and lapis lazuli
+mu munanidu$he decorated it for him .
+amarsuenke$Amar-Suen
+u imdabsure$shall therewith prolong his life .
+lu e abasumun$A person who , when the temple has become old ,
+undu$having rebuilt it ,
+musarabi$but this inscription
+u cukarbi$and its utensils
+kigubabi$from its standing-place
+nubdabkurea$does not change ,
+igi nannaka$in the eyes of Nanna
+hensa$may he find favor .
+lu musaraba$But a person who this inscription
+cu biburea$shall erase
+u cukarbi$and its utensils
+kigubice$to its standing-place
+nubcibgigia$shall not return ,
+muc nanna$may the serpent of Nanna
+hengar$be set upon him ,
+numunani$and to his descendants
+nanna$may Nanna
+hebtile$make an end .
+NUMB gu ab hia$NUMB oxen cows , various ,
+NUMB udu mac hia$NUMB sheep goats , various ,
+ziga$booked out ,
+ki culgiamu$with Šulgi-ayamu ,
+iti ezemah$month “ Big-festival , ”
+mu enunugal inanna unu bahun$year : “ Enunugal of Inanna in Uruk was installed ; ”
+etum$in the ‘house’ .
+amarsuen$Amar-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four quarters
+lugalitida$Lugal-itida ,
+dubsar$scribe ,
+dumu urdumuzida$son of Ur-Dumuzida ,
+ARADzu$is your servant .
+NUMB gukkal$NUMB fat-tailed sheep ,
+NUMB gukkal gecdu$NUMB fat-tailed sheep , breeders ,
+NUMB udu alum$NUMB aslum sheep ,
+NUMB udu alum gecdu$NUMB aslum sheep , breeders ,
+NUMB u gukkal$NUMB ewes , fat-tailed ,
+NUMB sila gukkal$NUMB lamb , fat-tailed ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+culgiamu idab$did Šulgi-ayamu accept ;
+iti ezemah min$month “ Great Festival , ” second ,
+mu enmahgalana en nanna bahun$year : “ Enmaḫgalana as priestess of Nanna was installed . ”
+NUMB$NUMB
+NUMB abmah$NUMB full-grown cows
+ki ludingira dumu ARADhulata$from Lu-dingira , son of ARAD-ḫula ,
+culgiamu idab$Šulgi-ayamu accepted ;
+iti u NUMB bazal$of the month , the ordNUMB day passed ;
+iti sesdagu$month “ Piglet feast , ”
+mu amarsuenke urbilum muhul$year : “ Amar-Suen Urbilum destroyed . ”
+X X$…
+amarsuen$Amar-Suena ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+X$…
+suena$of Suen ,
+X X X X X$…
+tadininanna$To Taddin-Ištar ,
+dumu kiaganir$his beloved daughter ,
+inaba$he presented it .
+culgi$Šulgi ,
+danum$the mighty ,
+X uri$king of Ur
+u X$and king
+kibratim$of the world quarters
+arbaim$the four ,
+X$builder
+X X$of the Esikil ,
+X ticpak$the temple of Tišpak
+in icnun$in Ešnunna .
+pisanduba$Basket-of-tablets
+tagtaga udu$xxx
+ca guaba$xxx
+u tagtaga KA zusika$xxx
+ca kinunir nigin$xxx
+igal$xxx
+mu amarsuen lugal$xxx
+X ninegalim$The temple of Bēlat-ekallim ,
+belaticu$his mistress ,
+ana balat,$for the life
+amarsuen$of Amar-Suena ,
+danim$the mighty ,
+X urima$king of Ur
+u X$and king
+kibratim$of the world quarters
+arbaim$the four ,
+zariqum$Zarriqum
+X$the military governor
+acur$of Aššur ,
+X$your servant ,
+ana balat,icu$life ,
+ipuc$he built .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+urnigar dumu lunincubur$xxx
+igal$xxx
+mu dumulugal ensi zabcalike bantuku$xxx
+pisanduba$Basket-of-tablets
+dub gida$long-tablets of
+idub gec ea$the silo of treshing ,
+ce gu i pirigindu$barley of the bank of the waterway Pirig-gindu ,
+giri ahua$via Aḫu’a ,
+dumu luduga$son of Lu-duga ,
+igal$are here ;
+mu simurum lulubum ara NUMB la NUMBkamac bahul$year : “ Simurum Lulubum for the ordNUMB time were destroyed . ”
+NUMB la NUMB udu$NUMB sheep ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abba-saga ,
+nalu idab$Nalu accepted ;
+iti ubigu$month : “ ubi-feast , ”
+mu enunugal inanna unuga bahun$year : “ Enunugal of Inanna of Uruk was installed ; ”
+NUMB la NUMB$NUMB .
+pisanduba$Basket-of-tablets
+im ce muhaldim$tablets of the barley of the cooks
+lugalazidace$for Lugal-azida ,
+igal$are here .
+NUMB GAN gecura ara NUMB GANta$A field of NUMB iku ; harrowed once ; NUMB iku each ,
+a erinabi u NUMB$its erin-work is NUMB man-days .
+aca dugecika$Field : Du-Gešika .
+ugula lugalitida$Overseer : Lugal-Itida .
+kicib lucara dumu urgigir$Sealed document of Lu-Šara son of Ur-Gigir .
+mu usa bad martu badu$Year : “ after the martu-wall was erected ” .
+lucara$Lu-Šara ,
+dubsar$the scribe ,
+dumu urgigir$son of Ur-Gigir .
+inanna $To Inanna ,
+ninani $his mistress ,
+culgi $Šulgi ,
+nitakalga $the mighty man ,
+lugal urima $king of Ur
+lugal kiengi kiurike $and king of Sumer and Akkad ,
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+beliarik$Belī-arik ,
+sagi$cupbearer ,
+ensi$governor
+cucin$Ur-of Susa ,
+cusuen guructurni$Šu-Suen , his little man .
+pisanduba$Basket-of-tablets
+nigkak$accounts
+lu nigdab kisurake$of the nigdab men of the borderlands
+bala egir$bala after ,
+igal$are here ;
+mu urbilum bahul$year : “ Urbilum was destroyed . ”
+NUMB pisan gida dusu$NUMB long-baskets for dusu-service ,
+NUMB kid cerum$NUMB šerrum mats ,
+kilabi NUMB sar$their extent : NUMB “ garden ”
+egalce ma tug badul$for the palace , garment-boat covered ;
+X$from …
+X cu bati$… received .
+kicib namcatam kicib ikala$Under official seal , under seal of Ikalla .
+mu huhunuri bahul$Year : “ Ḫuḫnuri was destroyed . ”
+ikala$Ikalla ,
+X$… ,
+X$… .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urculpae$Ur-Šulpa’e ,
+dubsar$scribe ,
+dumu urhaia$son of Ur-Ḫaya ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+ceba sikiba tugba$xxx
+girisega cairi$xxx
+u geme ucbar lamma cusuen$xxx
+ca guaba$xxx
+igal$xxx
+mu en inanna mace ipa$xxx
+NUMB amar macda$NUMB calf-gazelle ,
+euzga$for the uzga-house ,
+muku huba$delivery of Ḫubaya ;
+urbaba mackim$Ur-Baba was enforcer ;
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+bazi$booked out .
+iti ezemekigal$month : “ Festival of Mekigal , ”
+mu enmahgalana en nanna bahun$year : “ Enmaḫgalana , priestess of Nanna , was installed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+dub gida ca ze$xxx
+igal$xxx
+mu cacrum bahul$xxx
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+burmama$Burmama ,
+dubsar$scribe ,
+dumu X$son of … ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+gurumak$inspections ,
+etum$‘chambers’ of
+sagapin$head-plowmen
+erin ugIL$troops , porters ,
+e ninmar$house of Ninmar ,
+igal$are here ;
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents of dab ,
+naua$Na’ua
+mu NUMB iti NUMBkam$NUMB year NUMB months ,
+igal$are here ;
+mu enmahgalanata$from the year : “ Enmaḫgalana ”
+mu enunugal inanna bahun$to the year : “ Enunugal of Inanna was hired , ”
+iti NUMBce$NUMB months .
+NUMB guruc sagdub$NUMB male laborer , tablet-head ;
+NUMB guruc a NUMB$NUMB male laborer , labor : NUMB ;
+NUMB guruc a NUMB gin$NUMB male laborers , , labor : NUMB shekels ;
+cagume$they are ox-drivers ;
+NUMB guruc$NUMB male laborers ,
+iti ezemculgita$from month “ Festival of Šulgi , ”
+iti cesagkuce$to month “ Harvest ; ”
+abi NUMB guruc u NUMBce$the labor : NUMB male laborer workdays ,
+iti NUMBkam$of NUMB months ,
+ceba dahua dea$barley rations , added , delivered ,
+kuli idab$Kuli accepted ;
+mu enunugal inanna unu bahun$year : “ En-unugal of Inanna in Uruk was hired . ”
+pisanduba$Basket-of-tablets
+sagnigura cabi suga$credits , therefroms , restitutions , of
+dingiraka$Dingira ,
+igal$are here ;
+mu NUMBkam$NUMB years ;
+mu usa ara NUMBkam simurum u$year following : “ For the ordNUMB time Simurum ” and
+mu ancan$year : “ Anšan . ”
+pisanduba$Basket-of-tablets
+nigkak bala$xxx
+lu nigdabakene$xxx
+mu cacru bahul$xxx
+pisanduba$Basket-of-tablets
+nigkak$accounts ,
+ugula carakam ugula$foreman Šarakam , foreman ,
+iti NUMBkam$NUMB months ,
+igal$are here ;
+mu cusuen lugale e cara umma mudu$year : “ Šu-Suen , the king , the house of Šara in Umma erected . ”
+NUMB udu niga NUMB sila ceta$NUMB sheep , grain-fed , NUMB sila3 barley each ,
+NUMB sila duh sagata$NUMB sila3 fine bran each ,
+NUMB sila duh duta$NUMB sila3 regular bran each ,
+sadu cara$regular offerings of Šara ;
+NUMB udu niga NUMB sila ceta$NUMB sheep , grain-fed , NUMB sila3 barley each ,
+sadu culgi u amarsuen$regular offerings of Šulgi and Amar-Suen ;
+u NUMBce$for NUMB days ;
+cunigin NUMB ce gur$total : NUMB gur barley ,
+cunigin NUMB duh saga gur$total : NUMB gur fine bran ,
+cunigin NUMB duh du$total : NUMB gur regular bran ,
+iti cekaragala$total : month “ Barley at the quay , ”
+mu ma enki babdu$year : “ The boat of Enki was calked . ”
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+lueridu $for Lu-Eridu ;
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+bagaga $for Bagaga ;
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+DIili $for DI-ilī ;
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+SIAa $for SIAa ,
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+urictaran $for Ur-Ištaran ;
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+lala X $for Lala ;
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+X $for …
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3) beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $3) shekels oil , NUMB shekels alkali-plant ,
+X $for …
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+X $for …
+cunigin NUMB sila kac NUMB la NUMB sila ninda NUMB sila NUMB gin i $total : NUMB ban2 NUMB sila3 beer ; NUMB ban2 less NUMB sila3 bread ; NUMB sila3 NUMB shekels oil ;
+cunigin NUMB sila NUMB gin i NUMB gin naga $total : NUMB sila3 NUMB shekels oil ; NUMB shekels alkali-plant ;
+u NUMBkam $ordNUMB day ,
+iti dal $month : “ Flight . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+cuculgi$Šu-Šulgi ,
+cui$barber ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+kicib ra$xxx
+nubandagukene$xxx
+ingal$xxx
+mu huhnuri bahul$xxx
+pisanduba$Basket-of-tablets
+kicib daba a erina$sealed documents of dab , labor of troops ,
+urninsu nubandagu$Ur-Ninsu , manager of oxen ,
+iti NUMBkam$NUMB months ,
+igal$are here ;
+mu bad martu badu$year : “ The Amorite wall was erected . ”
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+urcuzianka$Ur-šuzi’anka ,
+dumu urbaba$son of Ur-Baba ,
+ARADzu$is your servant .
+alulu$Alulu ,
+dumu inimcara$son of Inim-Šara ,
+kurucda caraka$fattener of Šara .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+luculgira$Lu-Šulgira ,
+dubsar$scribe ,
+dumu dadaga$son of Dadaga ,
+ARADzu$is your servant .
+NUMB udu$NUMB sheep ,
+bauc$slaughtered ,
+u NUMB la NUMBkam$the ordNUMB day ,
+ki naluta$from Nalu
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti kisikininazu$month : “ ki-siki of Ninazu , ”
+mu en eridu bahun$year : “ The high-priestess of Eridu was hired . ”
+pisanduba$Basket-of-tablets
+mu didli ceba$xxx
+gu i nigincedu$xxx
+igal$xxx
+mu amarsuen lugal$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lugalitida$Lugal-itida ,
+dubsar$scribe ,
+dumu ceckala$son of Šeškalla ,
+ARADzu$is your servant .
+NUMB guruc$NUMB laborers ,
+ugula ludingira$foreman : Lu-dingira ;
+NUMB guruc ugula lugirizal$NUMB laborers , foreman : Lugal-girizal ;
+NUMB guruc ugula lusaga$NUMB laborers , foreman : Lu-saga ;
+NUMB guruc ludaia$NUMB laborers , foreman : Lu-Daya ;
+NUMB guruc ugula lugalmagure$NUMB laborers , foreman : Lugal-magure ;
+NUMB guruc NUMB guruc tura$NUMB laborers , NUMB laborers , sick ,
+ugula lugalmumag$foreman : Lugal-mumag ,
+NUMB guruc ugula urgigir$NUMB laborers , foreman : Ur-gigir ;
+gubam$are stationed ,
+pisanduba$Basket-of-tablets
+gu$xxx
+e ningirsu$xxx
+e nindara$xxx
+e dumuzi$xxx
+e igalim$xxx
+e amarsuen$xxx
+pisanduba$Basket-of-tablets
+nigkak gu$xxx
+e ninmar$xxx
+e dumuzi$xxx
+e nance$xxx
+e bagara$xxx
+e gatumdu$xxx
+e uru$xxx
+e inanna$xxx
+pisanduba$Basket-of-tablets
+erin engar cagu$xxx
+gu cudul hala$xxx
+igal$xxx
+ca hurim$xxx
+a urkalamka$labor of Ur-kalam ,
+mu NUMBkam mua NUMB ginta$of the year , each year NUMB shekels silver ,
+kubi NUMB gin laede$its silver : NUMB shekels shall be weighed out ;
+andaga$Andaga ,
+ninanara$to Nin-ana
+banagin$was confirmed ;
+X mackim$… , responsible official ;
+ningal$To Ningal ,
+ninani$his mistress ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+namtilanice$for his life
+a munaru$he dedicated it to her .
+NUMB udu niga$NUMB rams , grain-fed ,
+enlil$for Enlil ;
+NUMB udu niga$NUMB rams , grain-fed ,
+ninlil$for Ninlil ;
+ca gigurua lugal$in the royal g . ,
+urnance sagi mackim$Ur-Nanše , the cup-bearer , was enforcer ,
+iti u NUMB bazal$of the month day NUMB passed ,
+ki naluta$from Nalu
+bazi$lifted ,
+ca nibru$in Nippur ,
+iti ubigu$month “ ubi-feast , ”
+mu en eridu bahun$year : “ The priest in Eridu was installed ; ”
+NUMB$.
+NUMB sila baba munu $NUMB ban2 NUMB sila3 porridge of malt ,
+NUMB mana bappir saga $NUMB mana fine quality beer bread ,
+NUMB ce $NUMB barig NUMB ban2 sila3 barley ,
+dida guce $sweet-wort for consumption ,
+ki carakamta $from Šarakam ,
+kicib ensika $under seal of the governor ;
+iti dumuzi $month “ Dumuzi , ”
+mu simanum bahul $year : “ Simanum was destroyed . ”
+cusuen $Šū-Suen ,
+lugal kalga $strong king ,
+lugal urima $king of Ur ,
+lugal an ubda limmuba $king of the four regions
+akala $Ayakalla ,
+ensi $the governor
+umma $of Umma ,
+ARADzu $is your servant .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+ilimidi$Ilī-midi ,
+salhuba$s . ,
+ARADzu$is your servant .
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of the four world quarters ,
+egal kiagani$his/her beloved temple
+munadu$he built for him/her .
+baba$For Baba , 
+ninanir$his lady , 
+X$did …-Rim-Sin , 
+dumu X X X ugula damgar$son of … , foreman of traders , 
+a munaru$dedicate this . 
+NUMB udu niga$NUMB sheep , barley-fed ,
+NUMB gukkal niga$NUMB barley-fed , fat-tailed sheep ,
+NUMB sila niga$NUMB lamb , barley-fed ,
+NUMB macgal niga NUMB acgar$NUMB buck , barley-fed , NUMB female kids ,
+NUMB sila$NUMB lambs ,
+abisimti$of Abī-simtī ,
+muku usakar$delivery , Crescent Day ,
+rizidingir mackim$Rizi-ilum , responsible official ;
+n udu niga lugalmagure$NUMB sheep , barley-fed , of Lugal-magure ,
+X mackim$… , responsible official ;
+X enlil$… Enlil ,
+X ninlil$… Ninlil ,
+X ninurta$… Ninurta ,
+X mackim$…-zi , responsible official ;
+ca mukurata$from the deliveries ,
+u NUMBkam$the ordNUMB day ,
+ki abasagata bazi$from Abbasaga booked out ;
+iti ezemah$month : “ Grand Festival , ”
+mu enunugal inanna bahun$year : “ Enunugal of Inanna was hired ; ”
+pisanduba$Basket-of-tablets
+etum$xxx
+ce siki tug i uruda$xxx
+u a namlu$xxx
+ki lugina cabra$xxx
+eamara ecara$xxx
+iti macdagu$xxx
+mu kimac bahulta$xxx
+iti cesagku$xxx
+mu usa kimac bahulce$xxx
+iti NUMBkam$xxx
+igal$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urebabdu$Ure-babdu ,
+dubsar$scribe ,
+dumu lugalucumgal$son of Lugal-ušumgal ,
+ARADzu$is your servant .
+NUMB sila utu$NUMB lamb for the god Utu ,
+muku ensi curuppak$delivery , the governor of Šuruppak ,
+zabardab mackim$zabardab , responsible official ;
+NUMB gu emuhaldimce$NUMB ox for the Kitchen ;
+u nkam$the nth day
+ziga$booked out ;
+iti akiti$month : “ Akitu , ”
+mu en nanna mace ipa$year : “ The high-priestess of Nanna by means of extispicy was chosen ; ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+ka la$xxx
+acneu$xxx
+iti ezemculgita$xxx
+iti ezemana u NUMB bazalce$xxx
+iti NUMB u NUMBkam$xxx
+mu en nanna mace ipa$xxx
+kicib sagnigurakani$xxx
+u kicib baucbi isa$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+cabi suga$therefroms , restitutions ,
+sagnigura u ziga$debits and credits
+lukala$of Lukalla
+igal$are here ;
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destroyed . ”
+NUMB gu mu X$NUMB ox … ,
+NUMB u X$NUMB ewes … ,
+mu agaus atuaka$because of the soldiers who for the “ lustration ” ceremony
+egala kuranece$the palace entered ;
+NUMB u u$NUMB ewes , grass-fed ,
+mu agausenece$because of the soldiers ,
+emuhaldim$the Kitchen ;
+nannakam sukkal mackim$Nanna-kam , the messenger , responsible official ;
+u NUMBkam$the ordNUMB day ,
+ki urkununata bazi$from Ur-kununa booked out ,
+giri nannamaba dubsar$via Nanna-maba , the scribe ;
+iti kisikininazu$month : “ ki-siki of Ninazu , ”
+mu cusuen lugal urimake bad martu muriqtidnim mudu$year : “ Šu-Suen , king of Ur , the western wall ‘muriq-tidnim’ erected ; ”
+NUMB gu NUMB udu$NUMB ox , NUMB small cattle .
+cusuen$Šū-Suen
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lugalkuzu$Lugal-kuzu ,
+dubsar$scribe ,
+dumu urnigar cuc$son of Ur-nigar , chief cattle manager ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+mu didli sikiba$xxx
+ca girsu$xxx
+igal$xxx
+mu cacru bahul$xxx
+pisanduba$Basket-of-tablets
+ziga ce$credits of barley ,
+igal$are here ;
+iti ezemamarsuenta u NUMBam barazalata$from the month “ Festival-of-Amar-Suen , ” ordNUMB day passed ,
+mu amarsuen lugale cacurum muhulta$year : “ Amar-Suen , the king , Šaššurum destroyed . ”
+pisanduba$Basket-of-tablets
+cabi suga$thereins , restitutions ,
+marsa$of the shipyard
+giri lugalnirgal$via Lugal-nirgal ,
+igal$are here ;
+mu cacru bahul$year : “ Šašru was destroyed . ”
+pisanduba$Basket-of-tablets
+sagnigura u ziga$debits and credits ,
+gurgura$goods ,
+ki intaeata$from Intaea ,
+iti macdaguta$from month “ Gazelle-feast ”
+iti diri ezemekigale usace$to extra month “ Festival-of-Mekigal , ” the following one ,
+iti NUMBkam$NUMB months ,
+mu simanum bahul$year : “ Simanum was destroyed , ”
+igal$are here .
+pisanduba$Basket-of-tablets
+tagtaga udugi$weaving , domestic sheep ,
+ca girsu$in Girsu ,
+igal$are here ;
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+mu$year : “ … . ”
+NUMB gukkal babbar$NUMB white fat-tailed sheep ,
+NUMB gukkal gecdu babbar$NUMB white impregnated sheep ,
+NUMB gukkal$NUMB fat-tailed sheep ,
+NUMB |UHUL$NUMB ewes ,
+NUMB udu$NUMB sheep ,
+NUMB sila$NUMB lamb ,
+NUMB mac$NUMB male goat ,
+NUMB ud$NUMB female goat ,
+u NUMBkam$on the ordNUMB day ,
+ki abasagata$from Abbasaga
+culgiamu idab$Šulgi-a'amu took into his command .
+iti ubigu$Month : “ eating the Ubi , ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , destroyed Urbilum . ”
+NUMB la NUMB$NUMB .
+pisanduba$Basket-of-tablets
+niginba guruma$xxx
+cabrane$xxx
+igal$xxx
+X$xxx
+mu guza enlila bahul$xxx
+NUMB ancedina$Two onagers and
+NUMB ud cimacgi$two Šimaškian nanny goats
+bauc$slaughtered ;
+u NUMBkam$on the ordNUMB day ,
+ki ludingirata$from Lu-dingira
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti ezemana$month : “ Festival of An , ”
+mu enunugal inanna bahun$year : “ Enunugal was hired as  Inanna . ”
+pisanduba$Basket-of-tablets
+dusu$wooden containers
+kiri aktum kara$of the orchard …
+mu e cara badu$year : “ The house of Šara was erected . ”
+gec u miriza ude dea$lumber and punting poles to the day transported ,
+kiri duzana$to orchard Zanaya
+muku$delivery ,
+igal$are here ;
+mu ibisuen lugal$year : “ Ibbi-Suen is king . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+naramu$Naramu ,
+dumu guzala$son of Guzala ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+kicib daba$xxx
+cabi suga$xxx
+a ma hunga$xxx
+lugalebansa$xxx
+igal$xxx
+mu usa cusuen lugal urimake bad martu muriqtidnim mudu$xxx
+tisatal$Tiš-atal , 
+X karhar$king of Karaḫar : 
+mas,iamecdar$Maṣi’am-Ešdar 
+ARADzu$is your servant . 
+pisanduba$Basket-of-tablets
+cabi suga$therefroms , restitutions ,
+sagnigura$debits ,
+u ziga$and credits ,
+lukala$of Lukalla
+igal$are here ;
+mu cusuen lugal X X$year : “ Su-Suen , the king , … . ”
+diri NUMB tug hia$Surplus : NUMB diverse robes ,
+diri nigkak$surplus of the done account ,
+mu usa ancan bahul$year following : “ Anšan was destroyed , ”
+giri lubanda$via Lu-banda .
+ningirsu$To Ningirsu ,
+ursag kalga$the mighty warrior
+enlila$of Enlil ,
+lugalani$his master ,
+namti$for the life
+culgi$of Šulgi ,
+nita kalga$the mighty man ,
+lugal urimakace$king of Ur ,
+lugirizal$Lu-girizal ,
+ensi$the governor
+lagacke$of Lagaš ,
+NUMB sila ga$NUMB male lambs , suckling ,
+NUMB kir ga$NUMB female lamb , suckling ,
+utuda euduka$new-borns in the sheephouse ,
+endingirmu idab$Endingirmu accepted ;
+u NUMB la NUMBkam$ordNUMB day ;
+iti cueca$month : “ šuešša , ”
+mu enmahgalana en nanna bahun$year : “ Enmaḫgalana , en-priestess of Nanna , was installed . ”
+pisanduba$Basket-of-tablets
+sadu dingirene$xxx
+nance$xxx
+culgi$xxx
+ninmar munusa$xxx
+cu dula dingirene ca girsu$xxx
+X ninmarac$xxx
+dam urbaba$xxx
+dam gudea$xxx
+dam lugirizal$xxx
+igal$xxx
+mu huhnuri bahul$xxx
+idindingir$Iddin-ilum , 
+X$general 
+mari$of Mari : 
+ididagan$Iddin-Dagan , 
+X$the household manager . 
+NUMB GAN$NUMB bur3 NUMB esze3 NUMB iku field surface ,
+cebi NUMB ce gur culgi$its grain : NUMB , NUMB gur barley ;
+cabita$therefrom
+NUMB n NUMB sila gur X$NUMB , NUMB sila3 gur
+muku$delivery ,
+diri NUMB n gur X$surplus : NUMB gur …
+mu X$year : “ … ”
+NUMB GAN$NUMB bur3 field surface
+cebi NUMB ce gur$its grain : NUMB , NUMB gur barley ;
+cabita$therefrom
+NUMB gur$NUMB , NUMB gur
+muku$delivery ,
+laia NUMB ce gur$the deficit : NUMB , NUMB gur barley ;
+mu dumumunus lugalce lugal X$year : “ The king of Anshan married the king’s daughter . ”
+NUMB GAN$NUMB bur3 field surface ,
+cebi NUMB gur$its grain : NUMB , NUMB gur ;
+cabita$therefrom
+NUMB gur$NUMB , NUMB gur NUMB barig NUMB ban2
+muku$delivery ,
+laia NUMB gur$the deficit : NUMB , NUMB gur NUMB barig NUMB ban2 ;
+mu simurum ara NUMBkamac bahul$year : “ Simurrum was destroyed for the ordNUMB time . ”
+X cabra NUMBba$x household managers , of the NUMB .
+NUMB mac mu acgar NUMBce$NUMB billy goats , instead of the female kids ,
+ki abasagata$from Abbasaga
+lugalengardu$Lugal-engar-du
+idab$took control of .
+iti ezemah$Month “ big festival , ”
+mu enunugal inanna bahun$year : “ Enunugal of Inanna was installed . ”
+lugalengar$Lugal-engar ,
+dumu luenlila$son of Lu-Enlila ,
+gudu cakkan$gudu priest of Šakkan .
+n udu X$…
+muku en inanna$delivery of the priest of Inanna ,
+nanceGIRgal mackim$Nanše-GIRgal was enforcer ;
+NUMB udu$NUMB sheep ,
+NUMB ud$NUMB nanny goats ,
+cugid emuhaldim$šugid  for the kitchen ,
+u NUMBkam$ordNUMB day ;
+ki abasagata bazi$from Abbasaga booked out ;
+iti ezemana$month : “ Festival of An , ”
+mu amarsuen lugale X$year : “ Amar-Suen , the king , … ; ”
+NUMB n$.
+pisanduba$Basket-of-tablets
+dubgida namhani dumu huwawa$long-tablets of Namḫani , son of Ḫuwawa ,
+gudea dumu urutu$Gu’edina , son of Ur-Utu ,
+u sasaga$and Sasaga ,
+igal$are here ;
+mu usa urbilum bahul$year following : “ Urbilum was destroyed . ”
+nanna$For Nanna ,
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+NUMB mana$one-half mina
+munagin$he standardized for him .
+NUMB udu hursag$NUMB ram of the mountains ,
+NUMB macda$NUMB antelopes ,
+bauc$slaughtered ,
+ki turamdaganta$from Tūram-Dagan ,
+culgirimu$did Šulgi-irimu
+cu bati$receive ;
+kicib babati$under seal of Babati ;
+iti X$month “ … , ”
+mu X$year : “ … . ”
+amarsuen$Amar-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four quarters
+babati$Babati ,
+dubsar$the scribe ,
+ARADzu$is your servant .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+X$Puzur-… ,
+dumu X$son of KA-… ,
+sagi$cupbearer ,
+ARADzu$is your servant .
+NUMB geme u NUMBce$NUMB , NUMB workdays , female workers ,
+situm mu simanum bahul$remaining  of the year : “ Simanum was destroyed ; ”
+NUMB geme NUMB$NUMB female workers
+iti NUMBce$NUMB months ,
+abi u NUMB$its labor : NUMB , NUMB days ,
+iti cesagkuta$from the month “ Harvest ”
+iti dumuzice$through the month “ Dumuzi ; ”
+NUMB geme u NUMBce abi u NUMB$NUMB female workers for NUMB days , its labor : NUMB days ,
+geme barakara$female bara-kara workers ;
+cunigin NUMB la NUMB geme u NUMBce$total : NUMB , NUMB minus NUMB workdays
+sagnigurakam$are the debit ;
+cabita$therefrom
+NUMB sila zi sig gur$NUMB gur , NUMB barig , NUMB ban2 , NUMB sila3 sig-flour ,
+NUMB eca gur$NUMB gur , NUMB barig , NUMB ban2 eša flour ,
+NUMB zigu saga gur$NUMB gur , NUMB barig , NUMB ban2 fine pea flour ,
+NUMB nigara saga$NUMB barig fine ground ninda flour ,
+NUMB sila gin dabin gur$NUMB gur , NUMB barig , NUMB ban2 , NUMB sila3 NUMB shekels flour ,
+abi u NUMB gin$its labor : NUMB , NUMB days , NUMB shekels ,
+a uduabi u$labor of the free days involved : NUMB days ,
+nigka ceta$from the grain account .
+NUMB geme u NUMBce gura zar taba$NUMB , NUMB workdays , harvested and shocks laid ,
+NUMB geme u NUMBce kunzida i dena guba$NUMB workdays , at the river lagoon of “ Idena ” stationed ,
+NUMB geme u NUMBce kabku kiBAD guba$NUMB workdays , at the kiBAD reservoir stationed ,
+NUMB geme u NUMBce kunzida edurulumah guba$NUMB workdays , at the river lagoon of the Lumah village stationed ,
+kicib lugina$sealed tablet of Lu-gina ;
+NUMB geme u NUMBce aea barla agam gula guba$NUMB workdays , at the sluice of the division box  of “ Agam-gula ” stationed ;
+NUMB geme u NUMBce i eancece u gaga u sahar siga$NUMB workdays , to the “ E-anše ” canal grass carried and earth filled in ;
+geme u NUMBce kici kura X$NUMB workdays , acacia cut … ,
+aca gida u ugurturtur ga$at the “ long ” field and … ,
+GAN agugu$land of Agugu ;
+geme u NUMBce aca ninudu ara NUMBkam$NUMB workdays , at the field “ Ninnudu , ” the second ,
+GAN lucara$land of Lu-Šara ;
+NUMB geme u NUMBce aca gibil aca gusuhub u udulusaga$NUMB workdays , at the “ new ” field , the “ Oxen-boot ” and “ Udu-Lusaga ” fields ,
+GAN lucara ara NUMBkam$land of Lu-Šara , the second ,
+kicib luhegal dumu urutu$sealed tablet of Lu-ḫegal , son of Ur-Utu ;
+geme u NUMBce kici kura NUMB sarta aca auda$NUMB workdays , acacia cut at NUMB sar  in the “ Auda ” field ;
+geme u NUMBce aca gibil$NUMB workdays , at the “ new ” field ;
+geme u NUMBce aca bad dua$NUMB workdays , at the field “ erected wall ; ”
+geme u NUMBce aca icibene$NUMB workdays , at the field “ išib-priests ; ”
+geme u NUMBce aca gusuhub$NUMB workdays , at the field “ Oxen-boot ; ”
+geme u NUMBce aca ninudu$workdays , at the field “ Ninnudu , ”
+geme u NUMBce aca ninudu$
+kici kura NUMB sarta$acacia cut at NUMB sar ;
+kicib daga$under seal of Da’aga ;
+NUMB geme u NUMBce aea aca igiemahce guba$NUMB workdays , at the sluice of the field before Emaḫ stationed ,
+kicib akala$under seal of Akalla ;
+n geme u NUMBce kabku aca X u kabku X$NUMB workdays , female laborers , at the reservoirs of the fields … and … ;
+kicib X$under seal of … ;
+n geme u NUMBce zar taba aca muru$NUMB workdays , female laborers , shocks laid in the field “ muru , ”
+kicib lukuzu sukkal$under seal of Lu-kuzu , courrier ;
+NUMB geme u NUMBce kabku i culpae$NUMB workdays , female laborers , at the reservoir of the Šulpa’e canal ;
+NUMB geme u NUMBce kabku i ninura u kabku dukusig kabku abu u kabku naramsuen u na du$NUMB workdays , at the reservoir of the Nin-ura canal , the reservoir of Dukuge , the reservoir of Abu ? and the reservoir of Naram-Suen … ;
+NUMB geme u NUMBce u lugal tumagara naramsuen u gaga sahar ziga$NUMB workdays , at the “ Lugal-tuma-gara bridge of Naram-Suen , ” grass carried , earth excavated ;
+kicib lugalhegal$under seal of Lugal-ḫegal ;
+NUMB geme u NUMBce zi ar$NUMB workdays , flour ground ;
+NUMB geme u NUMBce kunzida i dena guba$NUMB workdays , stationed at the river lagoon of “ Idena ; ”
+kicib NUMB luhaia$two sealed tablets of Lu-Ḫaya ;
+NUMB geme u NUMBce kisu NUMBta$NUMB workdays , ‘threshing’ at NUMB ;
+NUMB geme u NUMBce eduru lumahta$NUMB workdays , from the Lumaḫ village
+guru apisalce ce ziga u ce muca ziga$to the silo of Apisal , barley winnowed and muša-grain winnowed ;
+kicib gududu$under seal of Gududu ;
+NUMB la NUMB geme u NUMBce kabku X$NUMB workdays , at the reservoir of Udu-… ;
+NUMB geme u NUMBce kabku bad dua u a X X$NUMB workdays , at the reservoir of the erected wall and the … ;
+NUMB geme u NUMBce kabku ninazu$NUMB workdays , at the reservoir of Nin-azu … ,
+haran gaga$haran-grass carried ;
+kicib nabasa$under seal of Nabasa ;
+NUMB geme u NUMBce$NUMB workdays ,
+kabku auda X guba$at the reservoir of Auda … stationed ;
+kicib lugalinimgina$under seal of Lugal-inim-gina ;
+NUMB geme u NUMBce kabku agamgula guba$NUMB workdays , at the reservoir of Agam-gula stationed ;
+NUMB geme u NUMBce sadu u bar guba$NUMB workdays , at sadu … stationed ;
+NUMB geme u NUMBce e sadura igi eamara$NUMB workdays , at the sadura ditch before calf-house ;
+kicib agugu$under seal of Agugu ;
+NUMB geme u NUMBce$NUMB female workers for NUMB days ,
+abi u NUMBkam$its labor : NUMB days
+balace gena balata gura$to the bala  returned ;
+NUMB geme u NUMBce$NUMB , NUMB workdays ,
+a udua$labor of the free days ;
+cunigin NUMB geme u NUMBce$total : NUMB , NUMB workdays
+zigam$booked out ;
+laia NUMB gin geme u NUMBce$the deficit : NUMB , NUMB workdays , NUMB shekels ,
+nigkak a geme$account of the labor of the female workers ,
+ugula X$foreman : …
+mu cusuen lugal bad martu muriqtidnim mudu$year : “ Šu-Suen , the king , the Amorite wall ‘muriq-tidnim’ erected ” .
+NUMB a hunga cumama $NUMB barig : wages of the hirelings of Šū-Mama ;
+NUMB gur igisasa ce puzursuen $NUMB gur NUMB barig : Igi-Sasa , grain of Puzriš-Suen ;
+NUMB cagal udu igisasa $NUMB barig fodder for sheep : Igisasa ;
+NUMB ce mucen ickurbani $NUMB barig barley for birds : Adda-bani ;
+NUMB ce udu zani $NUMB barig barley for sheep : Zani ;
+NUMB gur macbi NUMBkam e nasilim azlag ac $NUMB gur , its goat is NUMB ; house of Na-silim the fuller … ;
+NUMB X X $NUMB barig , …um-bani ;
+X $…
+kalu NUMBam $… are NUMB ;
+tumalta idub $from Tummal …
+iti ezemah edahe $month : “ Great festival ” it will be added .
+NUMB sila kac NUMB sila ninda$NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga$NUMB shekels oil , NUMB shekels potash ,
+NUMB ku NUMB sa cum$NUMB fish , NUMB bundle onions ,
+cuickur$Šū-Adad ;
+NUMB sila kac NUMB sila ninda$NUMB sila3 beer , NUMB sila3  bread ,
+NUMB gin i NUMB gin naga$NUMB shekels oil , NUMB shekels potash ,
+NUMB ku NUMB sa cum$NUMB fish , NUMB bundle onions ,
+urnanna$Ur-Nanna ;
+NUMB ninda NUMB kac du$NUMB ban2 bread , NUMB ban2 beer , regular ,
+NUMB sila igec$NUMB sila3 plant oil ,
+cagal kasene$provisions for messengers ,
+giri urnanna$via Ur-Nanna ;
+u NUMBkam$ordNUMB day ;
+iti nesag$month : “ First fruits , ”
+mu usa cacrum bahul$year following : “ Šašrum was destroyed . ”
+pisanduba$Basket-of-tablets
+dub gida$long-tablets ,
+arua ninmar$votive offerings of Ninmar
+giri luhurim$via Lu-Ḫurim ,
+igal$are here ;
+mu enunugal inanna bahun$year : “ Enunugal was hired . ”
+pisanduba$Basket-of-tablets
+di tila$xxx
+igal$xxx
+ARADnanna$xxx
+sukkalmah ensi$xxx
+giri lucara$xxx
+luebgal$xxx
+urictaran$xxx
+ludingira$xxx
+dikubime$xxx
+mu bad martu badu u$xxx
+mu usa cusuen lugale bad martu mudu$xxx
+pisanduba$Basket-of-tablets
+nigkak$xxx
+ce numun$xxx
+cabra sangane$xxx
+igal$xxx
+mu guza badim$xxx
+NUMB sila gub X$NUMB male lambs … ,
+NUMB kir gub X$NUMB female lambs … ,
+NUMB mac gub X$NUMB male ids … ,
+NUMB acgar gub X$NUMB female kids … ,
+NUMB$NUMB ,
+utuda$newborns ;
+NUMB kir gub X$NUMB female lambs … ,
+NUMB mac gub X$NUMB male kid … ,
+NUMB mac gub X$NUMB male kid … ,
+NUMB acgar gub X$NUMB female kids … ,
+NUMB acgar gub X$NUMB female kids ,
+NUMB la NUMB$NUMB ,
+diri utuda$additional newborns ;
+NUMB sila ga alum$NUMB suckling long-fleeced lamb ,
+NUMB mac ga$NUMB suckling male kid ,
+NUMB mac ga igigun$NUMB suckling male kid , speckled ,
+NUMB acgar igigun$NUMB female kid , speckled ,
+NUMB$NUMB ,
+diri utuda bauc$additional newborns , slaughtered ;
+ca libir$among the “ old ” ;
+NUMB kir ga gukkal$NUMB suckling fat-tailed female lamb ,
+NUMB$NUMB ,
+utuda bauc$newborn , slaughtered ;
+ca mukura$of the delivery ;
+X ziga X X ec$… house of shrine ,
+X X idab$… accepted ;
+X X X$…
+X X X$…
+iti X u$month : “ … , ” …th day ,
+mu kimac bahul$year : “ Kimas was destroyed ; ”
+NUMB udu$NUMB .
+NUMB dug dida X $NUMB jug of wort …
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ,
+cumama sukkal gabac $for Šū-Mama , the messenger , to the frontier ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundle onions ,
+icarili gabata $for Išar-ilī , from the frontier ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundle onions ,
+cutu kausa $for Šū-Utu , the ka’usa ;
+cunigin NUMB dug dida du NUMB $total : NUMB jug of common wort , NUMB ban2 ;
+X cunigin NUMB sila kac $… total : NUMB sila3 beer ;
+cunigin NUMB sila ninda cunigin NUMB gin cunigin i NUMB gin naga $total : NUMB sila3 bread ; total : NUMB shekels oil ; total : NUMB shekels alkali-plant ;
+cunigin NUMB sa cum X iti $total : NUMB bundles onions… nth day , month
+X $…
+pisanduba$Basket-of-tablets
+dub gida$xxx
+urnance dumu nabasa$xxx
+igal$xxx
+mu simuru lulubu ara NUMB la NUMBkamac bahul$xxx
+pisanduba$Basket-of-tablets
+pisan nigarkidu dumu lugalsaga$basket of Nigar-kidu son of Lugal-saga .
+pisanduba$Basket-of-tablets
+e ade$house of irrigation
+guce hala$for oxen distributed ,
+igal$are here ;
+mu cusuen lugal urimake madarabzu enki indim$year : “ Šu-Suen , king of Ur , Ma-dara-apsu fashioned . ”
+NUMB udu$NUMB rams ,
+NUMB sila$NUMB male lamb ,
+lanimu$Lanimu .
+NUMB guruc$NUMB male laborers ,
+NUMB ugIL$NUMB aš porter ,
+iti NUMBce$for NUMB months ,
+abi u NUMB$the labor : NUMB days ;
+lugalebansa idab$Lugal-ebansa accepted ;
+mu usa ancan bahul$year after : “ Anšan was destroyed . ”
+pisanduba$Basket-of-tablets
+ud gazaPI$nannies of gazaPI ,
+ririga$fallen ,
+igal$are here .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal uri$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lusuen$Lu-Suen ,
+dubsar$scribe ,
+dumu X$son of Ur-… ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+nigkak$xxx
+irita nue cabrane$xxx
+igal$xxx
+mu cusuen lugal$xxx
+naramsuen$Naram-Sin ,
+X$king
+agade$of Agade
+lugaluga$Lugal-uga ,
+X$scribe ,
+X$his servant .
+NUMB ce gur$NUMB gur NUMB barig of barley ,
+NUMB mana NUMB gin NUMB ce kubabbar$NUMB minas NUMB shekels NUMB grains of silver ,
+muku$delivery ,
+ki adakala$with Adda-kalla .
+NUMB sila$NUMB lambs ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+intaea$Intaea
+idab$accepted ;
+iti sesdagu$month : “ Piglet-feast , ”
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+ce gurgur$xxx
+ce gec rara$xxx
+igal$xxx
+mu ibisuen lugal$xxx
+NUMB udu niga emuhaldim$NUMB grain-fed sheep  the kitchen ,
+mu gunda lu hurtice$on account of Gunda the Hurtian ,
+u hurtita imgena$when he came from Hurti .
+giri itrakili sukkal$Conveyer : Itrak-ili , the messenger .
+curuckin cagina mackim$Šuruš-kin , the general , was guarantor .
+iti u NUMB bazal$The ordNUMB day of the month has passed .
+ki culgiamuta bazi$Booked out of Šulgi-a'amu .
+iti ezemah NUMBkam$ordNUMB “ great festival ” month
+mu enmahgalana en nanna bahun$year : “ Enmahgalanna was installed as priestess of Nanna ” .
+NUMB$NUMB
+NUMB ce gur lugal$NUMB gur NUMB barig barley , royal ,
+ki lunincuburta$from Lu-Ninšubur ,
+lukala kaguru$Lukalla , chief of the silo ,
+cu bati$received ;
+iti ezembaba$month : “ Festival of Baba , ”
+mu cacrum bahul$year : “ Šašrum was destroyed . ”
+NUMB udu niga amurdingir$NUMB sheep , barley-fed , for Amur-ilī
+lu kingia libanugcabac ensi marhaci$messenger of Libanug-šabaš , governor of Marhaši ,
+giri ludamu sukkal$via Lu-Damu , the messenger ;
+NUMB macgal niga gura lu urcu$NUMB buck , barley-fed , for Guraya , a man from Uršu ,
+NUMB udu niga eum lu mari$NUMB sheep , barley-fed , for E’um , a man from Mari ,
+giri bilia sukkal$via Bilila , the messenger ;
+ARADmu mackim$ARADmu , responsible official ;
+iti u NUMB bazal$of the month , day NUMB elapsed ,
+ki culgiamuta$from Šulgi-ayamu
+bazi$booked out ;
+iti ubigu$month : “ Ubi feast , ”
+mu usa guza enlila badim$year after : “ The throne of Enlil was fashioned ; ”
+NUMB udu$NUMB small cattle .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+halia$Ḫalliya ,
+dubsar$scribe ,
+dumu ada$son of Addaya ,
+ARADzu$is your servant .
+NUMB guruc iti NUMBce$NUMB male laborers for NUMB months ,
+a gurucbi NUMB u NUMBce$labor of the male laborers : NUMB workdays ,
+sagnigurakam cabita$are the debits ; therefrom
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+ganun dua kicib urtur$storage facility erected , under seal of Urtur ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+kicib lugalnidbae$under seal of Lugal-nidba’e ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+kicib urtur$under seal of Urtur ;
+NUMB guruc u NUMBce lugalezem$NUMB workdays , male laborers , Lugal-ezem ;
+NUMB guruc u NUMBce girsuce ma tur$NUMB workdays , male laborers , to Girsu the small barge ;
+NUMB guruc u NUMBce kicib abasaga$NUMB workdays , male laborers , under seal of Abbasaga ;
+NUMB guruc u NUMBce kicibi NUMBam$NUMB workdays , male laborers , the sealed documents are NUMB ,
+kicib urmes cabra$under seal of Urmes , household manager ;
+NUMB guruc u NUMBce a cutirum$NUMB workdays , male laborers , labor of Šutirum ,
+giri baer$via Ba’er
+NUMB gunigin gizi$NUMB bales , fodder reed ,
+kicib abasaga$under seal of Abbasaga ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+marsa guba$stationed at marsa ,
+kicib urbaba$under seal of Ur-Baba ;
+NUMB gur inu$NUMB gur straw ,
+kicib urmes$under seal of Urmes ;
+NUMB gunigin gi NE a gurucbi NUMB$NUMB bales of NE-reed , its labor of the male laborers : NUMB
+kicib lugalnincubur$under seal of Lugal-Ninšubur ;
+cunigin NUMB X ziga$total : NUMB … booked out ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+X a guruc utuca$labor of the male laborers , sat-out days ,
+X a diri NUMB$… labor , surplus : NUMB
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+ma gi girsuce gida$barge with reed from Girsu punted ,
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+marsa guba$at marsa stationed
+kicib urbaba$under seal of Ur-Baba ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+gi zea$reed uprooted ,
+kicib nigurum$under seal of Nir-urum ;
+NUMB inu gur$NUMB gur straw ,
+ara NUMBkam$the ordNUMB time ;
+NUMB inu gur$NUMB gur straw ,
+ara NUMBkam$the ordNUMB time ,
+kicib urmes$unders seal of Urmes ;
+NUMB gunigin gizi$NUMB bales of fodder-reed ,
+a gurucbi NUMB guruc u NUMBce$the labor of male laborers : NUMB workdays , male laborers ,
+kicib utuiks,ur$under seal of Šamaš-ikṣur ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+ganun marsa dua$storage facility of marsa erected ;
+kicib urtur$under seal of Urtur ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+kicib lugalnidbae$under seal of Lugal-nidba’e ;
+NUMB$NUMB
+zigam$booked out ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+a utuca$labor of sat-out days ,
+a diri NUMB guruc$labor , surplus : NUMB male laborers ;
+nigak ereb$account of Erreb ,
+kicib urtur$under seal of Urtur ;
+NUMB gur inu$NUMB gur straw ,
+kicib urmes$under seal of Urmes ;
+NUMB$NUMB
+zigam$booked out ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+a utuca$labor of sat-out days ,
+laia NUMB guruc u NUMBce$the deficit : NUMB workdays , male laborers ;
+nigkak nigla$account of Nigla’a ;
+NUMB guruc iti u NUMBce$NUMB male laborers for NUMB months ,
+abi u NUMBkam$its labor : NUMB workdays ,
+u NUMBce$for NUMB day ,
+sagnigurakam cabita$are the debits ; therefrom
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+NUMB guruc u NUMBce a ickurillat$NUMB workdays , male laborers , labor of Adda-tillati ,
+giri baer$via Ba’er ;
+NUMB guruc iti u NUMBce$NUMB male laborers for NUMB months ,
+abi u NUMBkam$its labor : NUMB workdays ,
+u NUMBce$for NUMB day ,
+sagnigurakam cabita$are the debits ; therefrom
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+kicib urmes$under seal of Urmes ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+marsa guba$at marsa stationed ,
+kicib urbaba$under seal of Ur-Baba ;
+NUMB gunigin gizi$NUMB bales of fodder-reed ,
+kicib abasaga$under seal of Abbasaga ;
+NUMB gunigin gi NE$NUMB bales of NE-reed ,
+kicib lugalnincubur$under seal of Lugal-Ninšubur ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+kicib X$under seal of Ur-… ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+kicib abasaga$under seal of Abbasaga ;
+X$… ;
+NUMB guruc u NUMBce$NUMB workdays , male laborers ,
+ganun marsa dua$storage facility of marsa erected ;
+ugula adalal$foreman : Adalal ,
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+NUMB$…
+pisanduba$Basket-of-tablets
+e kisumun u gidua$dikes of Kisumun and Gidu’a .
+NUMB ce gur$NUMB gur barley ,
+ce ura enlila$barley loan  of Enlil ,
+ki amarcubata$from Amar-šuba
+lugalpae guzala$did Lugal-pa’e , the throne bearer ,
+cu bati$receive ;
+buru amabi gigi$the harvest the obligation will discharge ;
+iti sigka ibgigi$in the month “ Brick ” it will be remitted ;
+acamu ae bare$“ My field by flooding was ruined! , ” or
+acamu ude bare$“ My field by the storm was ruined! ”
+baraben$you will not say! ;
+iti udru$month “ udru , ”
+mu huhunuri bahul$year “ Ḫuḫnuri was destroyed . ”
+ninmar $For Ninmar
+ninani $his mistress ,
+culgi $Šulgi ,
+nita kalga $the mighty man ,
+lugal urima $king of Ur
+lugal kiengi kiurike $and king of Sumer and Akkad ,
+e munus gilsa $her Munusgilsa temple
+girsukani $of Girsu
+munadu $he built for her .
+pisanduba$Basket-of-tablets
+nigkak a erina$accounts of the labor of the troops ,
+a erina$labor of the troops ,
+u dub gidabi$and their long-tablets ,
+igal$are here ;
+mu enmahgalana en nanna bahun$year : “ Enmaḫgalana , en of Nanna , was hired . ”
+abakala$Abba-kala ,
+dubsar$scribe ,
+dumu luningirsu$son of Lu-Ningirsu .
+pisanduba$Basket-of-tablets
+nigkak$xxx
+laia dirita suga$xxx
+sipa unuene$xxx
+mu amarsuen lugalta$xxx
+mu en eridu bahunce$xxx
+mu NUMBkam igal$xxx
+nanna$To Nanna ,
+lugalanir$his master ,
+ibisuen$Ibbi-Sîn ,
+dingir kalamana$the god of his country ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+namtilanice$for his life
+a munaru$dedicated  to him .
+NUMB udu$NUMB ram ,
+NUMB u$NUMB ewe ,
+bauc$slaughtered ,
+u NUMBkam$ordNUMB day ;
+ki nalu$from Nalu ;
+iti macdagu$month : “ Gazelle feast , ”
+mu usa simurum lulubu ara NUMB la NUMBkamac bahul$year after : “ Simurrum  Lullubi for the ordNUMB time were destroyed . ”
+NUMB udu mu udu nigace$NUMB sheep instead of sheep , grain-fed ,
+ca urima$in Ur ,
+giri puzurenlil dumu lugalitida$via Puzriš-Enlil , son of Lugal-itida ;
+ki intaeata$the place of…
+gabari$copy
+kicib abakala$of sealed document of Abbakala ;
+iti akiti$month : “ Akitu , ”
+mu en inanna mace ipa$year : “ The high-priest of Inanna was named . ”
+pisanduba$Basket-of-tablets
+ce ala$xxx
+u ce cakir$xxx
+ninkala$xxx
+igal$xxx
+mu usa mu usabi$xxx
+lu$Lu’u ,
+dumu bidu muhaldim$son of Bidu , the cook .
+NUMB guruc u NUMBce$NUMB workmen for NUMB days ,
+zi ma siga$flour loaded in the barge ,
+zi mata bal$flour unloaded from the barge ,
+NUMB guruc u NUMBce$NUMB workmen for NUMB days ,
+nig siskura ma gar$offerings placed in the barge ,
+sanganece$for the temple administrators ,
+NUMB guruce u NUMBce$NUMB workmen for NUMB days ,
+gi ila$reed carried ,
+gi madala ugula lugalmumanag$read of the tow-boat , foreman : Lugalmu-manag ,
+kicib abagina$under seal of Abbagina ;
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , destroyed Urbilum . ”
+abagina$Abbagina ,
+dubsar$scribe ,
+dumu lugalmagure$son of Lugal-magure .
+pisanduba$Basket-of-tablets
+nigkak$accounts
+lu nigdab$men of nigdab
+ugnimkene$of Ugnim ,
+mu kimac$year : “ Kimaš . ”
+pisanduba$Basket-of-tablets
+dugan$pouches ,
+ziga$credits ,
+kicib lugalitida$sealed documents of Lugal-itida ,
+ki abasaga$with Abbasaga ,
+iti macdaguta$from month “ Gazelle-feast ”
+iti cesagkuce$to month “ Harvest , ”
+iti NUMBkam$NUMB months ,
+mu amarsuen lugale cacru muhul$year : “ Amar-Suen , the king , Šašru destroyed . ”
+pisanduba$Basket-of-tablets
+kicib daba$xxx
+cegeci$xxx
+u a ku$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+gilsa sila$treasure split ,
+NUMB UCkalimmu$NUMB : UŠkalimmu ,
+NUMB ninhursagebsig$NUMB : Ninhursag-ebsig ,
+NUMB balagku UCkalimmu$NUMB : Silver harp , UŠkalimmu ,
+NUMB culgi$NUMB : Šulgi ,
+NUMB caragecgigal$NUMB : Šara-gešgigal ,
+NUMB ninura$NUMB : Ninura ,
+NUMB balagku ninura$NUMB : Silver harp , Ninura ,
+NUMB ninegal$NUMB : Nin-egal ,
+NUMB ninsigarana$NUMB : Ninsigarana ,
+NUMB lugalkurelam$NUMB : Lugal-kur-elam ,
+NUMB nine$NUMB : Nin-e’e ,
+NUMB ninagsu$NUMB : Nin-Nagsu ,
+NUMB nindalagac$NUMB : Nin-Da-Lagash ,
+NUMB nintulsag$NUMB : Nin-tulsag
+NUMB gectinanalugalbarabe$NUMB : Geštinana , Lugalbarabe .
+NUMB sila kac NUMB sila ninda NUMB gin cum$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of onions ,
+NUMB gin i NUMB gin naga$NUMB shekels of oil , NUMB shekels of alkali-plant ,
+zuludua$Zuludua ;
+NUMB sila kac NUMB sila ninda NUMB gin$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of onions ,
+NUMB gin i NUMB gin naga$NUMB shekels of oil , NUMB shekels of alkali-plant ,
+baza lu sag$Baza … ;
+NUMB sila kac NUMB sila ninda NUMB gin$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of onions ,
+NUMB gin i NUMB gin naga$NUMB shekels of oil , NUMB shekels of alkali-plant ,
+lugalkuzu$Lugal-kuzu ;
+NUMB kac NUMB ninda NUMB gin cum$NUMB ban2 of beer , NUMB ban2 sila3 of bread , NUMB shekels of onions ,
+NUMB gin i NUMB gin naga$NUMB shekels of oil , NUMB shekels of alkali-plant ,
+cuecdar$Šu-Ištar ;
+NUMB sila kac NUMB sila ninda NUMB gin$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of onions ,
+NUMB gin i NUMB gin naga$NUMB shekels of oil , NUMB shekels of alkali-plant ,
+mac$Maš ;
+NUMB sila kac NUMB sila ninda NUMB gin$NUMB sila3 of beer , NUMB sila3 of bread , NUMB shekels of onions ,
+NUMB gin i NUMB gin naga$NUMB shekels of oil , NUMB shekels of alkali-plant ,
+ubarum$Ubarum ;
+cunigin NUMB sila kac NUMB sila ninda NUMB sila cum$total : NUMB ban2 NUMB sila3 of beer , NUMB ban2 NUMB sila3 of bread , NUMB sila3 of onions ;
+cunigin NUMB gin i NUMB gin naga$total : NUMB shekels of oil , NUMB shekels of alkali-plant ;
+iti cesagku$month : “ Harvest , ”
+u NUMBkam$the ordNUMB day ;
+mu huhunuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+X ki$…
+X NUMB GAN$… NUMB iku field area ;
+X X X$…
+X NUMB GAN X$…
+NUMB GAN X X$NUMB eše3 NUMB iku field area …
+NUMB GAN X$NUMB eše3 field area …
+NUMB GAN X X$NUMB iku field area …
+X GAN$… field area …
+alimu$A’allium
+dumu namhani$son of Namḫani .
+pisanduba$Basket-of-tablets
+nigkak$accounts
+esir madaga$of bitumen to Madaga
+dea$transported ;
+mu kimac bahul$year : “ Kimaš was destroyed . ”
+pisanduba$Basket-of-tablets
+i zuluma$xxx
+ziga bala u ziga cairi$xxx
+mu en inanna mace inpa$xxx
+X X X X$…
+X X X$…
+X X X$…
+X dubsar$…-da , the scribe ;
+X NUMB gu NUMB udu$… NUMB oxen , NUMB sheep ,
+X suga ahuni$… repaid by Aḫuni ;
+X X cuninazu$… Šu-Ninazu ;
+NUMB gu NUMB udu X$NUMB ox , NUMB sheep … ,
+NUMB X X$NUMB … ;
+NUMB X$NUMB …
+NUMB X$NUMB …
+X ca X X$…
+ki X$from Enlil … ;
+giri X$via Ur-… ;
+X$…
+X X X X$…
+X X$…
+X X X$…
+X X X$…
+X X X X$…
+X X X X$…
+X X X$…
+NUMB udu X mu X$NUMB sheep , …
+X X en X$…
+X X X X$…
+X NUMB X$… NUMB …
+X X$…
+NUMB ud NUMB X$NUMB nanny goats , NUMB … ,
+NUMB u NUMB kir$NUMB ewes , NUMB female lambs ,
+NUMB udu NUMB sila$NUMB rams , NUMB male lambs ,
+NUMB ud$NUMB nanny goat ,
+laia suga X$deficit restored by Lu-… ;
+NUMB udu NUMB sila$NUMB sheep , NUMB lambs ,
+NUMB u NUMB kir$NUMB ewes , NUMB female lambs ,
+NUMB ud$NUMB nanny goat ,
+laia suga X X dumu X$deficit restored by … , son of … ;
+X X$…
+NUMB udu$NUMB sheep ,
+ki ugILta$from Ug-IL ,
+giri ilimahri$via Ilī-maḫ ;
+iti cesagku$month : “ Harvest ; "
+cunigin NUMB gu niga$total : NUMB oxen , grain-fed ,
+cunigin NUMB gu$total : NUMB oxen ,
+cunigin NUMB ab$total : NUMB cows ,
+cunigin NUMB X X$total : NUMB …
+cunigin NUMB X X$total : NUMB …
+cunigin NUMB X$total : NUMB …
+X X X$…
+NUMB ce gur$NUMB gur NUMB barig barley ,
+NUMB sila ziz gur$NUMB gur NUMB barig NUMB ban NUMB sila emmer ,
+ugula lugina$foreman : Lugina
+NUMB ce gur$NUMB gur NUMB barig barley ,
+NUMB ziz gur$NUMB gur emmer ,
+NUMB gig gur$NUMB gur NUMB barig wheat ,
+ugula lugalemahe$foreman : Lugal-emahe
+NUMB ce gur$NUMB gur barley ,
+NUMB ziz gur$NUMB gur NUMB barig NUMB ban emmer ,
+NUMB gig gur$NUMB gur NUMB barig wheat ,
+ugula dudumu$foreman : Dudumu
+NUMB ce gur$NUMB gur barley ,
+NUMB ziz gur$NUMB gur NUMB barig emmer ,
+NUMB gig gur$NUMB gur NUMB barig wheat ,
+ugula lugalgigire$foreman : Lugal-gigire
+NUMB ce gur$NUMB gur NUMB barig barley
+aca cara$of the field of Szara ,
+ugula aba$foreman : A'abba
+NUMB sila ce gur$NUMB gur NUMB barig NUMB ban NUMB sila barley
+aca cara ugula urgigir$of the field of Szara , foreman : Ur-gigir ?
+NUMB ce gur aca manu$NUMB gur NUMB barig barley of the field of manu-wood ,
+ugula agugu$foreman : Agugu
+NUMB ce gur aca manu$NUMB gur barley of the field of manu-wood ,
+NUMB ziz gur aca sipane$NUMB gur NUMB barig emmer of the “ field of the shepherds , ”
+ugula X$foreman : Lugal-xani
+NUMB sila aca sipane$NUMB barig NUMB ban NUMB sila  from the “ field of the shepherds , ”
+ugula lugalkugani$foreman : Lugalkugani
+NUMB gur aca sipane$NUMB gur NUMB barig NUMB ban  from the “ field of the shepherds , ”
+NUMB gur$NUMB gur NUMB barig ,
+NUMB gunida gur aca X$NUMB gur chickpeas from the “ field of the shepherds , ” ?
+ugula urenlila$foreman : Ur-Enlila
+ce gecea GANgu$threshed grain of the royal plots
+daumma$in Da-Umma
+ARAD cu bati$did ARAD2 receive
+giri lubanda$via Lu-banda .
+mu simurum lulubu ara NUMB la NUMBkam bahul$Year : “ Simurum and Lulubu were destroyed for the ordNUMB time . ”
+NUMB gin kubabbar$NUMB shekel silver
+urce$for interest
+ki lugalkuzu damgarta$from Lugalkuzu , merchant ,
+ubar idu ninlila$Ubar , doorman of Ninlil ,
+cu bati$has received .
+iti sig u NUMB bazal$Month : “ Bricks , ” NUMB days passed ;
+mu cusuen lugale mada zabcali muhul$year : “ Šu-Suen , the king , destroyed the country Zabšali . ”
+ubar X$Ubar … ,
+X$… ,
+X$… .
+pisanduba$Basket-of-tablets
+lu nigdabkene$takers ,
+X$… ,
+igal$are here ;
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+ceba sikiba$xxx
+lu azlagkene$xxx
+namdubsar cecduga$xxx
+lugalamarku$xxx
+u eucbar$xxx
+cusuenka$xxx
+igal$xxx
+nubanda luinimnigsaga$xxx
+ca guaba$xxx
+mu simurum bahul$xxx
+NUMB ce gur$NUMB gur NUMB barig barley ,
+diri nigkak$surplus of the account
+mu e cara badu$of the year : “ The house of Šara was built ; ”
+lunanna$Lu-Nanna .
+pisanduba$Basket-of-tablets
+dugan cabi suga$xxx
+ekas$xxx
+ca kinunir$xxx
+giri diku$xxx
+X$xxx
+X$xxx
+X$xxx
+NUMB sila ninda gal gur$NUMB gur NUMB ban2 NUMB sila3 of “ large bread ”
+ziga cunir$booked out of  Šu-nir ,
+ki gurzanta$from Gurzan ;
+kicib ensi$under seal of the governor ;
+iti diri$month “ extra , ”
+mu simanum bahul$year : “ Simanum was destroyed . ”
+cusuen$Šu-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+akala$Ayakalla ,
+ensi$governor
+umma$of Umma ,
+ARADzu$your servant .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+situm X$xxx
+igal$xxx
+mu urbilum bahul$xxx
+u$xxx
+mu kimac bahul$xxx
+NUMB kunga$NUMB k-equids ,
+cugid$šugid offerings ,
+ezemahce$for Great-festival ;
+u NUMBkam$ordNUMB day ;
+ki urkununata$from Ur-kununa
+bazi$booked out ;
+iti ubigu$month : “ Ubi-feast , ”
+mu cusuen lugal urimake magurmah enlil ninlilra munedim$year : “ Šu-Suen , king of Ur , Great-barge of Enlil and Ninlil fashioned . ”
+NUMB X X$NUMB  …tur ,
+NUMB X$NUMB  …da ;
+NUMB X$NUMB  Ša . . ;
+n luamarsuen dumuni$Lu-Amar-Suen , her son ;
+NUMB X X X X$NUMB  . . ;
+NUMB X X X X$NUMB . . ;
+NUMB X$… ,
+dumunime$being her children ;
+NUMB X$NUMB  … ,
+NUMB X$NUMB  … ,
+X$. . ;
+X$. . ;
+X$. . ;
+X X X X$. . ;
+X ninginabadim$… Ningin-abadim ,
+X ninmusisa$… Ninmusisa ,
+X X$. . ;
+X X$. . ;
+NUMB ninsadu$Nin-sadu
+NUMB gemebarasiga$Geme-bara-siga ,
+dumunime$being her children ;
+NUMB gemenigar$NUMB  Geme-nigar ;
+NUMB ninkanime$NUMB ? ,
+arua lucgida$donated  by Lu-ušgida ;
+NUMB ninzaginta$NUMB  Nin-zaginta ;
+NUMB ninezem$NUMB  Nin-ezem ;
+NUMB lammarebazige$NUMB  Lamma-ri-Bazige ,
+NUMB gemebarasiga$Geme-barasiga ,
+NUMB gemegigir$Geme-gigir ,
+NUMB ninmusisa$Ninmusisa ,
+dumunime$being her children ;
+NUMB ninkuzu$NUMB  Ninkuzu ,
+NUMB gemeucbar$Geme-ušbar ,
+NUMB gemenincubur$Geme-Ninšubur ,
+dumunime$being her children ;
+NUMB gemeceila$NUMB  Geme-še’ila
+NUMB gemenincubur$Geme-Ninšubur
+NUMB ninsadu$Nin-sadu ;
+NUMB gemenarua$Geme-Narua
+NUMB X$…-Narua ,
+dumunime$being her children ;
+NUMB gemebarasiga$NUMB  Geme-barasiga ,
+dumu lucgida$daughter of Lu-ušgida ;
+NUMB ninkine$NUMB  Nin-kine ;
+X ninmuban$…
+X gemeganun$…  Geme-ganun
+X ninue$…  Nin-u’e
+NUMB nigina$Niggina
+NUMB lunamtara$,
+dumunime$being her children ;
+NUMB ninkugani$NUMB  Nin-kugani ;
+NUMB aguzi$NUMB  Aguzi
+NUMB ningeckimzi$Nin-geškimzi
+NUMB etamuzu$Etamuzu
+NUMB gemenincubur$Geme-Ninšubur ,
+dumunime$being her children ;
+NUMB tug ki lula$NUMB textile  Kilula ;
+NUMB irinicekuc$NUMB  Irinišekuš
+NUMB gemedara dumuni$Geme-edara , her daughter ;
+NUMB nindicgalda$NUMB
+NUMB ninsadu dumuni$Nin-sadu , her daughter ;
+NUMB cazumba$NUMB  Šazumba ;
+NUMB gemenarua$NUMB  Geme-Narua ,
+dumu nincec$daughter of Nin-šeš ;
+tug ninikiag$textile  Nin-esir-kiag ,
+dumu ninaniea$daughter of Nin-ani’ea ;
+tug batasage$textile  Batasage ,
+arua tiniabzuta$donated  Tini-abzuta ;
+tug abaninisige$textile  Abani-nisige
+NUMB gemeculgi$Geme-Šulgi
+NUMB namragabikuc$Namraga-bikuš ,
+dumunime$being her children ;
+NUMB labacisegede$NUMB  Labašisegede
+NUMB ningakam dumuni$Ningakam , her daughter ;
+ar ninkicara$milling : Nin-kišara
+NUMB gemecdam$Geme-ešdam
+NUMB namceca dumuni$Namšeša , her daughter ,
+dumunime$being her children ;
+NUMB gemenarua$NUMB  Geme-Narua ,
+dumu atu$daughter of Atu ;
+tug |PUka$textile  Pukaka ;
+NUMB lunusa$NUMB  Lu’u-nusa ;
+NUMB tug gemeganun$NUMB textile  Geme-ganun ,
+dumu gemelisi$daughter of Geme-Lisi ;
+NUMB mactur$NUMB  Maštur
+NUMB gemeninmar$Geme2-Ninmar
+NUMB utuiks,ur$Šamaš-ikṣur ,
+dumunime$being her children ;
+tug gemecdam$textile  Geme-ešdam
+NUMB gemenarua$Geme-Narua
+NUMB kasa$Kasa ,
+dumunime$being her children ;
+NUMB bazige$NUMB  Bazige
+NUMB ninengi$Nin-engi
+NUMB urdardu$Ur-dardu ,
+dumunime$being her children ;
+NUMB gemeutu$NUMB  Geme-Utu ,
+dumu amagina$daughter of Amagina ;
+NUMB gemedardu$NUMB  Geme-dardu ;
+tug nindanirgal$textile  Ninda-nirgal
+NUMB nigtuku dumuni$Nigtuku , her child ,
+NUMB gememunukuga$Geme-munukuga ,
+dumunime$being her children ;
+NUMB ninigzuzu$NUMB  Nin-nig-zuzu ;
+NUMB ninmuhamucizu$NUMB  Ninmu-ḫamušizu
+NUMB nindanirgal$Ninda-nirgal
+NUMB abakine$Aba-kine ,
+dumunime$being her children ;
+NUMB nigtukuinabdu$NUMB  Nigtuku-inabdu
+NUMB abakine$Aba-kine
+NUMB ninmusisa$Ninmusisa ,
+dumunime$being her children ;
+uc nininimgina$dead : Nin-inimgina ;
+NUMB gemeirisiga$NUMB  Geme-irisiga ;
+NUMB nininimgina$NUMB  Nin-inimgina
+NUMB gemenarua$Geme-Narua
+NUMB gemebarasiga$Geme-barasiga ,
+dumunime$being her children ;
+NUMB gemeninmug$NUMB  Geme-ninmug ;
+NUMB nindanirgal$NUMB  Ninda-nirgal
+NUMB ninsisa$Nin-sisa
+NUMB acamugul$Aša-mugul ,
+dumunime$being her children ;
+NUMB nininimgina$NUMB ;
+NUMB X$NUMB  Nin-… ;
+NUMB X$NUMB  Geme-… ;
+NUMB X$NUMB  … ;
+NUMB X X$NUMB  . . ;
+NUMB gemelisi$Geme-Lisi
+NUMB gemeugIL$Geme-ugIL ,
+dumunime$being her children ;
+NUMB bacinisige$NUMB  Baši-nisige
+NUMB gememunukuga$Geme-munukuga
+NUMB ninibtae$Nin-ibtae ,
+dumunime$being her children ,
+arua nabasa$donated  Nabasa ;
+tug bacinisige$textile  Baši-nisige ,
+arua gemeana$donated  Geme-Eanna ,
+NUMB gemegigir dumuni$Geme-gigir , her daughter ;
+NUMB naridaha$NUMB
+NUMB ninkuzu dumuni$Nin-kuzu , her daughter ;
+tug gemelisi$textile  Geme-Lisi
+NUMB macgula dumuni$Mašgula , her child ;
+NUMB gemeutu$NUMB  Geme-Utu ;
+NUMB usanidu$NUMB  Usanidu
+NUMB gemeculgi$Geme-Šulgi
+NUMB abaduga$Abbaduga ,
+dumunime$being her children ;
+NUMB gemegigalCIMka$NUMB  Geme-gigal-ŠIMka
+NUMB ninkila$Nin-kila’a
+NUMB niginabadab$Niggina-badab ,
+dumunime$being her children ;
+NUMB ninamah$NUMB  Nin-tugmaḫ ;
+NUMB gemebarasiga$NUMB  Geme-barasiga
+NUMB X X$. . ;
+NUMB X$Nin- . . ;
+NUMB aguzi$Aguzi ,
+dumunime$being her children ;
+tug gemeictaran$textile  Geme-!štaran ,
+uc ninzalagani dumuni$dead : Nin-zalagani , her daughter ;
+NUMB gemesuen$NUMB  Geme-Suen ;
+NUMB gemedardu$NUMB  Geme-dardu ;
+NUMB gemeganun$NUMB  Geme-ganun
+X nininimgina$Nin-inimgina
+NUMB ninsadu$Nin-sadu ,
+dumunime$being her children ;
+NUMB zimuidagal$NUMB  Zimu-idagal ;
+NUMB menicuna$NUMB  Meni-šuna ,
+NUMB luru dumuni$Lu-Uru , her son ;
+NUMB namramumudu$NUMB  Namramu-mudu
+NUMB nineizu$Nine-izu
+NUMB dulumidu$Dulum-idu ,
+dumunime$being her children ;
+tug nindanirgal$textile  Ninda-nirgal
+NUMB gemeganun dumuni$Geme-ganun , her daughter ;
+tug dulumidu$textile  Dulum-idu ,
+dumu gemenarua$daughter of Geme-Narua ;
+NUMB dugalalbi$NUMB  Duga-lalbi ;
+NUMB ninsisa$NUMB  Nin-sisa
+NUMB namninani dumuni$Namninani , her child ;
+NUMB barkugani$NUMB  Barkugani
+NUMB ninmiduga$Nin-mi-duga
+NUMB gemeceila dumuni$Geme-še’ila , her daughter ,
+dumunime$being her children ;
+NUMB ninkuzu$NUMB  Nin-kuzu ,
+dumu bazige$daughter of Bazizi ;
+NUMB kubi$NUMB  Kubi
+NUMB gemeturnice dumuni$Geme2-turniše , her daughter ;
+NUMB zamubanius$NUMB  Zamu-banius
+X X X$. . ;
+X ninkiharsa$Nin-kiharsa ,
+dumunime$being her children ;
+NUMB lulzi$NUMB  Lulzi ;
+NUMB ninmagure$NUMB  Nin-magure
+NUMB namninani dumuni$Namninani , her child ,
+NUMB gemeucbar$Geme-ušbar
+NUMB gemenarua dumuni$Geme-Narua , her daughter ,
+NUMB ninhegal$Nin-ḫegal ,
+dumu lulzime$being descendants  Lulzi ;
+NUMB gemenarua$NUMB  Geme-Narua ;
+ar tug gemeturmac$milling : textile  Geme-turmaš
+NUMB lala$Lala
+urhendursag$Ur-Ḫendursag ,
+dumunime$being her children ;
+NUMB amamubandu$NUMB  Amamu-bandu
+ar gemelamma dumuni$milling : GemeLamma , her daughter ;
+NUMB nana$NUMB  Nana ;
+NUMB ninmuceigimu$NUMB  Ninmuše-igimu
+NUMB macgula$Mašgula
+NUMB nindanirgal$Ninda-nirgal ,
+dumunime$being her children ;
+tug nindamudagal$textile  Ninda-mudagal
+NUMB ninaba$Nin-aba
+NUMB gemenincubur dumuni$Geme-Ninšubur , her daughter ,
+dumu naname$descendants of Nana ;
+NUMB gemesuen$NUMB  Geme-Suen ,
+dumu ninluni$daughter of Nin-luni ;
+NUMB nincec$NUMB  Nin-šeš
+NUMB gemenarua dumuni$Geme-Narua , her daughter ;
+NUMB amatudani$NUMB  Amatudani ,
+dumu atu bauc$daughter of Atu , died ;
+NUMB mandaha$NUMB  mandaḫa ;
+NUMB nigurani$NUMB  Niggurani ;
+NUMB tug nininimgina$NUMB textile  Nin-inimgina
+NUMB gemebarasiga$Geme-barasiga ,
+dumu gemebarame$being children of Geme-bara ;
+NUMB nigtuku$NUMB  Nig-tuku ;
+NUMB ninginabadim$NUMB  Ningin-abadim ;
+NUMB iriganabdu$NUMB  Iriga-nabdu ;
+NUMB gemeana$NUMB  Geme-Eanna
+NUMB gemenungal$Geme-Nungal
+NUMB irinicekuc$Irinisze-kusz ,
+dumunime$being her children ;
+NUMB namucurani$NUMB  Namušurani
+NUMB luru$Lu-Uru
+NUMB gemedardu$Geme-dardu ,
+dumunime$being her children ;
+tug ninmuceigimu$textile  Ninmuše-igimu
+NUMB urdardu dumuni$Ur-dardu , her son ;
+NUMB ninzicagal$NUMB  Nin-zišagal ;
+NUMB sasa$NUMB  Sasa ;
+NUMB gememu$NUMB  Gememu ;
+tug tulta$textile  Tulta ,
+dumu utuirina bauc$daughter of Utu-irina , died ;
+NUMB gemedingira$NUMB  Geme-dingira ,
+dumu ningan$daughter of Nin-gan ;
+ar gemelamma$milling : Geme-Lamma ;
+NUMB ba$NUMB  Ba’aya ;
+NUMB gemedardu$NUMB  Geme-dardu ;
+NUMB ninsadu$Nin-sadu
+NUMB gemenarua$Geme-Narua ,
+dumunime$being her children ;
+NUMB camuzu$NUMB  Ša-muzu
+NUMB ninsagugal$Nin-saggugal
+NUMB gemelamma$Geme-Lamma ,
+dumunime$being her children ;
+NUMB ninibtae$NUMB  Nin-ibtae ;
+tug dumu nagam$textile
+NUMB X$Geme- . . ;
+NUMB X$. . ;
+X$. . ;
+X$. . ;
+X$. . ;
+NUMB irinicekuc$NUMB
+NUMB X$
+NUMB namirina$
+NUMB gemeamarsuen$Geme-Amar-Suen ,
+dumunime$being her children ;
+NUMB gememunukuga$NUMB  Geme-munukuga ;
+NUMB ninkuzu$NUMB  Nin-kuzu
+NUMB nigtukuinabdu$Nigtuku-inabdu
+NUMB ninzirina$Ninzi-irina
+NUMB gemeamarsuen$Geme-Amar-Suen ,
+dumunime$being her children ;
+NUMB niniga$NUMB  Nin-iga ;
+NUMB ninhegal$NUMB  Nin-ḫegal ,
+dumu gememunukuga$daughter of Geme-munukuga ;
+tug nininutuku$textile  Nin-innutuku ;
+NUMB ninmagure$NUMB  Nin-magure
+NUMB gemebikisal$Gemebi-kisal
+NUMB gemeamarsuen$Geme-Amar-Suen ,
+dumunime$being her children ;
+tug kiurenkal$textile  Kiur-enkal ;
+tug ninkicara$textile  Nin-kišara ;
+NUMB ninkuzu$NUMB  Nin-kuzu
+NUMB ninigtuku$Nin-nigtuku
+NUMB gemeculgi$Geme-Šulgi ,
+dumunime$being her children ;
+NUMB X$NUMB  Geme- . . ;
+NUMB X$Lu- . . ;
+NUMB X X$Geme-… ,
+dumunime$being her children ;
+NUMB gemecimkuga$NUMB  Geme-šimkuga
+NUMB zamubanius$Zamu-banius
+NUMB ninsadu$Nin-sadu ,
+dumunime$being her children ;
+NUMB ninirinice$NUMB ?  Nin-iriniše ? ;
+NUMB nigina$NUMB  Niggina ;
+NUMB egalesi$NUMB  Egalesi
+NUMB nininimgina$Nin-inimgina
+NUMB nineizu$Nine-izu ,
+dumunime$being her children ;
+NUMB ninarhucsu$NUMB  Nin-arhušsu
+NUMB gemekare$Geme-ekare
+NUMB ninmuceigimu$Ninmuše-igimu ,
+dumunime$being her children ;
+NUMB lammamamu$NUMB  Lamma-amamu
+NUMB namninani dumuni$Namninani , her child ;
+NUMB gemenindara$NUMB  Geme-nindara ,
+arua irikibi$donated  Iri-kibi ;
+NUMB gemekuga$NUMB  Geme-ekuga ,
+arua lutu$donated  Lu-Utu ;
+NUMB gemekare$NUMB  Geme-ekare ,
+arua urlamma$donated  Ur-Lamma ;
+NUMB ninburcuma$NUMB  Nin-buršuma ,
+arua cuna$donated  Šuna ;
+NUMB lammamamu$NUMB  Lamma-amamu ,
+arua bazi$donated  Bazi ;
+NUMB ninsisa$NUMB  Nin-sisa
+arua lugina$donated  Lugina ;
+ar halalamma$milling : Ḫala-Lamma ,
+arua ananece$donated ;
+ar tug gemedardu$milling : textile  Geme-dardu ,
+arua lunance$donated  Lu-Nanše ;
+NUMB gemelamma$NUMB  Geme-Lamma ,
+arua ananece$donated ;
+X nintura$…
+X ninkiharsa dumuni$Nin-kiharsa , her daughter ,
+X X$. . ;
+NUMB ninani$NUMB  Ninani ,
+arua lunarua$donated  Lu-Narua ;
+tug ninebazige$textile  Nine-Bazige ,
+arua urabzu$donated  Ur-abzu ;
+NUMB ningeckimzi$NUMB  Nin-geškimzi ,
+arua ceckala$donated  Šeškalla ;
+NUMB ninhegal$NUMB  Nin-ḫegal ,
+arua urlamma$donated  Ur-Lamma ;
+NUMB gememunukuga$NUMB  Geme-munukuga ,
+arua utubae$donated  Utu-ba’e ;
+NUMB gemebaba$NUMB  Geme-Baba
+NUMB nindanirgal dumuni$Ninda-nirgal , her daughter ,
+arua lugalti$donated  Lugal-ti ;
+NUMB ninebazige$NUMB  Nine-bazige ,
+arua ala$donated  Alla ;
+NUMB gemezida$NUMB  Geme-Ezida ,
+arua urabu$donated  Ur-Abu ;
+NUMB gemenindara$NUMB  Geme-Nindara ,
+arua nannadalla$donated  Nanna-dalla ;
+tug gemeana$textile  Geme-Eanna ,
+arua urhendursag$donated  Ur-Ḫendursag ;
+NUMB niniks,ur$NUMB  Nin-ikṣur ,
+arua urenlila$donated  Ur-Enlila ;
+X nidaga$… ,
+arua urlamma$donated  Ur-Lamma ;
+X X X$… ;
+arua lugalbi$donated ;
+NUMB ninigidu$NUMB  Nin-igidu ,
+uc ninsukkal dumuni$dead : Nin-sukkal , her daughter ,
+arua lugaltida$Lugal-tida ;
+NUMB ninmusisa$NUMB  Ninmusisa ,
+arua lunarua$donated  Lu-Narua ;
+NUMB ninmubanzige$NUMB  Ninmu-banzige ,
+arua ala cuc$donated  Alla , cattle manager ;
+NUMB gemeganun$NUMB  Geme-ganun ,
+arua lugalsaga$donated  Lugalsaga ;
+NUMB uba$NUMB  Uba ;
+NUMB nincuburama$NUMB  Ninšubur-ama ,
+arua abasaga$donated  Abbašaga ;
+NUMB ninensi$NUMB  Nin-ensi ,
+arua urmes$donated  Ur-mes ;
+NUMB gemeana$NUMB  Geme-Eanna ,
+arua lutu sipa$donated  Lu-utu , the shepherd ;
+NUMB enamutar$NUMB  Ennamutar ,
+arua cakuge$donated  Šakuge ;
+NUMB ninmadu$NUMB  Nin-ma-adu ,
+arua etamuzu$donated  Eta-muzu ;
+NUMB kue$NUMB  Ku’e ,
+arua lugaldubla$donated  Lugal-dubla ;
+ar tug gemebarasiga$milling : textile  Geme-barasiga ,
+arua lugalnukuc$donated  Lugal-nukuš ;
+NUMB gemeceila$NUMB  Geme-še’ila ,
+arua lugalnamah$donated  Lugal-tugmaḫ ;
+ar tug gemetur$milling : textile  Gemetur ,
+arua urenki$donated  Ur-Enki ;
+NUMB X X$NUMB  … ,
+arua X$donated  … ;
+tug X$textile  … ,
+arua X$donated  … ;
+NUMB X$NUMB  … ,
+arua X$donated  Ur-… ;
+ca gurum X$from the inspection  Lu-… ;
+NUMB nindalla$NUMB  Nin-dalla ;
+NUMB ninmagure$NUMB  Nin-magure
+NUMB ninkuzu$Nin-kuzu
+NUMB ninhegal$Nin-ḫegal ,
+dumunime$being her children ;
+ca gurum kuda$from the inspection of Kuda ;
+NUMB gemedumuzi$NUMB  Geme-Dumuzi
+NUMB gemedardu$Geme-dardu
+NUMB batasage$Batasage
+NUMB ninarhucsu$Nin-arhušsu ,
+dumunime$being her children ;
+NUMB ninama$NUMB  Nin-ama
+NUMB cadanukam$Šadanukam
+NUMB gemebarasiga dumuni$Geme-barasiga , her daughter ,
+NUMB ninmuamamu$Ninmu-amamu ,
+dumunime$being her children ;
+ar tug gemedardu$milling : textile  Geme-dardu ,
+dumu zakima$daughter of Zakīma ;
+ca gurum lugalaba$from the inspection of Lugal-abba ;
+tug gemebarasiga$textile  Geme-barasiga ;
+NUMB X$NUMB  Nin-am . . ;
+NUMB lugalmagure$lugal-magure
+NUMB gemeculgi$Geme-Šulgi
+NUMB nininimgina$Nin-inimgina
+NUMB gemeuru$Geme-Uru ,
+dumunime$being her children ;
+NUMB inbadbad$NUMB  Inbadbad ;
+ca gurum dada$from the inspection of Da’ada ;
+NUMB nininimgina$NUMB  Nin-inimgina ,
+arua girinisa$donated  Girini-isa ;
+NUMB ninhegal$NUMB  Nin-ḫegal ;
+NUMB ningakam$NUMB  Ningakam ;
+ca gurum lutu$from the inspection of Lu-Utu ;
+X nininimgina$… nin-inimgina ;
+NUMB X X X$NUMB …  Geme2-an… ,
+dumu ninbazi$daughter  Nin-bazi ;
+X ninesirkiag$…  Nin-esir-kiag
+NUMB gemenarua dumuni$Geme2-Narua , her daughter ;
+ar ninegalesi$milling : Nin-egalesi ?
+ar urdardu dumuni$milling : Ur-dardu , her son ;
+ca gurum lugalsukkal$from the inspection  Lugal-sukkal ;
+NUMB gemesaga$NUMB  Gemesaga ;
+NUMB cabanasig$NUMB  Šabanasig
+NUMB gemeceila$Geme-še’ila
+NUMB  NUMB lammanambazige$Lamma-nambazige
+NUMB urculgi$Ur-Šulgi ,
+dumunime$being her children ;
+ca gurum urningeczida$from the inspection  Ur-Ningešzida ;
+geme ucbaram$it is female weaver ;
+tug gemenigar$textile  Geme-nigar ,
+NUMB ninmuceigimu$NUMB  Ninmuše-igimu ,
+tug gemeckuga$textile  Geme-eškuga
+tug mama$Mama ,
+geme dumugime$being female laborers and dumugi ,
+ca gurum luninmar$from the inspection of Lu-Ninmar ;
+cunigin NUMB geme NUMB tugta$total : NUMB female laborers , NUMB textile each ;
+cunigin NUMB geme NUMB mana sikita$total : NUMB female laborers , NUMB mana wool each ;
+cunigin NUMB geme NUMB manata$total : NUMB female laborers , NUMB mana each ;
+cunigin NUMB la NUMB geme a NUMB manata$total : NUMB female laborers , NUMB , NUMB mana each ;
+cunigin NUMB la NUMB dumu NUMB manata$total : NUMB children , NUMB mana each ;
+cunigin NUMB dumu NUMB manata$total : NUMB children , NUMB mina each ;
+cunigin NUMB dumu NUMB manata$total : NUMB children , NUMB mina each ;
+cunigin NUMB geme cugi NUMB manata$total : NUMB old female laborers , NUMB mana each ;
+tugbi NUMB$their textiles : NUMB ,
+sikibi NUMB gu NUMB la NUMB mana$its wool : NUMB talents NUMB mana ,
+gubam$stationed ;
+cunigin NUMB la NUMB geme NUMB manata$total : NUMB female laborers , NUMB mana each ;
+cunigin NUMB dumu NUMB manata$total : NUMB children , NUMB mina each ,
+ara ziga$for milling booked out ;
+cunigin NUMB geme NUMB manata$total : NUMB female laborers , NUMB mana each ;
+cunigin NUMB dumu NUMB mana$total : NUMB child  NUMB mana ,
+baucme$dead ones ;
+tugba sikiba geme ucbar$textile rations ;
+X X$… ;
+ca guaba$in Gu’abba ;
+X X X$. . ;
+nubanda lugalirida$superintendent : Lugal-irida ;
+iti X$month  … ;
+mu enmahgalana enanna bahun$year “ Enmahgalanna  was installed . ”
+pisanduba$Basket-of-tablets
+dub gida$xxx
+amarcuba$xxx
+igal$xxx
+mu enmahgal$xxx
+nincubur$For Ninšubur
+unuga$of Uruk ,
+ninani$his mistress ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur ,
+NUMB gin kubabbar$NUMB shekel silver ,
+a ente iti minace$labor of the wintertime , over two months ,
+ki urdamuta$from Ur-Damu
+NUMB urgagia$did NUMB Ur-gagia ,
+NUMB lugalhegal$one Lugal-ḫegal
+NUMB urculpae$and NUMB Ur-Sulpa’e
+cu batiec$receive ;
+iti barazagar$month : “ bara-zagar ”
+u NUMB zala$the ordNUMB day completed ,
+mu lulubum bahul$year : “ Lullubum was destroyed . ”
+lamma$For Lamma
+ninani$his mistress ,
+namti$for the life
+culgi$of Šulgi ,
+nita kalga$the mighty man ,
+lugal urimakace$the king of Ur ,
+babaninam$Baba-ninam
+zabardab$the cup-bearer
+urningirsu$of Ur-Ningirsu ,
+en kiag nancekake$the beloved en-priest of Nanše ,
+hili namunuskani$her wig of womanhood
+munadim$he fashioned for her .
+NUMB sa gizi$NUMB bundles of fodder reed ,
+guniginba NUMB sata$in each bale : NUMB bundles ;
+ki lugalmumagta$from Lugal-mumag ,
+kicib alulu$under seal of Alulu ;
+iti cekaragala$month : “ Barley at the quay , ”
+mu en eridu bahun$Year : “ The high-priestess of Eridu was hired . ”
+alulu$Alulu ,
+dumu inimcara$son of Inim-Šara ,
+kurucda caraka$animal fattener of Šara .
+pisanduba$Basket-of-tablets
+ce erine cu tia$xxx
+nigka cu suba$xxx
+mu ancan bahulta$xxx
+mu bad mada baduce$xxx
+mu NUMBkam$xxx
+gun dea$xxx
+mu en eriduta$xxx
+mu usa bad mada baduce$xxx
+mu NUMBkam$xxx
+igal$xxx
+NUMB ceba zamu$NUMB barig , barley ration of the new year ,
+ekikkenta$from the milling house ,
+adamu nukiri$Addamu , the gardener ,
+cu bati$received
+ki lugalukkene$at the place of Lugal-ukkene ;
+iti ezemculgi$month : “ Festival of Šulgi , ”
+mu kimac bahul$year : “ Kimaš was destroyed . ”
+pisanduba$Basket-of-tablets
+muku cabi$xxx
+suga cara umma$xxx
+giri lugalnir$xxx
+iti NUMBkam$xxx
+iti cesagkuta$xxx
+iti paue$xxx
+mu en eridu bahun$xxx
+pisanduba$Basket-of-tablets
+kicib daba$xxx
+kuli$xxx
+iti NUMBkam$xxx
+iti cesagkuta$xxx
+iti dirice$xxx
+mu e cara badu$xxx
+NUMB ab$NUMB cows
+emuhaldim$the kitchen
+u NUMBkam$on the ordNUMB day
+ki intaeata$out of  Intaea
+bazi$were booked ;
+iti ezemah$month : “ Great festival , ”
+mu guza enlila badim$year : “ The throne of Enlil was built ; ”
+NUMB gu$NUMB bovines .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lugalkugani$Lugal-kugani ,
+dubsar$scribe ,
+ARADzu$is your servant .
+urnamma$Ur-Namma ,
+lugal urima$king of Ur
+lugal kiengi kiuri$and king of Sumer and Akkad ,
+lu e enlila$the person who the temple of Enlil
+indua$built .
+alamu$Ayallamu ,
+dumu lana$son of Lana ,
+kurucda$fattener .
+lamma tarsirsira$To the Guardian Angel of the Tarsirsira temple ,
+ama baba$mother Baba ,
+ninani$his mistress ,
+namti$for the life
+culgi$of Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurikace$and king of Sumer and Akkad ,
+halalamma$Hala-Lamma ,
+dumu lugirizal$daughter of Lu-girizal ,
+ensi$the governor
+lagackake$of Lagaš ,
+NUMB geme u NUMBce$NUMB female laborers for NUMB days 
+kac ebappirta$beer from the brewery 
+egal gibilce gaga$to New Palace carried , 
+NUMB geme u NUMBce$NUMB female laborers for NUMB days 
+NUMB dug kabduga ga$NUMB verified vessels carried  
+NUMB geme u NUMBce$NUMB female laborers for NUMB days 
+kac mace gaga$beer to the boat carried ; 
+NUMB geme u NUMBce$NUMB female laborers for NUMB day 
+HU mace gaga$strings to the boat carried ; 
+NUMB geme u NUMBce$NUMB female laborers for NUMB days 
+gi kiri engaldudu ila$reeds  
+NUMB geme u NUMBce$NUMB female laborers for NUMB day 
+ma i zulum kuc siga$the boat of oil , dates and leather loaded ; 
+ziga i macdarea lugal$booked out , oil for the mašdaria-delivery for king ; 
+iti mucudu$month “ Mušudu , ” 
+mu cusuen lugal$year : “ Šū-Suen is king . ” 
+pisanduba$Basket-of-tablets
+nigkak$accounts of
+luduga ugula$Luduga , the foreman ,
+mu e cara badu$year : “ The house of Šara was erected . ”
+pisanduba$Basket-of-tablets
+gagara$xxx
+enlilaka$xxx
+pisanduba$Basket-of-tablets
+nigka cuku gal$xxx
+NUMB eki$NUMB Eki ,
+iti dalta$from the month “ Flight , ”
+NUMB lugaldaban$NUMB Lugaldaban ,
+iti cunumunata$from the month “ Seeding , ”
+NUMB ARADhula$NUMB ARADhulla ,
+iti eitiNUMBta$from the month “ House-month-6 , ”
+ririga$fallen ;
+ugula basa$overseer : Basa ;
+kicib namcatam$official seal of
+urama$Uramma ;
+mu en eridu bahun$year : “ the en-priest of Eridu was installed . ”
+urama$Uramma ,
+dubsar$scribe ,
+dumu nasilim$son of Nasilim .
+pisanduba$Basket-of-tablets
+gurumak$inspections
+sipa unu$of shepherds , cattle herders of
+kinunir$Kinunir ,
+nigin$Nigin ,
+guaba$Guabba ,
+sipa cagan$equid herders
+sipa unu culgi$shepherds , cattle herders of Šulgi
+u sagapin e ninhursag$and head-plowmen of the house of Ninḫursag ,
+igal$are here ;
+mu harci bahul$year : “ Ḫarsi was destroyed . ”
+pisanduba$Basket-of-tablets
+guapin guba$plow-oxen , stationed ,
+e ninmar$house of Ninmar ,
+igal$are here ;
+mu cusuen lugal urimake bad martu muriqtidnim mudu$year : “ Šū-Suen , king of Ur , the Amorite wall  mūriq-tidnim erected . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urnungal$Ur-Nungal ,
+dubsar$scribe ,
+dumu urcara$son of Ur-Šara ,
+cadubaka$chief accountant ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+sikiba cudua$wool rations , completed ,
+ca umma$in Umma
+u ca apisal$and in Apisal ,
+igal$are here ;
+mu cacru bahul$year : “ Šašru was destroyed . ”
+NUMB amar macda$NUMB calf-gazelles
+nanna$for Nanna ,
+muku ku$delivery of Ku’u ,
+nannaGIRgal mackim$Nanna-GIRgal was enforcer ;
+NUMB amar macda$NUMB calf-gazelle ,
+euzga$to the uzga-house ,
+muku habrucer$delivery of Ḫabru-šer ,
+urbaba mackim$Ur-Baba was enforcer ;
+NUMB sila cugid$NUMB lamb , šugid offering ,
+emuhaldimce$for the kitchen ;
+u NUMBkam$ordNUMB day ,
+ki abasagata bazi$from Abbasaga booked out ;
+iti macdagu$month : “ Gazelle-feast , ”
+mu usa amarsuen lugal$year after : “ Amar-Suen is king ; ”
+NUMB$NUMB .
+n NUMB tug guza saga$NUMB garment , guz-za , good quality ,
+NUMB tug taba saga$NUMB garment , double-threaded , good quality ,
+NUMB tug bardul saga$NUMB garment , outer-cover , good quality ,
+NUMB tug bardul gutar$NUMB units of outer-cover … ,
+NUMB tug gue X$NUMB garments gu2-e3 … ,
+NUMB tug gue du$NUMB garments , gu2-e3 , regular quality ,
+NUMB la NUMB tug guza du$NUMB less NUMB garments , guz-za , f regular quality ,
+NUMB tug habum$one garment , soft ,
+NUMB tug X X gal$NUMB garments of … ,
+NUMB tug aktum gi$NUMB garments , native aktum ,
+NUMB tug elam$NUMB garments , Elamite ,
+NUMB tug barsi gue$NUMB garments , bar-si , gu2-e3 ,
+NUMB gada gal saga$NUMB linens , good quality ,
+NUMB gada cagadu$NUMB linens , ša3-ga-du3 ,
+NUMB gada sag$NUMB linens , head ,
+ki galagalta$from  the galla-gal
+dingirake$Dingira
+cu bati$received ;
+iti ezemnesag$month : “ Festival of first-fruits . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+a gacamene$xxx
+igal$xxx
+mu en eridu bahun$xxx
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents of dab ,
+cecsaga ugula ucbar$Šeš-saga , foreman of the weavers ,
+igal$are here ;
+mu enunugal inanna bahun$year : “ Enunugal of Inanna was installed . ”
+u$and
+mu cac bahul$year : “ Šašru was destroyed . ”
+NUMB dabin gu$NUMB barig of chick-pea flour ,
+ki kaguruta$from the chief of the granary ,
+kicib adudu musub$under seal of Adudu , the musub .
+ekikken sumunta$From Old-mill .
+mu ma enki babdu$Year : “ The boat of Enki was caulked . ”
+adudu$Adudu ,
+dumu urman$son of Ur-man ,
+gudu ninsunka$gudu-priest of Ninsun .
+pisanduba$Basket-of-tablets
+ludaba$daba men ,
+dingir apinla muku$gods , plough maintenance , deliveries ;
+mu bad martu badu$year : “ The Amorite wall was erected . ”
+pisanduba$Basket-of-tablets
+gurumak$inspections
+erin sagapin$troops , head-plowmen ,
+e culgi X$house of Šulgi … ,
+igal$are here ;
+mu cacrum bahul$year : “ Šaszrum was destroyed . ”
+NUMB |UHUL$NUMB fat-tailed ewe ,
+NUMB sila ga$NUMB male suckling lambs ,
+NUMB kir ga$NUMB suckling ewe lambs ,
+bauc u NUMBkam$slaughtered , ordNUMB day ;
+ki ludingirata$from Lu-dingira
+urnigar$Ur-nigar
+cu bati$received ;
+iti ezemana$month : “ Festival of An , ”
+mu amarsuen lugal$year : “ Amar-Suen  king ; ”
+NUMB$NUMB .
+di tila$Finished judgment
+pisanduba$in the basket-of-tablets
+igal$are ,
+cu sukkalmah$xxx
+ensi$xxx
+giri lucara$xxx
+giri luebgal$xxx
+giri ludingira$xxx
+giri urictaran$xxx
+dikubime$xxx
+mu en eridu bahun$xxx
+pisanduba$Basket-of-tablets
+a uda$xxx
+acata eda$xxx
+ca guaba$xxx
+igal$xxx
+mu ibisuen lugal$xxx
+dumu X X X$the son of … ,
+ensi$the governor
+nibrukake$of Nippur ,
+namtilanice$for his life
+a munaru$dedicated  to him/her .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urkununa sukkal$Ur-kununa , courrier ,
+dumu ARADdani$son of ARADani ,
+diku$judge ,
+ARADzu$is your servant .
+NUMB udu niga NUMB sila ceta$NUMB sheep , grain-fed , NUMB sila3 of barley each ,
+NUMB sila duh$NUMB ban2 NUMB sila3 of bran ,
+u NUMBce$for NUMB days ,
+cunigin cebi NUMB gur$the total , its barley : NUMB gur NUMB barig NUMB ban2 ;
+cunigin duhbi NUMB gur$the total , its bran : NUMB gur NUMB barig ;
+ki inimcara ca umma$from Inim-Šara in Umma
+giri alulu$via Alulu ;
+iti cesagku$month “ Harvest , ”
+mu usa enmahgalana bahun$year after : “ Enmaḫgalana was installed . ”
+NUMB udu niga$NUMB sheep , grain-fed ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+ahuwer$Aḫu-wer
+idab$accepted ;
+iti ezemninazu$month : “ Festival of Ninazu , ”
+mu enmahgalana en nanna bahun$year : “ Enmaḫgalana , priestess of Nanna , was installed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+cenumun$xxx
+cabrane$xxx
+igal$xxx
+mu en nanna karzida bahun$xxx
+pisanduba$Basket-of-tablets
+nigkak$accounts
+X X X X X ki$…
+e enlila$the house of Enlil
+igal$are here ;
+iti X X X mac$month : “ … , "
+mu cacrum bahul$year : “ Šašrum was destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+situm$xxx
+ce sumun$xxx
+igal$xxx
+mu kimac bahul$xxx
+pisanduba$Basket-of-tablets
+ceba zamuka$barley rations of the new year ,
+mu usa en eridu bahunga$year following : “ The en in Eridu was installed , ”
+igal$are here .
+pisanduba$Basket-of-tablets
+gilsa sila$xxx
+anunitum$xxx
+lugale igidua$xxx
+ingal$xxx
+pisanduba$Basket-of-tablets
+ca dugana ekas$xxx
+ca girsu$xxx
+mu huhunuri bahul$xxx
+nergal $O Nergal ,
+X $king
+hawilim $of HaWIlum -
+atalsien $Atal-šen ,
+reum epzum $the accomplished shepherd ,
+X $king
+urkic $of Urkiš
+u nawar $and Nawar ,
+X sadarmat $son of Sadar-mat
+X $the king ,
+X e $is the builder of the temple
+nergal $of Nergal
+nir caninutim $the slayer of rivals .
+X X $The one who the inscription
+cuati $this one
+ucasaku $shall remove ,
+utu $may Šamaš
+u inanna $and Ištar
+X $his seed
+lilquta $pluck out .
+NUMB ad udu niga$NUMB carcass of a grain-fed sheep ;
+NUMB ad udu u$NUMB carcasses of grass-fed sheep ;
+sadu cara apisal$as rations of Šara of Apisal ,
+muku$deliveries ;
+giri habaluge$via Habaluge .
+iti eitiNUMB$Month : “ house-sixth-month , ”
+mu cusuen lugale e cara mudu$year : “ Šu-Suen the king erected the house of Šara . ”
+cusuen$Šu-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+X$PN1 ,
+dubsar$scribe ,
+dumu X$son of PN2 ,
+ARADzu$is your servant .
+NUMB u kura bauc$NUMB ewe of mountainland , slaughtered ,
+ki uruta$from Urru ,
+kicib lukala$under seal of Lukalla ;
+iti cekaragala$month : “ Barley at the quay ; ”
+mu usa enmahgalana bahun$year after : “ Enmaḫgalana was installed . ”
+lukala$Lukalla ,
+dubsar$scribe ,
+dumu ure cuc$son of Ur-e’e , chief livestock manager .
+X X ce X X$…barley…
+X X$Ur-…
+NUMB GAN NUMB gur$NUMB eše3 field area : NUMB gur ,
+adaga dubsar$Adaga the scribe ;
+NUMB GAN NUMB diri cuku lucara musub$NUMB iku field area : NUMB barig , NUMB ban2 extra , prebend of Lu-Šara the … ;
+NUMB GAN NUMB diri cuku lugalsuen$NUMB iku field area : NUMB  NUMB barig NUMB ban2 extra , prebend of Lugal-Suen ;
+apinlam$cultivation ;
+NUMB GAN cebi NUMB gur$NUMB eše3 field area , its barley : NUMB gur ,
+cuku lucara musub$prebend of Lu-Šara , … ;
+NUMB GAN NUMB gur urgigir igidu$NUMB iku field area : NUMB gur , Ur-gigir , … ;
+NUMB GAN NUMB gur lugalkuzu$NUMB bur3 field area : NUMB gur , Lugal-Kuzu ;
+NUMB GAN NUMB gur luduga dumu lugalkiri$NUMB eše3 field area : NUMB gur , Lu-duga , son of Lugal-kiri6 ;
+aca gida buru$long field , harvest time ,
+aca X$at the field , … ;
+mu X lugal uri X X X X X$year : “ … , king of Ur , … . ”
+pisanduba$Basket-of-tablets
+kicib sagnigura$xxx
+nubanda gukene$xxx
+ki gududuta$xxx
+igal$are here ;
+mu cusuen lugale magurmah mudim$year : “ xxx . ”
+NUMB kuc NUMB udu$NUMB skin NUMB sheep ,
+ki cecsagata$From Šešsaga
+gurdub KWU$…
+BULUG ca kukku$…
+bagar bagar$…
+giri carumili lu kingia$via Šarrum-ilī , the messenger ,
+bur ku muku A X$…
+kicib ure$under seal of Ur-E’e .
+mu ku guza enlila badim$Year : “ The silver-throne of Enlil was fashioned . ”
+ure$Ur-E’e ,
+dubsar$the scribe ,
+dumu urnigar$son of Ur-Nigar .
+pisan ureckuga$Basket Ur-eškuga
+igal$are here .
+nanna$For Nanna
+lugalanir$his master ,
+urnamma$Ur-Namma
+NUMB habuda$NUMB axes ,
+kilabi NUMB mana NUMB gin$their weight is NUMB mina , and NUMB gin .
+NUMB gur NUMB ginta$NUMB plough sickles , NUMB  each ,
+kilabi NUMB mana NUMB gin$their weight is NUMB mina , and NUMB gin .
+kin tila$Finished tools .
+ki luebgalta$From Lu-Ibgal ,
+urcarake inla$Ur-Šara weighed .
+iti cunumun$Month “ harvest ” ;
+mu amarsuen lugal$year : “ Amar-Suen king ” .
+urcara$Ur-Šara ,
+dubsar$the scribe ,
+dumu lugalucur$son of Lugal-usur
+'animdagan$'Anun-Dagān ,
+lugal mari$king of Mari ,
+X$…
+pisanduba$Basket-of-tablets
+dub gida$xxx
+situm$xxx
+lumelam$xxx
+igal$xxx
+mu guza badim$xxx
+nanna$For Nanna ,
+amar banda ana$the impetuous calf of An ,
+dumusag$the first-born son
+enlila$of Enlil ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urimake$the king of Ur ,
+etemenigurni$his Temple With a Foundation Clad in Fearsomeness
+munadu$he built for him .
+pisanduba$Basket-of-tablets
+dub gida idub$xxx
+giri urnance$xxx
+dumu luduga$xxx
+igal$xxx
+mu harci kimac hurti bahul$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urculpae$Ur-Šupa’e ,
+dubsar$scribe ,
+dumu urhaia$son of Ur-Ḫaya ,
+ARADzu$is your servant .
+NUMB sila muku encakuge$NUMB lamb delivery from Enshakuge
+NUMB sila niga muku lunincubur$NUMB lamb delivery from Lu-ninshubur
+nanna$for Nanna
+zabardab mackim$official administrator
+NUMB u cugid$NUMB ewes accepted
+emuhaldimce$into the house of the cook
+ziga u NUMB la NUMBkam$credited on the ordNUMB day .
+iti ezemninazu$Month : “ festival of the Ninazu , ”
+mu usa urbilum bahul$year after : “ Urbilum was destroyed . ”
+NUMB sila kac saga NUMB sila ninda $NUMB sila3 fine beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundle onions ,
+X X $for A-…
+NUMB kac NUMB ninda X $NUMB ban2 beer NUMB ban2 bread…
+X $…
+giri X $via …
+cunigin NUMB sila kac saga cunigin NUMB kac $total : NUMB sila3 fine beer ; total : NUMB ban2 beer ;
+cunigin NUMB sila ninda cunigin NUMB gin i $total : NUMB ban2 NUMB sila3 bread ; total : NUMB shekels oil ;
+cunigin NUMB gin naga cunigin NUMB sa cum $total : NUMB shekels alkali-plant ; total : NUMB bundle onions ;
+u NUMBkam $ordNUMB day ,
+iti lisi $month : “ Lisi , ”
+mu cusuen lugale naruamah enlil munadu $year : “ Šū-Suen , the king , the great stele for Enlil erected . ”
+pisanduba$Basket-of-tablets
+nigkak$accounts of
+abilatum kurucda$Abilatum , the fattener ,
+iti ezemana u NUMB zala$month “ Festival-of-An , ” ordNUMB day passed ,
+mu en nanna mace ipa$year : “ The en of Nanna by the goat was found , ”
+iti cesagku$to month “ Harvest , ”
+mu simurum lulubu ara NUMB la NUMBkam bahulce$year : “ Simurum , Lulubu for the ordNUMB time were destroyed , ”
+itibi NUMB u NUMB$its months NUMB , days NUMB .
+NUMB udu alum$NUMB long-fleeced sheep
+lugalmagure$Lugal-magure ,
+utamicaram mackim$Uta-mišaram , responsible official ;
+NUMB amar az$NUMB bear cubs
+euzga$for the E’uzga house ,
+akala mackim$Ayakala , responsible official ;
+NUMB gu NUMB udu cimacgi$NUMB ox , NUMB Šimaškian sheep ,
+urningubalag nar$for Ur-Ningubalag , the cantor ;
+ca mukurata$from the deliveries ,
+u NUMB la NUMBkam$the ordNUMB day ,
+ki abasagata$from Abbasaga ;
+iti ezemah$month : “ Grand Festival , ”
+mu en inanna bahun$year : “ The en-priest of Inanna was hired ; ”
+NUMB$NUMB .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urgagia$Ur-gagia ,
+dubsar$scribe ,
+dumu namhani$son of Namhani ,
+ARADzu$is your servant .
+NUMB gu$NUMB ox ,
+NUMB udu u$NUMB sheep , grain-fed ;
+igikar dam sukkalmah$birth gift for the wife of the sukkalmaḫ ;
+NUMB acgar niga$NUMB female kids , grain-fed ;
+ma anace$for boat of An ;
+ziga$booked out
+belidu$Belī-ṭab ;
+iti ezemekigal$month : “ Festival of Mekigal , ”
+mu usa ancan bahul$year after : “ Anšan was destroyed . ”
+carakam$Šara-kam , 
+dubsar$scribe : 
+culgimudah ARADzu$Šulgi-mudaḫ , your servant . 
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+igianakezu sukkal$Igi-anakezu , messenger
+dumu ARADdani$son of ARADani
+diku$judge ,
+ARADzu$is your servant .
+NUMB mana NUMB gin NUMB ce kubabbar$NUMB mana NUMB shekel NUMB grains silver ,
+situm$the remainder ;
+cabita$therefrom
+NUMB mana NUMB gin kubabbar$NUMB mana NUMB shekels silver ,
+muku$delivery ;
+NUMB sila esir EA$NUMB barig NUMB ban2 NUMB sila3 ES-bitumen ,
+kubi NUMB gin$its silver : NUMB shekels ;
+n NUMB sila naga sie gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 horned-alkali plant
+kubi n gin n ce$its silver : NUMB shekels NUMB grains ;
+cunigin NUMB mana NUMB gin NUMB ce ku$total : NUMB mana NUMB shekels NUMB grains silver
+zigam$booked out ;
+laia NUMB mana NUMB gin NUMB ce ku$the deficit : NUMB mana NUMB shekels NUMB grains silver ;
+nigkak pada damgar$account of Pada , the trade agent ;
+mu enunugal inanna bahun$year : “ En-unugal of Inanna was hired . ”
+NUMB$NUMB
+NUMB sila ga$NUMB suckling lamb ,
+bauc$slaughtered ,
+u NUMBkam$the ordNUMB day ,
+ki kurbilakta$from Kurbilak
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti ezemana$month : “ Festival of An , ”
+mu ma enki badim$year : “ The boat of Enki was fashioned . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+liburculgi$Libur-Šulgi ,
+dumu enumili$son of Ennum-ilī ,
+ARADzu$is your servant .
+NUMB udu kicib lusaga$NUMB sheep , sealed tablet of Lu-saga ,
+NUMB udu kicib urickur cabra$NUMB sheep , sealed tablet of Ur-Iškur šabra ,
+NUMB udu kicib habamu$NUMB sheep , sealed tablet of Habamu
+NUMB udu kicib ilia$NUMB sheep , sealed  of Ilia ,
+NUMB udu urcu muhaldim$NUMB sheep of the cook Uršu ,
+NUMB udu kicib ursukkal$NUMB sheep , sealed tablet of Ur-sukkal ,
+NUMB udu rimili$NUMB sheep of Rim-ili ,
+abakala cu bati$did Abbakala receive .
+iti ezemculgi$Month “ Šulgi festival , ”
+mu e cara badu$year : “ The house of Šara was erected . ”
+mu e cara badu$year : “ The house of Šara was erected . ”
+NUMB$NUMB
+abakala$Abbakala ,
+dubsar$scribe ,
+dumu luningirsu$son of Lu-Ningirsu .
+pisanduba$Basket-of-tablets
+gurum ak daba$xxx
+e amarsuen$xxx
+igal$xxx
+mu cacru$xxx
+pisanduba$Basket-of-tablets
+di tila$xxx
+giri uludi$xxx
+u urictaran macugidgid$xxx
+igal$xxx
+mu guza enlil badim$xxx
+NUMB ma NUMB gur NUMBta malahbi ibu$NUMB barges of NUMB gur  each , their skippers piloting ,
+u NUMBce$for NUMB days ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ;
+apisalta$from Apisal
+nibruce siki basi$to Nippur , with wool filled ,
+giri ure$via Ur-e’e ,
+mu urbilum bahul$year : “ Urbilum was destroyed . ”
+muni bibsara$the one who shall write his name on it ,
+X$on this …
+meslamtae$the god Meslamtaea
+X$my …
+X |GA$…
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+luningirsu$Lu-Ningirsu ,
+dubsar$scribe ,
+dumu lubaba$son of Lu-Baba ,
+ARADzu$is your servant .
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca culpae aca nagatum u aca egirgilu$harvested and sheaves piled up in the Šulpa’e field , in the Nagatum field and in the Egirgilu field .
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca audagula aca audatur u aca nuna$harvested and sheaves piled up in the Audagula field , in the Audatur field and in the Prince field .
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca gusuhub aca urninti u aca ezina$harvested and sheaves piled up in the Oxen boot field , in the Ur-Ninti field and the E-Ezina field .
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca badua aca icibene u aca udulusaga$harvested and sheaves piled up in the field Constructed Wall , in the Incantation priests field and in
+NUMB guruc u NUMBce$NUMB workdays ,
+gura zar taba aca uduninarali u gaba aca gibil$harvested and sheaves piled up in the field Cattle-herder-of-Nin-Arali and  across from the new field .
+NUMB guruc u NUMBce$NUMB workdays ,
+ada guba aca audagula aca audatur u aca nuna$irrigation work in the Audagula field , in the Audatur field and in the Prince field .
+ugula lucara$The foreman is Lu-Šara .
+kicib daga$Sealed tablet by Da'aga .
+mu simanum bahul$Year : “ Simanum was destroyed . ”
+daga$Da'aga ,
+dubsar$scribe ,
+dumu urgecaga$son of Urgeš-šaga .
+pisanduba$Basket-of-tablets
+duba ziga X lugal$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+nigkak$xxx
+sipa unuene$xxx
+iti macdaguta$xxx
+iti diri cesagkuce$xxx
+iti NUMBkam$xxx
+caba iti diri NUMBam igal$xxx
+mu cusuen lugal$xxx
+igal$xxx
+NUMB guruc u NUMBce $NUMB male laborers for NUMB day
+u ila X $grass carried ,
+e sadura auda $sadura ditch of auda ,
+ugula ARADmu $foreman : ARADĝu ;
+kicib urmes aigidu $under seal of Ur-mes , the canal inspector ;
+mu cacurum bahul $year : “ Šašrum was destroyed . ”
+urmes $Ur-mes ,
+dumu nabalu $son of Nabalu .
+NUMB gu niga$NUMB grain-fed oxen ,
+NUMB ab niga$NUMB grain-fed cow ,
+NUMB la NUMB gu$NUMB less NUMB oxen ,
+NUMB ab$NUMB cows ,
+NUMB cegbarmunus$NUMB deer doe ,
+NUMB zizinita$NUMB stallion ,
+NUMB zizimunus$NUMB mare ,
+NUMB udu niga$NUMB grain-fed sheep ,
+NUMB u niga$NUMB grain-fed ewes ,
+NUMB mac niga$NUMB grain-fed buck goats ,
+NUMB ud niga$NUMB grain-fed doe goats ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewes ,
+NUMB mac$NUMB buck goats ,
+NUMB ud$NUMB goat doe goat ,
+NUMB daranita$mountain goat buck ,
+NUMB macda$NUMB gazelles ,
+NUMB az$NUMB bear ,
+NUMB$NUMB ,
+muku lugal$royal delivery ;
+NUMB udu$NUMB sheep ,
+NUMB mac$NUMB buck goats ,
+ NUMB$NUMB ,
+muku culgi$delivery of Šulgi ;
+NUMB la NUMB kunganita$NUMB less NUMB male k-equids ,
+NUMB kungamunus$NUMB female k-equids ,
+ NUMB$NUMB ,
+ki cabraneta$from the managers ;
+NUMB gu$NUMB oxen ,
+NUMB ab$NUMB cows ,
+NUMB cegbarnita$NUMB deer bucks ,
+NUMB cegbarmunus$NUMB deer doe ,
+NUMB dusunita$NUMB jackasses ,
+NUMB dusumunus$NUMB jenny ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewes ,
+NUMB mac$NUMB buck goats ,
+NUMB ud$NUMB doe goats ,
+NUMB$NUMB ,
+edula$estate .
+NUMB gu$NUMB oxen ,
+NUMB ab$NUMB cow ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewes ,
+NUMB mac$NUMB buck goats ,
+NUMB ud$NUMB doe goats ,
+NUMB macda$NUMB gazelles ,
+NUMB$NUMB ,
+acata$from the field .
+cunigin NUMB gu niga$total : NUMB grain-fed oxen ,
+cunigin NUMB ab niga$total : NUMB grain-fed cow ,
+cunigin NUMB gu$total : NUMB oxen ,
+cunigin NUMB ab$total : NUMB cows ,
+cunigin NUMB cegbarnita$total : NUMB deer bucks ,
+cunigin NUMB cegbarmunus$total : NUMB deer does ,
+cunigin NUMB zizinita$total : NUMB stallion ,
+cunigin NUMB zizimunus$total : NUMB mare ,
+cunigin NUMB la NUMB kunganita$total : NUMB less NUMB male k-equids ,
+cunigin NUMB kungamunus$total : NUMB female k-equids ,
+cunigin NUMB dusunita$total : NUMB jackasses ,
+cunigin NUMB dusumunus$total : NUMB jenny ,
+cunigin NUMB udu niga$total : NUMB grain-fed sheep ,
+cunigin NUMB u niga$total : NUMB grain-fed ewes ,
+cunigin NUMB mac niga$total : NUMB grain-fed jack gaots ,
+cunigin NUMB ud niga$total : NUMB grain-fed doe goats ,
+cunigin NUMB udu$total : NUMB sheep ,
+cunigin NUMB u$total : NUMB ewes ,
+cunigin NUMB mac$total : NUMB buck goats ,
+cunigin NUMB ud$total : NUMB doe goats ,
+cunigin NUMB daranita$total : NUMB male mountain goat ,
+cunigin NUMB macda$total : NUMB gazelles ,
+cunigin NUMB az$total : NUMB bear ,
+niginba NUMB gu ab hia$altogether : NUMB various oxen and cows ,
+niginba NUMB la NUMB cegbar$altogether : NUMB less NUMB deer ,
+niginba NUMB zizi$altogether : NUMB horses ,
+niginba NUMB kunga$altogether : NUMB k-equids ,
+niginba NUMB dusu$altogether : NUMB donkeys ,
+niginba NUMB udu mac hia$altogether : NUMB various sheep and goats ,
+niginba NUMB macda$altogether : NUMB gazelles ,
+niginba NUMB az$altogether : NUMB bear ,
+NUMB$NUMB ,
+sagnigurakam$are the debit ;
+cabita$therefrom
+NUMB gu niga$NUMB grain-fed oxen ,
+NUMB gu$NUMB oxen ,
+NUMB udu niga$NUMB grain-fed sheep ,
+NUMB ud niga$NUMB grain-fed doe goat ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewes ,
+NUMB mac$NUMB buck goats ,
+NUMB ud$NUMB doe goats ,
+NUMB macda$NUMB gazelles ,
+NUMB$NUMB ,
+ziga lugal$royal deductions .
+adbi urnigar$their carcasses Ur-nigar
+cu bati$received ;
+kucbi$their leather
+lugalerin cu bati$Lugal-erin received .
+NUMB udu niga$NUMB grain-fed sheep ,
+NUMB udu$NUMB sheep ,
+NUMB mac$NUMB buck goat ,
+NUMB$NUMB ,
+guza culgi$throne of Šulgi .
+NUMB la NUMB gu niga$NUMB less NUMB grain-fed oxen ,
+NUMB udu niga$NUMB grain-fed sheep ,
+NUMB udu$NUMB sheep ,
+NUMB mac$NUMB buck goats ,
+NUMB macda$NUMB gazelle ,
+NUMB$NUMB ,
+nigba lugal$royal gift .
+NUMB udu$NUMB sheep ,
+NUMB$NUMB ,
+sadu gula$ration of Gula .
+NUMB udu$NUMB sheep ,
+NUMB$NUMB ,
+sadu inimnanna$ration of Inim-Nanna ,
+NUMB la NUMB kunganita$NUMB less NUMB male k-equids ,
+NUMB kungamunus$NUMB female k-equids ,
+NUMB$NUMB ,
+mu urace$for the dogs
+kalculgi cu bati$Dan-Šulgi received .
+NUMB udu$NUMB sheep ,
+NUMB mac$NUMB buck goats ,
+NUMB$NUMB ,
+bauc mu urace$slaughtered , for the dogs
+dingirbani cu bati$Ilum-bani received .
+NUMB ab bauc$NUMB cow , slaughtered ,
+NUMB$NUMB ,
+kicib urnigar$under seal of Ur-nigar .
+NUMB ab$NUMB cows ,
+NUMB daranita$NUMB male mountain goat ,
+NUMB az$NUMB bear ,
+NUMB$NUMB ,
+kicib ensi u cabrane$under seal of the governor and the managers ;
+NUMB gu niga$NUMB grain-fed oxen ,
+NUMB gu$NUMB oxen ,
+NUMB ab$NUMB cows ,
+NUMB udu niga$NUMB grain-fed sheep ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewes ,
+NUMB mac$NUMB buck goats ,
+NUMB$NUMB ,
+kicib ludingira dumu inimcara$under seal of Lu-dingira son of Inim-Šara .
+NUMB gu niga$NUMB grain-fed oxen ,
+NUMB ab$NUMB cow ,
+NUMB udu niga$NUMB grain-fed sheep ,
+NUMB ud niga$NUMB grain-fed doe goat ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewes ,
+NUMB la NUMB mac$NUMB less NUMB buck goats ,
+NUMB$NUMB ,
+kicib culgiamu$under seal of Šulgi-ayamu ;
+NUMB cegbarnita$NUMB deer bucks ,
+NUMB cegbarmunus$NUMB deer does ,
+NUMB zizinita$NUMB stallion ,
+NUMB zizimunus$NUMB mares ,
+NUMB$NUMB ,
+kicib ludingira dumu ARADhula$under seal of Lu-dingira son of ARAD-ḫula ;
+NUMB udu niga$NUMB grain-fed sheep ,
+NUMB u niga$NUMB grain-fed ewes ,
+NUMB mac niga$NUMB grain-fed buck goats ,
+NUMB ud niga$NUMB grain-fed doe goats ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewe ,
+NUMB mac$NUMB buck goats ,
+NUMB$NUMB ,
+kicib nalu$under seal of Nalu ;
+NUMB dusunita$NUMB jackasses ,
+NUMB dusumunus$NUMB jenny ,
+NUMB$NUMB ,
+kicib cuera$under seal of Šū-Erra ;
+NUMB gu niga$NUMB grain-fed oxen ,
+NUMB ab niga$NUMB grain-fed cow ,
+NUMB gu$NUMB ox ,
+NUMB$NUMB ,
+kicib urcugalama$under seal of Ur-šugalama ;
+NUMB gu niga$NUMB grain-fed oxen ,
+NUMB udu niga$NUMB grain-fed sheep ,
+NUMB la NUMB udu$NUMB less NUMB sheep ,
+NUMB$NUMB ,
+cula$… ,
+sila SIGa$on the street ,
+kicib beliazu$under seal of Belī-azu ,
+NUMB gu$NUMB oxen ,
+NUMB ab$NUMB cows ,
+NUMB udu$NUMB sheep ,
+NUMB mac$NUMB buck goats ,
+NUMB ud$NUMB doe goats ,
+NUMB macda$NUMB gazelles ,
+NUMB la NUMB$NUMB less NUMB ,
+ibtak acace$remainder for the field ;
+cunigin NUMB gu niga$total : NUMB grain-fed oxen ,
+cunigin NUMB ab niga$total : NUMB grain-fed cow ,
+cunigin NUMB gu$total : NUMB oxen ,
+cunigin NUMB ab$total : NUMB cows ,
+cunigin NUMB cegbarnita$total : NUMB deer bucks ,
+cunigin NUMB cegbarmunus$total : NUMB deer does ,
+cunigin NUMB zizinita$total : NUMB stallion ,
+cunigin NUMB zizimunus$total : NUMB mares ,
+cunigin NUMB la NUMB kunganita$total : NUMB less NUMB k-equids ,
+cunigin NUMB kungamunus$total : NUMB female k-equids ,
+cunigin NUMB dusunita$total : NUMB jackasses ,
+cunigin NUMB dusumunus$total : NUMB jenny ,
+cunigin NUMB udu niga$total : NUMB grain-fed sheep ,
+cunigin NUMB u niga$total : NUMB grain-fed ewes ,
+cunigin NUMB mac niga$total : NUMB grain-fed buck goats ,
+cunigin NUMB ud niga$total : NUMB grain-fed doe goats ,
+cunigin NUMB udu$total : NUMB sheep ,
+cunigin NUMB u$total : NUMB ewes ,
+cunigin NUMB mac$total : NUMB buck goats ,
+cunigin NUMB ud$total : NUMB doe goats ,
+cunigin NUMB daranita$total : NUMB male mountain goat ,
+cunigin NUMB macda$total : NUMB gazelles ,
+cunigin NUMB az$total : NUMB bear ,
+niginba NUMB gu$altogether : NUMB oxen ,
+niginba NUMB la NUMB cegbar$altogether : NUMB less NUMB deer ,
+niginba NUMB zizi$altogether : NUMB horses ,
+niginba NUMB kunga$altogether : NUMB k-equids ,
+niginba NUMB dusu$altogether : NUMB donkeys ,
+niginba NUMB udu mac hia$altogether : NUMB various sheep and goats ,
+niginba NUMB macda$altogether : NUMB gazelles ,
+niginba NUMB az$altogether : NUMB bear ,
+NUMB$NUMB ,
+kibe gia$restored ,
+abasaga$Abbasaga ;
+iti macdagu$month : “ Gazelle feast , ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen the king destroyed Urbilum . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urkununa$Ur-kununa ,
+dubsar$scribe ,
+dumu luningirsu$son of Lu-Ningirsu ,
+sipa nagabtum$herder of the nakabtum .
+pisanduba$Basket-of-tablets
+ime taka$xxx
+X$xxx
+igal$xxx
+X $…
+X X AB X $…
+NUMB sila kac saga n X $NUMB sila3 fine beer …
+NUMB X $NUMB …
+NUMB urnanna $NUMB Ur-Nanna ;
+NUMB lueridu $NUMB Lu-Eridu ;
+NUMB duili $NUMB Du-ilī ;
+NUMB akala $NUMB Ayakala ;
+NUMB cuengar $NUMB Šū-engar ;
+NUMB nannakam $NUMB Nannakam ;
+NUMB ursaga $NUMB Ur-saga ;
+NUMB azaza $NUMB Azaza ;
+NUMB X $NUMB …
+NUMB dingirbani $NUMB Ilī-bani ;
+NUMB sila kac NUMB sila nindata $NUMB sila3 beer , NUMB sila3 bread each ;
+NUMB gin cum NUMB gin i NUMB gin nagata $NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant each ;
+cunigin NUMB sila kac saga cunigin X NUMB sila X $total : NUMB ban2 NUMB sila3 fine beer ; total : … NUMB sila3 …
+cunigin NUMB sila ninda cunigin NUMB sila X $total : NUMB ban2 NUMB sila3 bread , total : NUMB sila3 …
+X n sila NUMB gin X $… sila3 NUMB shekel … .
+X n NUMB gin X $… NUMB shekels …
+NUMB ud$NUMB nanny goat ,
+gabi zeda cah gude$its milk to feed the piglet ,
+ki abasagata$from Abbasaga ,
+ludingira idab$did Lu-dingira accept ;
+kicib eabani$under seal of Ea-bani ;
+iti akiti$month : “ Akitu , ”
+mu guza badim$year : “ the divine chair was fashioned . ”
+NUMB ud gabi cah zeda gude$NUMB nanny goat , its milk to feed the piglet ,
+ki abasagata$from Abbasaga ,
+ludingira idab$did Lu-dingira take command of ;
+kicib eamalik$under seal of Ea-mālik ;
+iti akiti$month : “ Akitu , ”
+mu guza enlila badim$year : “ the divine chair was fashioned . ”
+X$…
+ARAD X$servant of …
+pisanduba$Basket-of-tablets
+nigkak$xxx
+ugula ucbara$xxx
+u lu azlagene$xxx
+cairi bara$xxx
+ingal$xxx
+iti NUMBkam$xxx
+mu ibisuen lugal urimake simurum muhul$xxx
+pisanduba$Basket-of-tablets
+guapin guba$plow-oxen , stationed ,
+ecucuma$the house of consignments ,
+e ningirsu$house of Ningirsu ,
+e amarsuen$house of Amar-Suen ,
+igal$are here ;
+mu$year : “ … . ”
+NUMB macgal niga$NUMB billy goats , full-grown , grain-fed ,
+NUMB acgar niga$NUMB female kids , grain-fed ,
+NUMB sila NUMB acgar$NUMB lamb , NUMB female kid
+nanna$Nanna ,
+muku lugalmagure$delivery of Lugal-magure ,
+zabardab mackim$zabardab was enforcer ;
+NUMB gu NUMB udu$NUMB ox , NUMB cows ,
+NUMB sila NUMB mac$NUMB lambs , NUMB male goats ,
+cugid emuhaldimce$šugid for the kitchen ;
+u NUMB la NUMBkam$ordNUMB day ,
+ki abasagata bazi$from Abbasaga booked out ;
+iti ezemana$month : “ Festival of An , ”
+mu amarsuen lugal$year : “ Amar-Suen is king ; ”
+NUMB$NUMB .
+NUMB gin (|NINDA kubabbar$NUMB shekels silver ,
+situm$remainder ;
+NUMB zulum gur lugal$NUMB gur NUMB barig NUMB ban2 dates , royal ,
+kubi NUMB gin igiNUMBgal la NUMB ce$its silver : NUMB  NUMB shekels less NUMB grains ,
+ki cabrata$the the household manager ;
+NUMB gin kubabbar$NUMB shekels silver ,
+mu aca NUMB GANce$because of the field of NUMB bur3 surface area ,
+ki urgigir damgarta$from Ur-gigir , the trade agent ;
+cunigin NUMB mana NUMB gin la NUMB ce kubabbar$total : NUMB mana NUMB shekels less NUMB grains silver ,
+sagnigurakam$consitute the debits ;
+cabita$therefrom
+NUMB mana NUMB gin uruda$NUMB mana NUMB shekels copper ,
+kubi NUMB gin NUMB ce$it silver : NUMB  NUMB shekels NUMB grains ;
+NUMB mana NUMB gin la igiNUMBgal suhe$NUMB mana NUMB less NUMB shekels , suḫe ,
+kubi NUMB gin (|NINDA NUMB ce$its silver : NUMB shekels NUMB grains ;
+NUMB sila igec$NUMB ban2 NUMB sila3 plant oil ,
+mu i tuge akdace$for oiling garments ,
+ili damgar$Ilī , the trade agent ,
+kubi NUMB gin (|NINDA$its silver : NUMB shekels ;
+NUMB igec$NUMB ban2 plant oil ,
+tuge akde$oiling garments ,
+giri urdamu ugula ucbar$via Ur-Damu , foremen of weavers ,
+kubi NUMB gin NUMB ce$its silver : NUMB shekel NUMB grains ;
+NUMB sila esir EA$NUMB ban2 NUMB sila3 EA-bitumen ,
+pisan im sarace$for the basket of inscribed tablets ,
+kubi igiNUMBgal$its silver : NUMB ;
+NUMB zulum$NUMB barig dates ,
+giri intila$via Intila ,
+NUMB sila zulum$NUMB ban2 NUMB sila3 dates ,
+giri giribabaidab$via Giri-Baba-idab ,
+kubi igiNUMBgal NUMB ce$its silver : NUMB  NUMB grains ,
+NUMB gu imbabbar$NUMB talents of plaster ,
+kubi igiNUMBgal NUMB ce$its silver : NUMB  NUMB grains ,
+giri lugecbare$via Lu-Gešbare ;
+NUMB usuh cudim mace$NUMB pine planks , šudim for barges ,
+kubi igiNUMBgal X ce NUMB ce$its silver : NUMB ;
+NUMB sila icah$NUMB sila3 lard ,
+kubi igiNUMBgal NUMB ce$its silver NUMB  NUMB grains ,
+ugILme$the porters ,
+giri ezimu$via Ezimu ;
+NUMB kuc cah$NUMB pigskins ,
+kubi NUMB la NUMB ce$it silver : NUMB less NUMB grains ;
+cunigin NUMB mana igiNUMBgal NUMB ce kubabbar$total : NUMB mana NUMB  NUMB grains silver ,
+muku$deliveries ;
+laia NUMB gin (|NINDA NUMB ce kubabbar$the deficit : NUMB shekels , NUMB grain silver ;
+nigkak$done account of
+iks,ur damgar$Ikṣur , the trade agent ;
+iti amarasi$from month : “ Amar-ayasi , ”
+mu cacrum bahulta$year : “ Sasrum was destroyed , ”
+iti amarasi$to month : “ Amar-ayasi , ”
+mu en nanna mace ipace$year : “ The high-priestess of nanna was named . ”
+ureckuga$Ur-eškuga ,
+dubsar$scribe ,
+dumu abagina$son of Abbagina .
+NUMB gu niga sagu$NUMB oxen , grain-fed , top grade ,
+NUMB gu niga$NUMB oxen , grain-fed ,
+ecec euNUMB$“ Temples ” , House-of-Day-7 ;
+iti u NUMB bazal$the month , day NUMB passed ;
+NUMB gu niga inanna$NUMB oxen , grain-fed , Inanna ,
+iti u NUMB bazal$the month , day NUMB passed ;
+NUMB gu niga sagu$NUMB oxen , grain-fed , top grade ,
+NUMB la NUMB gu niga$NUMB oxen , grain-fed ,
+ecec euNUMB NUMB$“ Temples ” , House-of-Day-15 ;
+iti u NUMB bazal$the month , day NUMB passed ;
+ca nibru$in Nippur ;
+NUMB gu niga inanna$NUMB oxen , grain-fed , Inanna ,
+iti u NUMB bazal$the month , day NUMB passed ;
+NUMB gu niga inanna$NUMB oxen , grain-fed , Inanna ,
+iti u NUMB bazal$the month , day NUMB passed ;
+NUMB gu niga inanna$NUMB oxen , grain-fed , Inanna ,
+iti u NUMB bazal$the month , day NUMB passed ;
+NUMB gu niga ezemana$NUMB oxen , grain-fed , “ Festival Boat-of-Heaven , ”
+zabardab mackim$the zabardab  was enforcer ;
+iti u NUMB bazal$the month , day NUMB passed ;
+ca unuga$in Uruk ;
+NUMB gu niga ninhursag nubanda$xxx
+NUMB gu niga anunitum$NUMB ox , grain-fed , Annunītum ,
+NUMB gu niga ulmacitum$NUMB ox , grain-fed , Ulmašitum ,
+nanceGIRgal mackim$Nanše-GIRgal was enforcer ;
+iti u NUMB bazal$the month , day NUMB passed ;
+ca urima$in Ur ;
+NUMB$;
+cunigin NUMB gu niga sagu$total : NUMB oxen , grain-fed , top grade ,
+cunigin NUMB gu niga$total : NUMB oxen , grain-fed ,
+cula bala namzitara ensi gudua$… , bala  of Namzitara , governorn of Kutha ,
+beliazu idab$did Beli-zu accept ;
+ki ahunita$from  Aḫuni
+bazi$booked out ;
+iti akiti$month “ Akītu ”
+mu amarsuen lugal$year : “ Amar-Suen is king . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+a erina$xxx
+nubandagu ipae$xxx
+mu naruamah badu$xxx
+igal$xxx
+NUMB n inun lugal$NUMB ,
+X X X lugal$… ,
+n gu NUMB mana sikiud$NUMB talents NUMB ma-na goat hair ,
+X idab$… received ;
+NUMB n inun$… butter oil ,
+NUMB n ga galgal$… big-cheese ,
+NUMB gu NUMB mana siki$NUMB talent NUMB mana wool ,
+X idab$Inim-… received ;
+NUMB n NUMB sila inun$NUMB  NUMB sila3 butter oil ,
+NUMB n sila ga gal$NUMB barig NUMB ban2 NUMB  big-cheese ,
+NUMB gu NUMB mana siki$NUMB talent NUMB mana wool ,
+X idab$Lugal-inim-… received ;
+n X NUMB sila inun$… NUMB sila3 butter oil ,
+X n la NUMB sila ga gal$… NUMB less NUMB sila3 big-cheese ,
+X n mana siki$… NUMB mana wool ,
+X idab$… received ;
+X n NUMB sila inun$… NUMB sila3 butter oil ,
+n NUMB sila ga gal$NUMB sila3 big-cheese ,
+NUMB mana siki$NUMB mana wool ,
+ursusu idab$Ur-susu received ;
+laiam$deficit ;
+mu nigka ala mu usabi$year : “ Accounts of the hoes , ” year after .
+NUMB ce cagal udu$NUMB ban2 barley , fodder of sheep ,
+u NUMBkam$ordNUMB day ,
+NUMB ce duh$NUMB barig , barley , bran ;
+NUMB ce nigara$NUMB barig NUMB ban2 barley , groats ;
+NUMB ce dabin$NUMB ban2 barley , dabin-flour ;
+u NUMBkam$ordNUMB day ,
+muca siga$muša loaded ,
+ekicibata$from the storage facility ;
+kicib lusuen$under seal of Lu-Suen ;
+iti akiti$month : “ Akītu , ”
+mu magurmah badim$year : “ Great-barge was fashioned ; ”
+NUMB gur$NUMB gur NUMB barig NUMB ban2 .
+lusuen$Lu-Suen
+dumu ursaga$son of Ur-saga ,
+sipa gu niga$herdsman of grain-fed oxen .
+pisanduba$Basket-of-tablets
+GAN ce sanga ninmar$fields , barley , chief household administrator of Ninmar ,
+urnance dumu ensi$Ur-Nanše , son of the governor ,
+igal$are here ;
+mu amarsuen lugal$year : “ Amar-Suen is king . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+X$Lugal-maḫ-… ,
+dubsar$scribe ,
+dumu nasaga$son of Nasaga ,
+ARADzu$is your servant .
+ningubalag$To Ningublaga ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+en unuga$the lord of Uruk ,
+lugal urima$king of Ur ,
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+namtilanice$for his life
+a munaru$he dedicated it to him .
+pisanduba$Basket-of-tablets
+mu didli ceba$xxx
+girisega iri$xxx
+ca guabaka$xxx
+igal$xxx
+urlamma$xxx
+ensi$xxx
+iti GANmac$xxx
+mu usa kimac bahul$xxx
+NUMB kir niga$NUMB female lamb , grain-fed ,
+bauc u NUMB la NUMBkam$slaughtered , ordNUMB day ;
+ki endingirmuta$from En-dingirmu ,
+culgirimu$Šulgi-irimu
+cu bati$recieved ;
+iti cueca$month : “ šu’ešša , ”
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+NUMB u sila nua$NUMB nu'a ewes and lambs ,
+NUMB ud mac nua$NUMB nu'a female and male goats ,
+abiabih$of Abi-Ebih ;
+NUMB u$NUMB ewes ,
+NUMB ud$NUMB female goats ,
+urnigar abrige$of Ur-nigar the butcher ;
+ki intaeata$from Inta'e'a
+urkununa$Ur-kunna
+idab$took into his command .
+iti akiti$Month : “ Akiti , ”
+mu cacru bahul$year : “ Šašrum was destroyed . ”
+NUMB$NUMB
+ninsun$For Ninsun ,
+dingirani$his goddess ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+emah$the Emah ,
+e kiagani$her beloved temple ,
+munadu$he built for her .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lugalamarku$Lugal-amarku ,
+dubsar$scribe ,
+dumu lugalmagure$son of Lugal-magure ,
+icib ninurta$priest of Ninurta ,
+ARADzu$is your servant .
+NUMB sila niga nanna $NUMB fattened lamb  Nanna
+muku lunanna cabra $delivery of Lu-Nanna , household manager ;
+NUMB sila niga ningal $NUMB fattened lamb  Ningal
+muku lunincubur $delivery of Lu-Ninšubur ;
+NUMB sila enlil $NUMB lamb  Enlil
+muku urningal $delivery of Ur-Ningal ;
+NUMB sila ninlil $NUMB lamb  Ninlil
+muku inda cabra $delivery of Indaya , household manager ;
+NUMB sila utu $NUMB lamb  Utu
+muku urmes nubanda $delivery of Ur-mes the manager ;
+NUMB acgar niga ninsun $NUMB fattened nanny goat  Ninsun
+muku ceczimu $delivery of Šešzimu ;
+NUMB sila lugalbanda $NUMB lamb  Lugal-banda ,
+muku mana nubanda $delivery of Manaya the manager ;
+NUMB sila niga nanna $NUMB fattened lamb  Nanna ,
+muku lugalinimgina dumu igianakezu $delivery of Lugal-inimgina , son of Igianakezu ;
+NUMB sila ningal $NUMB lamb  Ningal
+muku girinisa cabra ninhursag nubanda $delivery of Girini’isa household manager of Nin-ḫursag , the manager ;
+NUMB sila enlil $NUMB lamb  Enlil
+NUMB sila ninlil $NUMB lamb  Ninlil
+muku cecdada sanga $delivery of Šešdada , the sanga-priest ;
+NUMB sila gectinanamalugal $NUMB lamb  Geštinana-ama-lugal
+X mackim $… , the officiant ;
+X euzga $… for the fattening house
+X mackim $… , the officiant ;
+X ZU X gi $… .
+ki X bazi $from … was booked out ;
+iti ezemana $month “ Festival of An , ”
+mu usa harci u kimac bahul $year after “ Ḫarši and Kimaš were destroyed . ”
+pisanduba$Basket-of-tablets
+udugi$domestic sheep
+u siki balabi$and their weighed wool ,
+nigdaba$…
+ensika$of the governor ,
+igal$are here ;
+mu guza$year : “ Chair . ”
+NUMB ce gur lugal$NUMB gur barley , royal ,
+cagal udu niga$fodder for sheep , grain-fed ,
+X X$…
+ki X$from …
+KA X$…
+cu bati$received ;
+iti minec$month : “ min-eš , ”
+mu e puzurdagan badu$year : “ The house of Puzriš-Dagan was erected . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urkununa$Ur-kununa ,
+dubsar$scribe ,
+dumu luningirsu kurucda$son of Lu-Ningirsu , fattener ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+sipa X hedabne$xxx
+girsuta guabace$xxx
+mu usa e puzuricdagin badu$xxx
+NUMB sila$NUMB lambs ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+intaea idab$Intaea accepted ;
+iti sesdagu$month : “ Piglet-feast , ”
+mu en nanna bahun$year : “ The en-priestess of Nanna was installed ; ”
+NUMB$NUMB .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+adalal$Adalal ,
+dumu ibnickur$son of Ibni-Adda ,
+ARADzu$is your servant .
+NUMB gecur$NUMB beams
+karta$from the docks
+emac$the Emaš
+kura$delivered ;
+iti eitiNUMB$month : “ House-month-6 , ”
+mu cusuen lugal$year : “ Šu-Suen is king . ”
+NUMB geme$NUMB female laborers ,
+iti cesagkuta$from month “ Harvest ”
+iti dumuzice$to month : “ Dumuzi , ”
+abi u NUMB$their labor : NUMB , NUMB days ,
+sagnigurakam$are the debit ;
+cabita$therefrom
+NUMB a udua$NUMB , labor , freed days ;
+NUMB sila dabin gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 barley flour ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sila zi sig gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 rough flour ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sila eca gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 spelt ,
+abi u NUMB$its labor : NUMB days
+NUMB zigu saga gur$NUMB gur NUMB barig NUMB ban2 fine "string" flour ,
+abi u NUMB$its labor : NUMB days
+NUMB geme u NUMBce$NUMB female laborer days ,
+cu ura zar taba aca GANmah$leveled , sheaves piled up at thes field GANmaḫ ;
+kicib abagina$under seal of Abbagina ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+cu ura zar taba$leveled , sheaves piled up
+aca muru$at the field Muru ;
+kicib akala dumu lugalemahe$under seal of Akalla son of Lugal-emaḫe ;
+NUMB la NUMB geme u NUMBce$NUMB female laborer days ,
+kunzida i dudu guba$at the weir of the waterway Dudu stationed ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+aca abududu$at the field Abu-dudu ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+aca ninudu$at the field Nin-nudu ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+aca culpae$at the field Šulpa’e ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+aca duninhursag$at the field Mound-of-Ninḫursag ;
+NUMB u NUMBce$NUMB female laborer days ,
+aca gusuhub$at the field Booted-oxen ;
+NUMB la NUMB geme u NUMBce$NUMB female laborer days ,
+aca nagabtum$at the field Nagabtum ;
+giri ukkene$under seal of Ukkene ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+aca GANmah$at the field GANmaḫ ;
+giri daga$under seal of Da’aga ;
+zar taba cu ura$sheaves piled up , leveled ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+GANmahce gena$to GANmaḫ walked ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+GAN mahta$from GANmaḫ
+guedinace gena$to Gu’edina walked
+NUMB la NUMB geme u NUMBce$NUMB female laborer days ,
+guedinata$from Gu’ednina
+nagabtumce gena$to Nagabtum walked ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+kisu ninuduta$from the threshing floor Nin-nudu
+eduruabuce$to the Village-Abu
+ce zigu imga$barley and pea-flour carried ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+kisu aca ninurata muca imzi$at the threshing floor of Nin-ura m-grain moved ;
+NUMB geme u NUMBce$NUMB female laborers for NUMB days ,
+kisu ninudu muca imzi$at the threshing floor of Nin-nudu m-grain moved ;
+NUMB geme u NUMBce$NUMB female laborers for NUMB days ,
+ce gusuhub u ce aca gibil$barley of Booted-oxen and barley of the new field
+guru apisalce imzi$to the silo of Apisal moved ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+kunzida i gibil guba$stationed at the weir of New Canal ;
+zar taba cu ura u ada guba$sheaves piled up , leveled and at the water stationed ,
+kicib ure$under seal of Ur-e’e ;
+NUMB geme u NUMBce$NUMB female laborers for NUMB days ,
+abi u NUMB$their labor : NUMB
+apisalta$from Apilsal
+nibruce gena gura$to Nippur walked and returned ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+diri nigkak mu usa kimac bahul$surplus of the account of the year after : “ Kimaš was destroyed ; ”
+cunigin NUMB geme u NUMBce$total : NUMB , NUMB female laborer days
+zigam$booked out ;
+laia NUMB geme u NUMBce$deficit : NUMB female laborer days ;
+nigkak a geme kikkena$account of the labor of the female laborers , millers ,
+lugalinimgina$of Lugal-inim-gina ;
+mu harci hurti kimac bahul$year : “ Ḫarši , Ḫurti  Kimaš were destroyed . ”
+NUMB guruc u NUMBce $NUMB male laborer days
+kagirida $on duty
+barla dublautu guba $at the basin of the Dubla-Utu  stationed ;
+ugula lugalitida $foreman : Lugal-itida ,
+kicib cecani $under seal of Šešani ;
+mu cusuen lugale narumah  mudu $year : “ Šū-Suen , the king , Big Stele erected . ”
+cecani $Šešani ,
+dubsar $scribe ,
+dumu dada $son of Dada .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+X$Šū-… ,
+dubsar$scribe ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+udu gukkal baur$xxx
+siki bala$xxx
+girsuta$xxx
+guabace$xxx
+ugula dugazida$xxx
+igal$xxx
+mu cacrum bahul$xxx
+pisanduba$Basket-of-tablets
+gurumak$inspections ;
+NUMB guruc$NUMB workmen ,
+e dumuzi$house of Dumuzi ,
+pisanduba$Basket-of-tablets
+nigkak ce siki i zulum$xxx
+cagal amar gu apina$xxx
+ceba girisega kiri$xxx
+didila dumu bauc iti NUMBkam$xxx
+cenumun murgu a lu hunga$xxx
+al ak u kua$xxx
+ance gu gida$xxx
+acata edabi$xxx
+ca NUMB GAN gubi$xxx
+nigkak udu emegira$xxx
+udu gukkal$xxx
+gugara kiri kabduga kiri$xxx
+a erina engar cagu casahar$xxx
+iti NUMBkam$xxx
+im cuku hala$xxx
+e lugalkuzu$xxx
+u e ninmunuszida$xxx
+pisanduba$Basket-of-tablets
+sagnigura$debits ,
+cabi suga$therefroms , restitutions ,
+muku cara apisal$deliveries to Šara of Apisal ,
+giri cakuge$via Šakuge
+kicib arua$sealed documents , offerings ,
+igal$are here ;
+mu bad martu badu$year : “ The Amorite wall was erected . ”
+NUMB sa gi marsac$NUMB bundles of reed , to the shipyard ,
+ki ceckalata$from Šeškalla ,
+kicib lugalnirgal$under seal of Lugal-nirgal ;
+iti cekaragala$month “ Barley-at-the-docks , ”
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+lugalnirgal$Lugal-nirgal ,
+magin$boat-builder ,
+ARAD cara$servant of Šara .
+pisanduba$Basket-of-tablets
+nigkak guapin$xxx
+ab etur$xxx
+gusuhub$xxx
+u ance gub$xxx
+igal$xxx
+mu amarsuene urbilum muhul$xxx
+NUMB guruc u NUMBce$NUMB male laborer workdays ,
+i acnan guba$at the waterway of Ašnan stationed ,
+ugula lugalnesage$foreman : Lugal-nesage ;
+kicib lugalemahe$under seal of Lugal-emaḫe ,
+iti diri$extra month ,
+mu cacrum ara NUMBkam bahul$year : “ Šašrum a ordNUMB time destroyed . ”
+lugalemahe$Lugal-emaḫe ,
+dubsar$scribe ,
+dumu lugalkugani$son of Lugal-kugani .
+X X$… ,
+cusuen$Šū-Sîn ,
+kiag enlila$the beloved of Enlil ,
+lugal enlile$the king whom Enlil
+kiag cagana$as beloved in his heart
+inpa$did choose ,
+pisanduba$Basket-of-tablets
+kicib daba lugalmea$sealed documents of conveyances of Lugal-me’a ,
+mu guza enlila badim u mu enmahgalana bahun$year : “ The chair of Enlil was fashioned ” and year : “ Enmaḫgalana was installed , ”
+u kicib daba$and sealed documents of conveyances
+acian$of Aši’an ,
+mu NUMBkam$NUMB years ;
+mu guzata$from year : “ Chair ”
+mu cacruce$to year : “ Šašru ”
+igal$are here .
+NUMB udu$NUMB sheep ,
+NUMB macgal$NUMB billy goats , full grown ,
+u NUMB la NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+zubaga$Zubaga
+idab$accepted ;
+iti ubigu$month : “ Ubi-feast , ”
+mu en nanna karzida bahun$“ The priest of Nanna of Karzida was installed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+udu gukkal guba$sheep , fat-tailed sheep stationed ,
+abisimti$Abi-simti
+ugula cia cuc$foreman Ši’aya , cattle manager ,
+udu kubatum$sheep k . ,
+ugula lunanna cabra nin$foreman Lu-Nanna , chief household administrator of the queen ,
+udu egal$sheep of the palace ,
+ugula namhani cuc$foreman Namḫani , cattle manager ,
+igal$are here ;
+ca girsu$in Girsu ,
+mu cusuen lugal urimake naruamah enlil ninlilra munedu$year : “ Šu-Suen , king of Ur , Big-Stele for Enlil Ninlil , erected . ”
+pisanduba$Basket-of-tablets
+mu didli ceba lu azlag$xxx
+u ceba niginba$xxx
+igal$xxx
+mu usa kimac$xxx
+NUMB X X X$NUMB …
+NUMB lugalhamati$NUMB Lugal-hamati
+NUMB lugalkala$NUMB Lugal-kala
+NUMB ahucuni$NUMB Ahušuni
+NUMB inimanizi$NUMB Inimanizi
+NUMB dingirmaheizu$NUMB Dingirmahe-izu
+NUMB urninsu$NUMB Ur-Ninsu
+NUMB lugula$NUMB Lu-gula
+NUMB namzitara$NUMB Namzitara
+NUMB lusaga$NUMB Lu-saga
+NUMB dingirsaga lu ugula kasmec$NUMB Dingir-saga are foremen of the runners .
+NUMB sila kac saga NUMB sila ninda NUMB gin i NUMB gin naga NUMB gin cumta$NUMB sila fine beer , NUMB sila ninda , NUMB shekels oil , NUMB shekels naga , NUMB shekels onions each .
+NUMB sila kac NUMB sila ninda urnance$NUMB sila beer , NUMB sila ninda : Ur-Nanše
+NUMB sila kac NUMB sila ninda lubalasaga$NUMB sila beer , NUMB sila ninda : Lu-bala-saga
+cunigin NUMB sila kac saga cunigin NUMB kac du$Together : NUMB  regular beer ,
+cunigin NUMB sila ninda zi saga cunigin NUMB sila ninda$together : NUMB sila ninda of sig-flour , together NUMB sila ninda ,
+cunigin NUMB sila NUMB gin i$together : NUMB sila NUMB shekels of oil ,
+cunigin NUMB sila NUMB gin naga$together : NUMB sila NUMB shekels of naga ,
+cunigin NUMB sila NUMB gin cum$together : NUMB : sila NUMB shekels of onions ,
+u X NUMBkam$x+2nd day ,
+iti dal$month : “ Flight ”
+mu en inanna mace ipa$Year : “ en
+pisanduba$Basket-of-tablets
+nigkak$accounts
+igal$are here .
+mu simurum bahul$year : “ Simurum was destroyed . ”
+NUMB sa gi $NUMB bundles of reed ,
+buranhuhran $… ;
+NUMB sa gi $NUMB bundles of reed ,
+saharkiti $Saḫarkiti ;
+NUMB sa gi NUMB dam $NUMB bundles of reed , … ;
+NUMB sa gi $NUMB bundles of reed ,
+cu ba ur habru $… Ḫabru
+nubanda niridagal $the nubanda Niridagal .
+iti ezemninzu $month : “ Festival of Ninazu . ”
+NUMB sila kac saga NUMB sila ninda$NUMB sila of high-quality beer , NUMB sila of bread ,
+NUMB gin i NUMB gin naga$NUMB shekels of oil , NUMB shekels of naga ,
+NUMB ku NUMB sa cum$NUMB fish , NUMB bundle of onions
+iniminanna$Inim-Inanna ;
+NUMB ninda cagal simugene$NUMB ban of bread as provisions for smiths ,
+giri iniminanna$via Inim-Inanna ;
+NUMB sila kac NUMB sila ninda$NUMB sila of beer , NUMB sila of bread ,
+NUMB gin i NUMB gin naga$NUMB shekels of oil , NUMB shekels of naga ,
+NUMB ku NUMB sa cum$NUMB fish , NUMB bundle of onions
+giri dada$via Dada ;
+u NUMB la NUMBkam$it is on the ordNUMB day ,
+iti ezemculgi$Month : “ Festival of Šulgi . ”
+pisanduba$Basket-of-tablets
+mu didli ceba sikiba geme ucbar$xxx
+NUMB abagula$xxx
+NUMB lunincubur dumu urlamma$xxx
+NUMB ada dumu dada$xxx
+NUMB lugalaba$xxx
+NUMB urceila$xxx
+NUMB ada dumu emelam$xxx
+NUMB izu$xxx
+NUMB girinisa$xxx
+NUMB lunincubur$xxx
+NUMB dada$xxx
+u niginba$xxx
+igal$xxx
+ca guaba$xxx
+mu en inanna unu mace ipa$xxx
+urnamma$Ur-Namma ,
+lugal urima$king of Ur .
+NUMB guruc$NUMB male laborers ,
+ugula ikala$foreman : Ikalla ,
+NUMB ugula tabcala$NUMB , foreman : Tabšala ,
+NUMB ugula caramu$NUMB , foreman : Šara-amu ,
+NUMB la NUMB ugula lugaligihuc$NUMB , foreman : Lugal-igiḫuš ,
+NUMB ugula agu$NUMB , foreman : Agu ,
+NUMB ugula lugalnirgal$NUMB , foreman : Lugal-nirgal ,
+NUMB ugula kalpalu$NUMB , foreman : Kalpalu ,
+NUMB ugula akala$NUMB , foreman : Akalla ,
+NUMB la NUMB ugula lugamu$NUMB , foreman : Lugamu ;
+cunigin$total
+NUMB$,
+cabita$therefrom
+NUMB guruc ugula akala$NUMB male laborers , foreman : Akalla
+kabku e cara$,
+NUMB guruc ugula tabcala$NUMB male laborers , foreman : Tabšala
+kabku aca ukunuti$the reservoir of the field Ukunuti ;
+kisu ukunuti$threshing floor Ukunuti ;
+pisanduba$Basket-of-tablets
+nigkak$xxx
+a erina$xxx
+igal$xxx
+mu enunu inanna bahunta$xxx
+mu cacrumce$xxx
+inanna$For Inanna ,
+nin eana$the queen of the Eanna temple ,
+ninani$his mistress ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+eani$her temple
+munadu$he built for her
+kibe munagi$and restored  for her .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+urikidu$Ur-kidu ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+pisan bazi$xxx
+dumu nasilim$xxx
+igal$xxx
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB ku NUMB sa cum $NUMB fish , NUMB bundle onions ,
+idizu $for Idī-zu ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB ku NUMB sa cum $NUMB fish , NUMB bundle onions ,
+urningal $for Ur-Ningal ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB ku NUMB sa cum $NUMB fish , NUMB bundle onions ,
+cuenlila $for Šū-Enlil ;
+u NUMBkam $ordNUMB day ,
+iti cesagku $month : “ Harvest . ”
+pisanduba$Basket-of-tablets
+nigkak nubandakene$accounts of the inspectors ,
+a geme$the labor of the female workers ,
+a hedab$the labor of the ‘takers , ’
+nigka sahara urdue$accounting of soil …
+u sahar ziga didli X umma$and soil lifted , various … Umma ,
+mu NUMBkam$NUMB year ,
+igal$are here ;
+mu harci kimac bahul$year : “ Ḫarši , Kimaš were destroyed . ”
+pisanduba$Basket-of-tablets
+kicib daba catam$xxx
+NUMB agugu$xxx
+NUMB lugalezem$xxx
+NUMB lugalkugani$xxx
+NUMB lucara$xxx
+igal$xxx
+mu bad martu badu$xxx
+cara$For Šara ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+NUMB anahili munim$One , Ana-ḫili his name ,
+ARAD puzurmamakam$is the servant of Puzur-Mama ;
+urninmug cec ama anahili$Ur-Ninmug , the maternal uncle of Ana-ḫili ,
+ugu anahili$on account of Ana-ḫili ,
+dibi igar$a legal complaint brought ;
+igi habaluge ensi adaba$before : Ḫabaluge , the governor of the city of Adab ,
+igi uremah dumu X$before : Ur-Emah , the son of … ,
+igi badudu damgar$before : Badudu , the merchant ;
+NUMB luacgi dumu bibi$one : Lu-Ašgi , son of Bibi ,
+NUMB ididam BULUG$one : Itidam , the DIM4 ,
+NUMB magarum$one : Magarum ,
+NUMB uludi dubsar$one : Uludi , the scribe ,
+NUMB KAili dumu malahkuzu$one : KA-NI-NI , the son of Malaḫ-kuzu ,
+NUMB namhani dumu sangabita$one  its chief temple administrator ,
+NUMB eluti dumu sangabita$One  its chief temple administrator ,
+NUMB X mackim ensi$One  the governor ,
+luinimabime$are its  witnesses ;
+igibice namARAD$before them , the servant status
+ingin$he  firm ;
+mu urbilum kimac bahula$in the year : “ Urbilum  Kimaš were destroyed . ”
+cara$For Šara ,
+nirgal ana$jewel of heaven ,
+dumu kiag$beloved child
+inanna$of Inanna ,
+lugalanir$his lord ,
+namti$for the life of
+cusuen$Šu-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmubakace$king of the four quarters ,
+X$did Ur-… ,
+agaus lugal$royal soldier ,
+dumu urabake$son of Ur-abba ,
+munadim$this fashion .
+NUMB gu gi$NUMB talents of reeds ,
+NUMB gu manu$NUMB talents of willow ,
+ki cecanita$from Šešani
+lugalezem$did Lugal-ezem
+cu bati$receive ;
+iti eitiNUMB ca bala$month “ House-month-6 , ” of the bala .
+lugalezem$Lugal-ezem ,
+dubsar$the scribe ,
+dumu lugalemahe$son of Lugal-emaḫe ,
+cabra$the household manager .
+pisanduba$Basket-of-tablets
+nig X X$…
+X$…
+X$…
+mu simurum bahul$year : “ Simurum was destroyed . ”
+NUMB la NUMB guruc u NUMBce$NUMB less NUMB workdays , male laborers ,
+ugula basa$foreman : Basa ,
+barla i sisa guba$at barla of straight-canal stationed ;
+kicib ure$under seal of Ur-e’e ;
+iti cekaragala$month : “ Barley-at-the-harbor , ”
+mu usa amarsuen lugal$year after : “ Amar-Suen  king . ”
+ure$Ur-e’e ,
+dubsar$scribe ,
+dumu sae$son of Sa’e .
+NUMB udu$NUMB rams ,
+NUMB ud mac nua$NUMB nanny , a billy known ,
+u NUMBkam$ordNUMB day ;
+ki abasagata$from Abbasaga
+intaea$Intaea
+idab$accepted ;
+iti akiti$month : “ Akitu , ”
+mu cacru bahul$year : “ Šašrum was destroyed . ”
+NUMB$NUMB .
+ninhursag$For Ninhursag
+ninani$his mistress ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+gec kecra$the dam
+kiagni$her beloved
+munadu$he built for her .
+NUMB ce gur lugal$NUMB gur of barley in the royal measure ,
+ki luinannaka$with Lu-Inanna-ka ,
+a lu hunga$the wages of day-laborers ,
+abiati$Abi-ati
+cu bati$received .
+iti kisikininazu$Month “ kisiki-Ninazu . ”
+NUMB ce gur lugal$NUMB gur of barley in the royal measure ,
+ki luinannaka$with Lu-Inanna-ka ,
+a lu hunga$the wages of day-laborers ,
+abiati$Abi-ati
+cu bati$received .
+abiati$Abi-ati
+dumu X$son ? of …
+abasaga$Abbasaga ,
+dubsar$scribe ,
+dumu nasa kurucda$son of Nasa , fattener .
+pisanduba$Basket-of-tablets
+cuku daba$xxx
+girisega$xxx
+inadaha$xxx
+igal$xxx
+NUMB macgal niga saga us$NUMB barley-fed full-grown billy goat of the second grade ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewes ,
+NUMB ud$NUMB nanny goats ,
+NUMB mac$NUMB billy goats ,
+NUMB sila ga$NUMB suckling lambs ,
+NUMB mac ga$NUMB suckling goats ,
+bauc$were slaughtered ,
+u NUMBkam$it is on the ordNUMB day ,
+ki ahuwerta$from Ahuwer ,
+culgirimu$Šulgi-irimu
+cu bati$received them .
+iti cesagku$Month : “ Harvest . ”
+mu en nanna bahun$Year : “ The en-priestess of Nanna was installed . ”
+NUMB udu$NUMB sheep
+nincucin$For Inšušinak ,
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+arkec$the A'arkeš ,
+e kiagani$his beloved temple ,
+munadu$he built for him .
+NUMB udu niga$NUMB sheep , grain-fed ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+nalu idab$Nalu accepted ;
+iti ezemekigal$month : “ Festival of Mekigal , ”
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB$NUMB
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+kunanna$Ku-Nanna ,
+dumu lunanna$son of Lu-Nanna ,
+kurucda ARADzu$fattener , is your servant .
+X$…
+NUMB gin kubabbar$NUMB shekels silver ,
+egala banku$into the palace brought ,
+giri ala dumu luru$via Alla , son of Lu-Uru ;
+n gin kubabbar ala kurucda urima$NUMB shekels silver from Alla , fattener in Ur ,
+X$… ,
+kicibi tumdam$the sealed document is to be delivered ;
+ziga$booked out ;
+laia NUMB mana NUMB gin$the deficit : NUMB mana NUMB shekels
+ala dumu lugalerin$Alla , son of Lugal-erin ;
+NUMB guruc iti NUMBce$NUMB male laborers , for NUMB months ,
+NUMB guruc iti NUMBce$NUMB male laborer , for NUMB months ,
+kubi NUMB mana NUMB gin kubabbar$its silver : NUMB mana NUMB shekels ;
+cabita$therefrom
+NUMB gin kubabbar$NUMB shekels silver ,
+egala banku$into the palace brought ,
+giri ala dumu luru$via Alla , son of Lu-Uru ,
+NUMB gin ala kurucda urima$NUMB shekels from Alla , the fattener , in Ur ,
+kicibi tumdam$the sealed document is to be delivered ;
+ziga$booked out ;
+laia NUMB mana NUMB gin ku$the deficit : NUMB mana NUMB shekels silver ;
+X ugula$Lu-… , the foreman ;
+NUMB guruc iti NUMBce$NUMB male laborers , for NUMB months ,
+kubi NUMB mana NUMB gin kubabbar$its silver : NUMB mana NUMB shekels silver ;
+cabita$therefrom
+NUMB gin (|NINDA ku$NUMB shekels silver
+egala banku$into the palace brought ,
+giri ala dumu luru$via Alla , son of Lu-Uru ;
+NUMB gin ku ala kurucda urima$NUMB shekels silver from Alla , fattener in Ur ,
+kicibi tumdam$the sealed document is to be delivered ;
+ziga$booked out ;
+laia NUMB mana NUMB gin$the deficit : NUMB mana NUMB shekels
+lubimu$Lubimu ;
+NUMB guruc iti NUMBce$NUMB male laborers , for NUMB months ,
+NUMB guruc iti NUMBce$NUMB male laborer , for NUMB months ,
+NUMB guruc iti NUMBce$NUMB male laborer , for NUMB months ,
+kubi NUMB mana NUMB gin igiNUMBgal$ist silver : NUMB mana NUMB shekels ;
+cabita$therefrom
+laia NUMB mana NUMB gin igiNUMBgal$the deficit : NUMB mana NUMB shekels
+urtur$Urtur ;
+cunigin NUMB mana NUMB gin igiNUMBgal ku$total : NUMB mana NUMB shekels silver ,
+giri ala dumu luru$via Alla , son of Lu-Uru ;
+cunigin n gin$total : … shekels ,
+X ala kurucda$from Alla , the fattener ,
+kicib ziredam$the sealed document is to be destroyed ;
+X gin igiNUMBgal$… NUMB shekel ,
+X$…
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lugalitida$Lugal-itida ,
+dubsar$scribe ,
+dumu urdumuzida$son of Ur-dumuzida ,
+ARADzu$is your servant .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+alinisu$Alinisu ,
+dubsar$scribe ,
+nubanda ucbar$nubanda of the weavers ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+girisega$xxx
+lu azlag guabaka$xxx
+u niginba ziga lugal$xxx
+igal$xxx
+mu huhunuri bahul$xxx
+NUMB udu$NUMB sheep
+u NUMBkam$ordNUMB day ,
+NUMB udu u$NUMB sheep , grass-fed ,
+NUMB u u$NUMB ewe , grass-fed ,
+u NUMBkam$ordNUMB day
+bauc ki bali$slaughtered , with Balli ;
+iti ezemah$month : “ Big-festival . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+X$Ur-Gal-… ,
+dubsar$scribe ,
+dumu X$son of …-sa ,
+ARADzu$is your servant .
+NUMB gin kubabbar$NUMB shekels of silver ,
+ki SIAata$from S .
+cunincubur$Šu-Ninšubur
+cu bati$received .
+igi qasuahum$Before Qassu-aḫum ;
+igi nurili$before Nur-ili ;
+igi cumama$before Šu-Mama .
+iti gisiga$The month “ gisiga . ”
+NUMB udu niga NUMBkam us$NUMB sheep , grain-fed , ordNUMB grade ,
+NUMB udu niga$NUMB sheep , grain-fed
+NUMB udu niga gueusa$NUMB sheep , grain-fed , “ following the ox , ”
+emuhaldim mu kaskenece$for the kitchen on account of the messengers ,
+ARADmu mackim$ARADmu was enforcer ;
+NUMB udu niga lugale girta ingaz$NUMB sheep , grain-fed , the king with knife killed
+uzubi ula dumuni cu banti$its meat did Ula , his child , receive ;
+cusuendingir cui mackim$Šu-Suen-ilī , the barber , was enforcer ;
+NUMB udu$NUMB sheep ,
+ziga lugal$booked out of the king ;
+NUMB udu niga dada gala u girsuce igena$NUMB sheep , grain-fed ,  Dada the castrate , when to Girsu he went ;
+NUMB udu niga gueusa$NUMB sheep , grain-fed , “ following the ox , ”
+NUMB udu u$NUMB sheep , grass-fed ,
+culgirakam dumu X$… ;
+NUMB udu niga banana lu marhaci$NUMB sheep , grain-fed , for Banana , man of Marhaši ,
+unuce duni ma bagub$to Uruk going , on a barge stationed ;
+NUMB gu niga$NUMB ox , grain-fed ,
+NUMB udu niga$NUMB sheep , grain-fed
+iphuha lu simanum$of Ipḫuḫa , man of Simanum ,
+dubsag iria kurani$tablet-lead , into the city having entered ;
+ARADmu mackim$ARADmu was enforcer ;
+NUMB gu NUMB udu$NUMB ox , NUMB sheep ,
+nigba lugal ageba$gifts of the king , midnight ,
+ca puzuricdagan$in Puzris-Dagan ,
+u NUMBkam$ordNUMB day ;
+ki culgilita bazi$from Šulgi-ilī booked out ;
+giri nannamaba catam u cusuenidilimalik carabdu$via Nanna-maba , šatam-official , and Šu-Suen-idi-ili-mālik the šarabdu-official ;
+iti sesdagu$month : “ Piglet-feast , ”
+mu ibisuen lugal$year : “ Ibbi-Suen is king ; ”
+NUMB gu NUMB udu$NUMB ox , NUMB sheep .
+ididingir$Iddin-Ilum ,
+X mari$the governor-general of Mari ,
+ana inanna$to Ištar
+X$statue of himself
+X X$dedicated .
+ca X sua$One who this inscription
+usasaku$shall remove ,
+inanna X$his seed may Ištar
+lu talqut$pluck up .
+namti$for the life
+culgice$of Šulgi ,
+X$…-saga
+nukiri$the orchardman
+a munaru$dedicated  to him .
+NUMB u$NUMB ewes ,
+NUMB mac$NUMB billy goats ,
+NUMB ud$NUMB nanny goats ,
+emuhaldim$the kitchen ,
+u NUMBkam$on the ordNUMB day .
+ziga$Booked out
+ki urkununa$from  Ur-kununa .
+iti ezemculgi$Month “ Šulgi festival ” ,
+mu usa kimac bahul$Year after : “ Kimaš was destroyed ” .
+NUMB GAN gecura ara NUMB GANta$NUMB bur3 NUMB iku NUMB iku field area harrowing , NUMB time , at NUMB iku ,
+a erinabi u NUMB$its troops’ labor : NUMB days ;
+NUMB GAN tugur NUMB GANta$NUMB iku field area of tug-sag work at NUMB iku ,
+a erinabi u NUMB$its troops’ labor : NUMB days ;
+iti dal$month : “ Flight ; ”
+NUMB GAN gecura ara NUMB GANta$NUMB bur'u NUMB bur3 NUMB eše3 NUMB iku field area harrowing , NUMB times , at NUMB eše3 ,
+a erinabi u NUMB$its troops’ labor : NUMB days ;
+NUMB GAN gecura ara NUMB GANta$NUMB bur3 NUMB iku harrowing , NUMB times , at NUMB eše3 field area ,
+a erinabi u NUMB$its troops’ labor : NUMB days ;
+a gecura$labor of harrowing ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing , at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing , at NUMB sar ;
+abi u NUMB$its labor : NUMB days ;
+NUMB sar kici kura NUMB sarta$NUMB sar acacia cut at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB X sarta$600+ at NUMB sar ,
+abi u X$its labor : NUMB days ;
+NUMB X sarta$1060+ at NUMB sar ,
+abi u NUMB X$its labor : 80+ days ;
+NUMB sar kici NUMB sarta$NUMB sar : acacia at NUMB sar ;
+abi u NUMB$its labor : NUMB days ;
+NUMB sar kici X NUMB sarta$NUMB sar acacia at NUMB sar ;
+abi u NUMB la NUMB$its labor : NUMB days .
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar nigul NUMB sarta$NUMB sar of pickaxing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+a lu hunga NUMB silata$work of hirelings at NUMB sila3 ;
+NUMB sar al NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al X NUMB sarta$NUMB sar of hoeing at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+a caguka$labor of oxen drivers ;
+acage kinak$field work to be done
+aca kamari$field of Kamari ;
+ugula basa$foreman : Basa ;
+kicib nimgirane$under seal of Nimgir-ane .
+mu ara NUMBkam cacrum bahul$Year : Šašrum was destroyed for the ordNUMB time .
+nimgirane$Nimgir-ane ,
+dubsar$scribe ,
+dumu inimcara$son of Inim-Šara .
+pisanduba$Basket-of-tablets
+nigkak sahar ziga$accounts of soil raised
+apisal$in Apisal ,
+giri ure$via Ur-e’e ,
+igal$are here ;
+mu cusuen lugal urimake naruamah enlil ninlilra munedu$year : “ Šū-Suen , king of Ur , Big-stele for Enlil and Ninlil erected . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+guruta ea$xxx
+ceba ca sahara$xxx
+u ceba ucbar$xxx
+igal$xxx
+guedina$xxx
+mucbiana$xxx
+u apisal$xxx
+mu ku guza enlila badim$xxx
+pisanduba$Basket-of-tablets
+mu didli ceba$xxx
+geme ucbar lu azlag$xxx
+gu i nigincedu$xxx
+igal$xxx
+mu enunugalana en inanna$xxx
+NUMB mana NUMB gin NUMB ce kubabbar$NUMB mana , NUMB shekel , NUMB grains of silver ,
+situm$remaining
+iti cesagkuta$<<from the month “ harvest ”
+iti nesagce$through the month “ nesag sacrifice ” >> .
+NUMB gin ki luinannata$NUMB shekels from Lu-Inanna
+cabita$Therefrom
+NUMB mana suhe$NUMB mana suḫe ,
+kubi NUMB gin$its silver equivalent : NUMB shekels ,
+NUMB sila cumsikil igi nusaga$NUMB barig NUMB sila3 garlic of poor appearance ,
+kubi NUMB gin NUMB ce$its silver equivalent : NUMB shekels NUMB grains ,
+kicib lukala$sealed tablet of Lukalla .
+NUMB celu$NUMB barig , NUMB ban2 of coriander ,
+kubi NUMB gin NUMB ce$its silver equivalent : NUMB shekels , NUMB grains ,
+NUMB sila gectin had$NUMB barig , NUMB ban , NUMB sila of raisins ,
+kubi NUMB gin NUMB ce$their silver equivalent : NUMB shekels , NUMB grains ,
+nigdab dukuga$nigdab of “ Holy Hill , ”
+kicib lugalniglagare$sealed tablet of Lugal-niglagar-e .
+NUMB gu esir had$NUMB talents NUMB of dried bitumen
+kubi NUMB gin n$its silver equivalent : NUMB shekels NUMB
+kicib adumu$sealed tablet of Adumu .
+NUMB mana uruda$NUMB mana of copper ,
+kubi NUMB gin NUMB ce$its silver equivalent : NUMB shekels , NUMB grains ,
+NUMB gin suhe$NUMB shekels of suhe ,
+kubi igiNUMBgal la NUMB ce$its silver equivalent : NUMB  minus NUMB grains ,
+kicib luenlila$sealed document of Lu-Enlila .
+cunigin NUMB mana NUMB gin NUMB ce kubabbar$Total : NUMB mana , NUMB shekels , NUMB grains of silver
+zigam$booked out .
+laia NUMB mana NUMB gin NUMB ce kubabbar$Deficit : NUMB mana , NUMB shekels , NUMB grains of silver .
+nigkak pada$Account of Pada .
+iti minec$Month : “ mineš , ”
+mu cusuen lugal$year : “ Šu-Suen is king . ”
+NUMB ce gur kicib katarni malah$NUMB gur barley , under seal of Katarni the boatman ;
+NUMB gur kicib urgigir dumu aribi$NUMB gur , under seal of Ur-gigir , son of Aribi ;
+NUMB X gur zi$NUMB gur NUMB sila3 flour ,
+kicib urlugalbanda$under seal of Ur-lugalbanda
+NUMB gur$NUMB gur NUMB barig NUMB ban2 ,
+NUMB ziz$NUMB ban2 emmer ,
+lugalezem cabra$from Lugalezem , the chief household manager ;
+NUMB sila gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3
+lanimu$Lanimu ;
+cunigin NUMB sila ce gur$total NUMB gur , NUMB barig NUMB ban2 NUMB sila barley ;
+cunigin NUMB ziz$total NUMB barig NUMB ban2 emmer ;
+cunigin NUMB zi$total NUMB barig flour .
+kicibi gurudam$The sealed documents will be returned ;
+kicib ikala dumu hedam$under seal of Ikalla , son of Hedam .
+NUMB sila icah$NUMB sila3 lard ,
+giri daga cabra$via Da’aga , chief household administrator ;
+ki akalata$from Akalla ,
+ugu ure bagar$on the deficit ledger of Ur-e’e set ;
+kicib urcara caduba$under seal of Ur-Šara , chief accountant ;
+mu harci kimac bahul$year : “ Ḫarši and Kimaš were destroyed . ”
+urcara$Ur-Šara ,
+dubsar$scribe ,
+dumu lugalucur$son of Lugal-ušur .
+NUMB gu ab hia$NUMB various oxen and cows ,
+NUMB udu mac hia$NUMB various sheep and goats ,
+cu cuma$—the delivered—
+ki enlilzicagalta bazi$from  Enlil-zišagal booked out ;
+iti ezemcusuen$month “ Festival of Šu-Suen . ”
+X X$…
+X X$…
+X$…
+X$…
+X$…
+X$…-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four regions
+X X$…
+X X$…
+X$…
+X$…
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+dubsar$scribe ,
+ARADzu$is your servant .
+NUMB amar gir ga$NUMB heifer calf , suckling ,
+NUMB sila ga$NUMB male lambs , suckling ,
+NUMB kir ga$NUMB female lambs , suckling ,
+NUMB mac ga$NUMB male kids , suckling ,
+NUMB acgar ga$NUMB female kids , suckling ,
+utuda$newborns ,
+u NUMBkam$the ordNUMB day ,
+ki ahuni$with Aḫuni ;
+iti ubigu$month : “ ubi-feast , ”
+mu amarsuen lugal$year : “ Amar-Suen is king . ”
+pisanduba$Basket-of-tablets
+ance cagan guba$xxx
+mu naruamahta$xxx
+mu magurmah badimce$xxx
+igal$xxx
+NUMB sila$NUMB lamb ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+intaea idab$Intaea accepted ;
+iti cueca$month : “ šu’ešša , ”
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB$NUMB .
+NUMB sig$NUMB bricks
+lamazatum$by Lamazatum ,
+NUMB X$NUMB by … ,
+NUMB X$NUMB by …-num ,
+NUMB$NUMB ,
+namNUMB lamazatum$10- of Lamazatum ;
+NUMB X$NUMB , x ,
+NUMB handu$NUMB by Handu ,
+NUMB anahepat$NUMB by Ana-hepat ,
+NUMB$NUMB ,
+namNUMB catbizil$10- of Šat-bizil ;
+NUMB itirum$NUMB by Ana-hepat ,
+NUMB aditi$NUMB by Aditi ,
+NUMB abumdingir$NUMB by Abum-ilum ,
+NUMB haburitum$NUMB by Haburitum ,
+NUMB ecdarumi$NUMB by Ištar-ummi ,
+NUMB taturi$NUMB by Taturi ,
+NUMB ilidumqi$NUMB by Ili-dumqi ,
+NUMB eanuhci$NUMB by Ea-nuhši ,
+NUMB$NUMB ,
+namNUMB udurum$10- of Uddurum ;
+cunigin NUMB sar NUMB gin sig$together : NUMB sar NUMB shekels of brick ,
+usbi NUMB ninda$the length involved : NUMB ninda ,
+a NUMBta$labor of NUMB ,
+gemebi NUMB gin u NUMBce$the female laborers involved : NUMB days NUMB shekels ,
+ce NUMB silata bahun$hired at NUMB sila3 barley each ,
+cebi NUMB sila$the barley involved : NUMB barig NUMB ban2 NUMB sila3 ,
+a sig gaga$labor of brick transportation ,
+muku$delivery
+ekibagara$for the replacement house of
+en inannagal$of the priest of Inanna-gal ;
+bazi ugula$Bazi is the foreman ;
+giri ickurillat$via Adda-tillati ,
+u puzurninkarke$and Puzrum-Ninkarke ,
+ca garcana$in Garšana ;
+iti ezemana$month : “ Festival of An , ”
+mu cusuen lugale naruamah enlil ninlilra munedu$year : “ Šu-Suen , the king , erected great-stele for Enlil and Ninlil . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+siki geme ucbar u lu hungane$xxx
+mu cusuen lugal urimake naruamah enlil ninlilra muneduta$xxx
+mu zabcalice$xxx
+mubi mu NUMBam$xxx
+itibi iti NUMBam$xxx
+ninurta$Ninurta ,
+ensi gal$the great farmer
+enlila$of Enlil .
+NUMB gu mana siki$NUMB talent-pounds ? of wool ,
+NUMB kugi$NUMB geese ,
+NUMB zulum$NUMB  dates ,
+NUMB sila icah$NUMB sila of lard ,
+NUMB sila NUMB gin i X$NUMB sila NUMB shekels of …-oil ,
+NUMB luhua$NUMB ban …
+NUMB gec X X$NUMB ban …
+ki urkugata$from Ur-kuga
+urcubur$did Ur-šubur
+cu bati$receive .
+cabita$Therefrom
+NUMB ce gur situm$NUMB gur NUMB ,
+nigkak laia$account , deficit .
+igi zuzu ugula X X$Before : Zuzu , foreman of the … ,
+NUMB tabani$NUMB Tabbani ,
+NUMB urcumah$NUMB Ur-Šumah ,
+NUMB X X$NUMB …-zu ,
+NUMB X$NUMB …-la ,
+iti sigcebagar$Month : “ Set for the bricks ”
+mu en inanna mace ipa$Year : “ en
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+laia ce$debts of barley
+igal$are here ;
+mu usa kimac bahul$year following : “ Kimaš was destroyed . ”
+NUMB ceckala$NUMB  Šeškala ,
+NUMB urgigir$NUMB  Ur-Gigir ,
+dumu guzzanime$son of Guzzani ,
+NUMB lucara dumu lugalitida dumu X$NUMB  Lu-Šara , son of Lugal-itida , son of NI-x-šari ,
+NUMB guzzani dumu ninurda SIGa$NUMB  Guzzani , son of Nin-Urda , SIG-a ,
+NUMB lualamuc bara guba$NUMB  Lu-Alamuš , x x
+lu zah daba X$Seized runaways … ,
+enuga tila$in the prison residing ;
+iti eitiNUMB X u NUMBam barazal$month : “ House-month-6 , ” … , the ordNUMB day of has passed ;
+mu cusuen lugale naruamah indu$year : “ Šu-Suen , the king , erected big-stela . ”
+atu dubsar$Atu , scribe ,
+dumu nigarkidu$Son of Nigar-kidu ,
+galagal$The police chief .
+n NUMB X X X$… NUMB …
+X X$…
+X gu NUMB udu NUMB mac X$… ox goat …
+X gudea X X X$… Gudea …
+n gu niga NUMB X X$… grain-fed ox , NUMB …
+n NUMB udu NUMB X$… NUMB sheep , NUMB …
+akala X X$Akalla …
+X X X$…
+X$…
+X X adakala ugula ucbar$… Adda-kal , foreman of weavers ,
+ziga s,elucdagan$credited to ? elluš-dagan ,
+muku$deliveries .
+iti sesdagu$Month : “ eating piglettes , ”
+mu kimac u hurti bahul$year : “ Kimaš and Hurti were destroyed . ”
+pisanduba$Basket-of-tablets
+gurgura$xxx
+ki urkununa$xxx
+iti cesagku$xxx
+mu bad martu baduta$xxx
+iti diri ezemekigal$xxx
+mu naruamah baruce$xxx
+mu NUMBkam$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+e bagara$xxx
+e igalim$xxx
+e inanna$xxx
+e ninsun$xxx
+pisanduba$Basket-of-tablets
+aca gida$xxx
+GANgu$xxx
+u cuku girisega$xxx
+carili cabra$xxx
+mu en inanna unu mace ipa$xxx
+aca gida$xxx
+ziga lugal$xxx
+mu ibisuen lugal$xxx
+aca imlikcusuen$xxx
+giri urnigar sadu lugal$xxx
+igal$xxx
+NUMB sa gizi$NUMB , NUMB bundles of fodder reed ,
+kicib igipec$under seal of  Ratface ,
+ki abata$from Elder ,
+basa cu bati$did Pretty receive ;
+mu bad badu$year : “ The Wall was built . ”
+ga X X X bu X $…
+mahazum X $Maḫazum , …
+puc X $Puš , …
+X X X X da ac gi ku X X $…
+ebla mari tutul X $Ebla , Mari , Tuttul , …
+urgic X |EZEN×X|NIickur  $Urkeš , Mukiš , …-Adad ,
+X abarnum  $…-la , Abarnum ,
+u kur erin kur mada madabi $and the land where cedars are cut , together with it provinces ,
+kur cubura gaba gaba aba iginima X X $the land of Subartu on the shores of the Upper Sea , …
+u magan mada madabi kur X X $and Magan , together with its provinces , the land …
+balari aba X$on the other side of the Sea …
+X X$his …
+za ka ebgal$beside the Great Oval
+ka utu$and the Gate of Utu
+henabe$let him say to him .
+X$The …
+mundu$he built .
+pisanduba$Basket-of-tablets
+gu apin guba$xxx
+e nance$xxx
+e dumuzi$xxx
+e cabra$xxx
+e gecbare$xxx
+igal$xxx
+mu madarabzu babdu$xxx
+X$…
+NUMB X X$NUMB …
+NUMB X sila$NUMB … lambs ?
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+X X X$…
+iti X$month “ … , ”
+mu X X X$year “ … ” .
+NUMB X$…
+NUMB sila lunincubur$NUMB male lamb  Lu-Ninšubur ,
+u NUMBkam$ordNUMB day ,
+muku$delivery ,
+abasaga$Abbasaga
+idab$received ;
+iti macdagu$month : “ Gazelle feast , ”
+mu enunugal inanna bahun$year : “ En-unu-gal of Inanna was installed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+nigkak$accounts
+X situm$… deficits ,
+mu urbilum bahul$year : “ Urbilum was destroyed . ”
+pisanduba$Basket-of-tablets
+gurum ak daba$xxx
+e ningirsu minabi$xxx
+e baba ecabi$xxx
+bursag$xxx
+kunga ningirsu$xxx
+kunga baba$xxx
+u kunga gecbare$xxx
+igal$xxx
+giri niridagal$xxx
+u ludingira$xxx
+mu huhunuri bahul$xxx
+NUMB ce gur lugal$NUMB gur barley , royal ,
+mu sagnigura$because of the debits
+ki lugalinimginakata$that from Lugal-inimgina
+imitakace$were left behind ,
+ki lugalezemta$from Lugal-ezem
+urcarake$to Ur-Sara
+susudam$will be repaid ;
+mu usa simurum bahul$year after : “ Simurrum was destroyed . ”
+NUMB gugu$NUMB Gu’ugu ,
+ARAD urnungalka$slave of Ur-Nungal ,
+bandazah$fled ;
+mudab$he was captured
+igini ingar$and presented .
+mu lugal u ara NUMBka$By the royal name , “ When a ordNUMB time
+izahdena$I flee ,
+gahul bindu$may I be destroyed , ” he said .
+NUMB lugalazida$NUMB Lugal-azida ,
+NUMB abaenlilgin$NUMB Aba-Enlil-gin ,
+NUMB idi$NUMB Iddi ,
+dikubime$are the judges ,
+dumu nibru$son of Nippur ;
+mu amarsuen lugal$year : “ Amar Suen is king . ”
+NUMB dabin$NUMB  of dabin-flour ,
+zi agar guce$for aGAR flour ,
+ki urzuta$from Urzu ,
+kicib umani$sealed tablet of Umani .
+iti dal$Month : “ Flight ” ,
+mu en nanna mace ipa$year : “ en
+umani$Umani ,
+dubsar$scribe ,
+dumu namhani$son of Namhani .
+pisanduba$Basket-of-tablets
+ziga$credits
+nigkakta$from the accounts ,
+cu suba$… ,
+igal$are here ;
+mu usa mu usabi$year following its year following .
+pisanduba$Basket-of-tablets
+etum$xxx
+udu cida$xxx
+uduluka$xxx
+igal$xxx
+mu ibisuen lugal$xxx
+pisanduba$Basket-of-tablets
+ziga$xxx
+kicib carakam$xxx
+ki abasaga$xxx
+iti macdaguta$xxx
+iti cesagkuce$xxx
+caba iti diriam$xxx
+igal$xxx
+iti NUMBkam$xxx
+mu guza enlila badim$xxx
+pisanduba$Basket-of-tablets
+dugan cabi suga$pouch , therefroms , repayments ,
+ziga kas$credits of Kas ,
+ca umma$in Umma ;
+mu usa e puzur badu$year following : “ The house of Puzriš was built . ”
+pisanduba$Basket-of-tablets
+dubgida arua$long-tablets of the offerings
+igal$are here ;
+mu kimac bahul$year : “ Kimaš was destroyed . ”
+NUMB udu$NUMB sheep ,
+NUMB mac$NUMB goats
+lubanda dubsar$Lu-banda , the scribe .
+X$…
+X$…
+X X$…
+X cencena$the queen of war and battle ,
+amgin dudu$battering like a wild bull ,
+inin namursagce$the Lady who for the warrior's craft
+tuda$was born ,
+X tukul ti maruru$who with … , mace , arrows , and quiver
+sagce riga$was presented ,
+mudmegar duldula$all covered with astonishing qualities ,
+dumu gal suena$great daughter of Suen ,
+me ninnu cudu$holding the fifty divine powers ,
+ku inannake$the holy one , Inanna ,
+cusuen$Šū-Sîn ,
+mus kiaganir$her beloved spouse ,
+kur gu erimgal$in the hostile land
+nucegana$not obedient to him
+me gec gece lakam$which wages war and combat ,
+amaru u mah$like a huge flood and wind-storm
+zigagin$which has risen up
+ugba ururde$to sweep over its people ,
+a tuku hulgal$of those powerful , inimical ,
+erimdubine$evildoers
+tutu tutubi akde$to accomplish the striking and smiting of them ,
+sage zigal$of those vital black-headed folk
+mu tukuba$with the famous name
+mubi halamede$to obliterate the name of them ,
+hursag galgal$and to make all its big mountain ranges
+a surabi$with distant flanks
+gu kice gagade$to submit ,
+inanna enlile$Inanna by Enlil
+cusuen$for Šū-Sîn ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubara$and king of the four world quarters ,
+adahana$his helper
+munanikuku$was caused to become .
+minanene$The two of them
+zida gubuna$to his right and left
+anta muec$came down from heaven .
+lugal cusuen$King Šū-Sîn ,
+X$…
+X$…
+ekur zagin$the lapis lazuli Ekur ,
+X$…
+X$…
+X$…
+inim enlilata$By the order of Enlil
+X$…
+X$…
+cusuen$Šū-Sîn
+X X$…
+za X$the border of
+X$the god …
+X$the god …
+sig X$below …
+X X$…
+NI X$…
+kur X$the land …
+X X$…
+lugalbi$its king
+me cencenba$in those wars and battles
+X enlil$by the might of Enlil
+ninlilata$and Ninlil
+cusuen$Šū-Sîn ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+agakar bisese$repeatedly vanquished them .
+kur bala X X$The rebellious lands …
+gu erimgal$the hostile territory
+X X$…
+X X X X amaru$… flood
+lugal X X X amaru$the king … a flood
+kibala urur$which sweeps over the rebellious land ,
+agani$whose orders
+kur tuktuke$make the foreign land tremble ,
+kalgani$whose might
+sagbice ea$is pre-eminent ,
+dumumunusani$his daughter
+simanume$to Simanum
+namegiabice$for a bride
+X X$was  given .
+simanum$But Simānum ,
+habura$Habūra ,
+u mada madabi$and all their lands
+lugalda gu erim$against the king did hostilites
+bandabgal$instigate .
+dumumunusani$His daughter
+e kitucanita$from the house where she resided
+sag imtaec$they dislodged .
+martu lu X X X$The Amorites , people who … ,
+tidnum X KI$the Tidnumites ,
+iamadiumda$and the Iam'adiumites
+imadaec$came out .
+lugalbi$Their kings
+me cencenba gaba$in their war and battles
+imanadariec$confronted him together .
+a enlil$By the might of Enlil
+lugalnata$his master ,
+me cencenba$in war and battle with them
+agakar bisese$he repeatedly vanquished them .
+cul utu X$youthful Utu …
+dumumunusani$his daughter .
+simanum$Simānum ,
+habura$Habūra ,
+u mada madabi$and their lands
+lugalda gu erimgal$hostilities against the king
+bandabgal$did instigate .
+dumumunusani$His daughter
+e kitucanita$from the house where she resided
+sag imtaecam$they dislodged .
+cusuen lugal kalga$Šū-Sîn ,
+lugal urima$the king of Ur ,
+hur X$…
+am TAR X X$…
+X X$…
+du tukubi caga$their runners into captivity
+minindab$he took ,
+namluba$and their personnel
+sahar imidu$he covered with earth .
+simanum$Simānum ,
+habura$Habūra ,
+u mada madaba$and all their lands ,
+sagdubi$their heads
+tibir imira$he slapped .
+dumumunusani$His daughter
+e kitucania$to her residence house
+imacingi$he sent back .
+simanum$Simānum ,
+habura$Habūra ,
+u mada madabi$and all their lands
+namARADdanice$to serve her
+sagce munirig$he presented to her .
+sag erimgal$The evil persons
+namrac akni$which he had taken as booty
+enlil ninlilra$for Enlil and Ninlil
+kisura$in the borderland
+nibruka$of Nippur
+simanum$Simānum
+ki munegar$he settled them ,
+iri munedu$and he built a city for them
+X munetangub$and set it apart from … for them .
+iriba$Of that city
+cusuen$Šū-Sîn
+dingirbim$was its god .
+u namtarata$Since the time fate was decreed ,
+lugalname$no king
+sag namrac aknita$with the persons he had made into booty
+enlil ninlilra$for Enlil and Ninlil
+kisura$in the borderland
+nibruka$of Nippur
+iri$a city
+ki nunegar$had ever founded ;
+cusuen$but Šū-Sîn ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+simanum$Simānum
+ki munegar$he founded for them .
+X X X X$…
+X$…
+X$…
+X$…
+X$…
+sag namrac aknita$with the persons he had made into his booty
+enlil ninlilra$for Enlil and Ninlil
+kisura$on the borderland
+nibruka$of Nippur
+simanum$Simānum
+ki munegar$he settled for them .
+ubita$Since that time ,
+martu lu halama$the Amorites , a destructive people ,
+dim$with discernment
+urbaragin$like a wolf's ,
+tur X X X$… the pens .
+lu ce nuzu$A people who do not know barley ,
+lu X$a people who . . , .
+X silima$… in/of well-being
+X X$together with …
+X X$by the …
+munsese$he put them all .
+X$…
+X$…
+X$…
+X$…
+X$…
+u iri X$When the city …
+anta X X$from above was … ,
+hursag galgal$all the big mountain ranges
+huringin$as if by an eagle ,
+gu kice$with neck to the ground
+bandabgar$were put before him .
+iri adam$All their towns and villages
+kigargarabi$which had been settled
+dudura minigar$he made into ruined mounds .
+X X$…
+cusuen$Šū-Sîn ,
+lugal kalga$the mighty king ,
+lugal urima$the king of Ur ,
+gectu cuma enkika$given wisdom by Enki
+gectu mah X$and great wisdom by … ,
+lugal nibru X$the king of Nippur …
+cusuen$Šū-Sîn
+X$…
+X$…
+X X X$…
+sag X$he dislodged .
+martu lu halama$The Amorites , a destructive people ,
+tidnum X$the Tidnumites ,
+iamadium X$and the Iam'adiumites
+imadaec$came forth .
+lugal X X X$Its kings
+me cencena$in war and combat
+imadudu$he battered .
+X$…
+X$…
+X$…
+X$…
+X$…
+X mi du X X$…
+ubda anake$to all the quarters of the sky
+sa binec$they reached .
+X X HI X X$…
+X ga X X$…
+ensiensi$all the governors
+cusuen lugal X$Šū-Sîn the king …
+X X iri X$…
+cusuen lugal X$Šū-Sîn the king
+agalbi X$their great forces …
+uba X X ursag X X$At that time , … warrior . .
+inim enlilata$by the command of Enlil ,
+sig ekura X$the brickwork of the Ekur …
+me cencena X$in war and battle …
+X a X X$…
+X ankia X$… in heaven and earth …
+X$…
+X$…
+X$…
+guza suhuc gina$May a throne with a secure foundation
+kalama X$be … in the country .
+muni kurkura$May his name in all the lands
+hezu$be known .
+igi dingir galgalnece$Before all the great gods
+hulhulane$may he most happily
+hedibdibe$pass by ,
+ekur zagin$and in the lapis lazuli Ekur
+enlilaka$of Enlil
+gu ance henizi$may he lift high his shoulders .
+alanga$Of my statue
+kigubi$if off its standing place
+ibdabkura$one removes it ,
+alanani$and a stone statue of himself
+bibguba$one makes stand upon it ,
+nigdimamu$or he who my handiwork
+ibzirea$shall erase ,
+pisanduba$Basket-of-tablets
+gurumak$inspections of
+enungal X X$of Ennungal-… ,
+luningirsu$Lu-Ningirsu ,
+dumu bazi$son of Bazi ,
+iti ezemekigal$month : “ Festival-of-Mekigal , ”
+iti NUMBkam$of NUMB month ,
+X$…
+X X ce$…
+X$…
+igal$are here ;
+mu simurum lulubu$year : “ Simurum Lulubu . ”
+ninhursag$For Ninhursag
+cucina$of Susa ,
+ninani$his mistress ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+eani$her temple
+munadu$he built for her .
+gectinana$To Geštinana ,
+dumune$her son ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+namtilanice$for his life
+a munaru$dedicated  to her .
+NUMB dug dida saga$NUMB jugs of good dida-beer ,
+NUMB dug dida du$NUMB jugs of common dida-beer ,
+kicib umani$under seal of Umani ,
+ca bala$part of the bala .
+umani$Umani ,
+dubsar$scribe ,
+dumu namhani$son of Namhani .
+culgi $Šulgi ,
+nita kalga $the mighty man ,
+lugal urima $king of Ur
+lugal an ubda limmuba $and king of the four world quarters ,
+menlil $Simat-Enlil
+dumumunusani $his daughter .
+hunili$Ḫunḫili , 
+X kimac$governor of Kimaš , 
+X mat elam$general of the land of Elam : 
+tamgugu$Tamgugu 
+ze ARAD zimi$… . 
+X X X$…
+X NE IGI$…
+culgi$Šulgi ,
+danum$the mighty ,
+X uri$king of Ur
+u X$and king
+kibratim$of the world quarters
+arbaim$the four ,
+X X$…
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+luanatum$Lu-annatum ,
+dubsar$scribe ,
+dumu hesa$son of Ḫesa ,
+ARADzu$is your servant .
+culgi$Šulgi ,
+dingir kalamana$the god of his country ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+ninkala$Ninkala ,
+dumu nibru$a citizen of Nippur
+kiagani$beloved by him ,
+NUMB udu sadu gula$NUMB rams , regular offerings of Gula ;
+NUMB udu$NUMB rams ,
+NUMB u$NUMB ewes ,
+NUMB mac$NUMB billy goats ,
+bauc mu urgi$slaughtered , because of the dogs ;
+dingirbani cu bati$Ilī-bani received ;
+ziga$booked out
+ki urkununa$from  Ur-kununa ;
+iti ezemculgi$month : “ Festival-of-Šulgi , ”
+mu usa kimac bahul$year after : “ Kimaš was destroyed . ”
+NUMB sila ga$NUMB suckling lamb ,
+NUMB kir ga$NUMB suckling female lamb ,
+NUMB mac ga$NUMB suckling kid ,
+utuda$new-borns ;
+u NUMB la NUMBkam$it is on the ordNUMB day ,
+culgiamu idab$Šulgi-ayamu took .
+iti cueca$Month : “ šu’ešša . ’
+mu amarsuen lugale urbilum muhul$Year : “ King Amar-Suen destroyed Urbilum . ”
+NUMB$NUMB .
+NUMB guruc NUMB ginta$NUMB male laborers at NUMB shekels each ,
+kubi NUMB gin$the silver : NUMB shekels ;
+lu geci sanga dumuzime$they are plant oil workers of the temple household manager of Dumuzi ;
+mu namuce$instead of Namu
+habazizi$will to Ḫabazizi
+susudam$be repaid ;
+mu en nanna mace ipa$year : “ The high-priestess of Nanna through extispicy was named . ”
+dingirigidu$to Dingir-igi-du
+unadu$speak!
+NUMB zulum$NUMB barig dates ,
+NUMB sila inun$NUMB sila3 ghee ,
+NUMB sila ga gal$NUMB sila3 big-cheese ,
+NUMB imgaga$NUMB ban2 spelt ,
+NUMB dabin$NUMB barig flour ,
+lucarara$to Lu-Šara
+henabcumu$may he give!
+kicibani$His sealed document
+cu nababtiti$may he not receive!
+NUMB guruc u NUMBce$NUMB male laborer work days ,
+u gaga$food transported ,
+ki lututa$from Lu-Utu ,
+kicib urcara$under seal of Ur-Šara ;
+ca bala$that of the bala ;
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+ARADnintu$ARAD-Nintu , 
+ARAD cailicu$servant of Ša-ilišu . 
+NUMB gu NUMB mana sikigi$NUMB talents NUMB mina tan wool ,
+NUMB gu NUMB mana siki gukkal$NUMB talents NUMB mina wool of fat-tailed sheep ,
+NUMB mana siki udu bauc$NUMB mina wool , slaughtered sheep
+namena$lordship ;
+ki kasta$from Kas
+gududu$did Gududu
+cu bati$receive ;
+mu cusuen lugal urimake mada zabcali muhul$year : “ Šu-Suen , king of Ur , the land of Zabšali destroyed . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+alinisu$Alinisu ,
+dubsar$scribe ,
+ARADzu$is your servant .
+X X$…
+X$…
+X$…
+X$…
+X$…
+X X$…
+X X$…
+X X$…
+X X X X$…
+NUMB sila ninlil$NUMB male lamb  Ninlil ,
+muku ensi curuppak$delivery of the governor of Šuruppak ,
+zabardab mackim$the zabardab was the responsible official ;
+NUMB gu NUMB ab NUMB udu$NUMB oxen , NUMB cows , NUMB rams ,
+NUMB la NUMB u NUMB mac NUMB ud$NUMB ewes , NUMB he-goats , NUMB she-goats ,
+cugid emuhaldimce$šu-gid for the kitchen ;
+u NUMBkam$ordNUMB day ;
+ki nasata bazi$from  Nasa booked out ;
+iti ezemana$month : “ Festival of An , ”
+mu harci kimac bahul$year : “ Ḫarši and Kimaš were destroyed . ”
+pisanduba$Basket-of-tablets
+niginba sikiba$grand totals , wool rations ,
+giri uraba$via Ur-abba ,
+igal$are here ;
+mu enmahgalana bahun$year : “ Enmaḫgalana was hired . ”
+pisanduba$Basket-of-tablets
+e bigua bala$xxx
+ugula kikkenkene$xxx
+igal$xxx
+mu simurum lulubum ara NUMB la NUMBkamac bahul$xxx
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+X$Al-… ,
+sukkal X$courrier … ,
+ARADzu$is your servant .
+nani$To Nani
+unadu$speak
+NUMB ce gur$NUMB gur of barley
+elakcuqira$to Elak-šuqir
+henabcumu$may he give ;
+namigure$there is no recourse ,
+gunakam$it is his burden .
+tukumbi$Should he
+nunancum$not give  to him ,
+eanita$it will , out his own household ,
+ibsusu$be redeemed .
+cusuen$Šu-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+ARADnanna$ARAD-Nanna ,
+sukkalmah$sukkalmaḫ ,
+dumu urculpae$son of Ur-Šulpa’e ,
+sukkalmah$sukkalmaḫ ,
+ARADzu$is your servant .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+culgisipakalama$Šulgi-sipa-kalama ,
+ragaba$rider ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+kicib urenlila$sealed documents of Ur-Enlila
+igal$are here ;
+mu engalana$year : “ Engalana . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+gu apin$xxx
+ab ud$xxx
+gabari ensi$xxx
+igal$xxx
+aca ublupada$xxx
+mu usa kimac mu usabi$xxx
+NUMB dur$NUMB dur3-jacks ,
+NUMB eme$NUMB eme6-jennies ,
+NUMB cegbarnita$NUMB bucks ,
+NUMB cegbarmunus$NUMB does ,
+NUMB udu hursag$NUMB rams , mountain-range ,
+NUMB u hursag$NUMB ewes , mountain-range ,
+u NUMBkam$ordNUMB day ;
+ki abasagata$from Abbasaga ,
+ludingira idab$Lu-dingira accepted ;
+iti ezemah$month : “ Great-festival , ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destroyed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+nigkak a erina$accounts of the labor of troops ,
+ipae dumu aba$Ipa’e , son of Ayabba ,
+igal$are here ;
+mu bad martu badu$year : “ The Amorite wall was erected . ”
+nanna$To Nanna ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+namtilanice$for his life
+a munaru$he dedicated it to him .
+NUMB ceba zamu$NUMB barig ration barley , New Year , 
+ekikkenta$from the mill , 
+ninurada$did Ninurada 
+cu bati$receive ; 
+iti dumuzi$from month “ Dumuzi , ” 
+mu urbilum bahul$year : “ Urbilum was destroyed . ” 
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents of dab ,
+urcara dumu daga$Ur-Šara , son of Dayaga ,
+igal$are here ;
+mu enunugal inanna bahun$year : “ Enunugal of Inanna was hired . ”
+NUMB udu bargal bauc$NUMB sheep , with fleece , slaughtered ,
+ki kuganita$from Kugani ,
+kicib lukala$under seal of Lukalla ;
+iti minec$month “ mineš , ”
+mu enunugal en inanna bahun$year : “ Enunugal , the en-priest of Inanna , was installed . ”
+lukala$Lukalla ,
+dubsar$scribe ,
+dumu ure cuc$son of Ur-E’e , cattle manager .
+NUMB guruc u NUMBce$NUMB laborer workdays ,
+ecitimguba$at Ešitimgubba ,
+ecutumka guba$storehouse stationed ;
+ugula ARAD$foreman : ARAD ;
+kicib luhaia$under seal of Lu-Ḫaya ;
+mu en gaec bahun$year : “ The high-priestess of Ga’eš was hired . ”
+luhaia$Lu-Ḫaya ,
+dubsar$scribe ,
+dumu ure cuc$son of Ur-e’e , chief livestock manager .
+pisanduba$Basket-of-tablets
+pisan lubanda$xxx
+X zu$…
+NUMB nigin ilar alanum$NUMB bundles of … of hazel wood ,
+NUMB X nukuc$NUMB … ,
+NUMB patium halub maba ku gar$NUMB pati’um-container made of oak … with silver inlay ,
+NUMB sig cu$NUMB … with a bronze handle ,
+NUMB girigub cakal$NUMB foot-stool of šakal-wood ,
+NUMB girigub asal$NUMB foot-stool of poplar ,
+NUMB guzanin cinig$NUMB … chairs made of tamarisk ,
+NUMB guza gida$NUMB long chair ,
+NUMB na pec$NUMB bed of fig-tree wood ,
+NUMB na cakal$NUMB bed of šakal-wood ,
+NUMB na hachur$NUMB bed of apple-tree wood .
+anahegal$Ana-ḫegal ,
+dumu magure$son of Magure .
+NUMB ce gur$NUMB gur NUMB barig of barley
+gurucbi NUMB u NUMBce$its workmen : five days ;
+ce gurde$for harvesting barley
+sagbi gigidam$its sag will be brought in ,
+ki SIAa nagadata$from S . , the shepherd ,
+zumakum engar$Zumakum , the ploughman ,
+cu bati$has received .
+mu zumakumce$Instead of Zumakum ,
+kicib belisipa engar$sealed tablet of Beli-re’i , the ploughman .
+antalu$Antalu ? ,
+urculpae acgab$Ur-Šulpae , the leatherworker ,
+adalal$Adalal
+luinimabime$are its witnesses .
+mu cusuen lugal urima mada zabcalim muhula$Year : “ Šu-Suen , the king of Ur , destroyed the lands of Zabšali . ”
+NUMB gu$NUMB ox ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+cumama$Šu-Mama
+idab$accepted ;
+iti cueca$month : “ šu’ešša , ”
+mu cacru bahul$year : “ Šašru was destroyed ; ”
+NUMB gu$NUMB ox .
+NUMB sar NUMB gin igiNUMBgal e dua u kislah$NUMB ? NUMB sar NUMB shekels  finished house and lot
+nigsabi NUMB gin igiNUMBgal kubabbarce$as its exchange value : NUMB shekels of silver ,
+lucalim dumu dada sangake$did Lu-šalim , son of Dada , the household administrator ,
+lubalasaga dumu ceckala$to Lu-bala-saga , son of Šeškala ,
+enlilda lugalHAR dumunime$Enlilda and Lugal-HAR , his children ,
+u gemenlila damnir$and Geme-Enlila , his wife ,
+incisa$give in exchange for it .
+ninurta$Ninurta ,
+ensigal$big-governor
+enlil$of Enlil .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+urlamma$xxx
+dumu erinda$xxx
+ca ekikken$xxx
+igal$xxx
+mu harci hurti bahul$xxx
+pisanduba$Basket-of-tablets
+X$xxx
+idab X X$xxx
+igal$are here ;
+mu amarsuen lugal$year : “ xxx . ”
+pisanduba$Basket-of-tablets
+barakara hala$xxx
+igal$xxx
+mu cusuen lugal$xxx
+enki$For Enki ,
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+eani$his temple
+munadu$he built for him .
+pisanduba$Basket-of-tablets
+kiri kabduga$xxx
+girsuta$xxx
+guabace$xxx
+igal$xxx
+mu usa simanum bahul$xxx
+pisanduba$Basket-of-tablets
+gizi udu gua$xxx
+udu muku$xxx
+udu ziga$xxx
+nigkak udu$xxx
+siki girgul$xxx
+igal$xxx
+iti GANmacta$xxx
+iti ceilace$xxx
+iti NUMBkam$xxx
+mu naruamah badu$xxx
+lusuen$Lu-Suen
+dumu ursaga$son of Ur-saga ,
+sipa gu niga$herdsman of grain-fed oxen .
+pisanduba$Basket-of-tablets
+dub gida$long-tablets ,
+didli$various ones ,
+igal$are here .
+pisanduba$Basket-of-tablets
+kicib dab$xxx
+a erina$xxx
+urama$xxx
+dumu nasilimka$xxx
+iti NUMBkam$xxx
+igal$xxx
+iti sigicubagarata$xxx
+iti dumuzice$xxx
+mu cusuen lugale mada zabcali muhul$xxx
+pisanduba$Basket-of-tablets
+mu didli$xxx
+ce cukura$xxx
+erin girsu$xxx
+igal$xxx
+mu simurum bahul$xxx
+X$,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+u mada zabcali$when the land of Zabšali
+u mada mada$and the lands
+cimackika$of Simaški
+muhula$he destroyed ,
+mac gal$a big goat —
+gun ancana$tribute of Anšan
+muntumana$which they had brought to him —
+damcilumbi$a representation of it
+munandim$he fashioned for her ,
+namtilanice$and for his life
+a munaru$he dedicated it to her .
+NUMB udu niga$NUMB grain-fed sheep ,
+n udu niga gueusa$NUMB grain-fed sheep “ attached to the ox , ”
+n macgal niga$NUMB grain-fed large billy goats ,
+u X$nth day ,
+ki abasagata$from Abbasaga
+nalu idab$Nalu took control of .
+iti kisikininazu$Month “ weaving of Ninazu , ”
+mu huhnuri bahul$year : “ Huhnuri was destroyed . ”
+NUMB ud cimacgi$NUMB nanny goat , Šimaškian ,
+u NUMBkam$ordNUMB day ;
+ki abasagata$from Abbasaga
+utamicaram$Ūta-mīšaram
+idab$accepted ;
+iti cueca$month : “ šu’ešša , ”
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+lu nigdab$xxx
+girsuta$xxx
+guabace$xxx
+pisanduba$Basket-of-tablets
+ce gecea NUMB$threshed barley , …
+X X X$… ,
+mu simurum lulubu$year : “ Simurum Lulubu ”
+u mu urbilum$and the year : “ Urbilum , ”
+igal$are here .
+ebarad$Ebarad ,
+lugal ancan u cucin$king of Anshan and Susa
+silhaha$Silḫaḫa
+sukkalmah$Grand-Regent ,
+X$Addašu…
+ancan u cucinam$Anshan and Susa
+adahucu$did Addaḫušu
+sukkal u ipir ca cucin$Regent and … in Susa ,
+dumu nin silhaha$son of the sister of Silḫaḫa
+e |EN×KUR|$the house of …
+mudu$build .
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+titi $for Titi ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+kamu $for Ka’amu ;
+NUMB kac NUMB ninda NUMB sa cum $NUMB ban2 beer , NUMB ban2 bread , NUMB bundles onions ,
+NUMB sila i NUMB gin naga $NUMB sila3 oil , NUMB shekels alkali-plant ,
+lugalammamu $for Lugal-Lammamu ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+inhan $for Inhan ;
+NUMB sila kac NUMB sila ninda NUMB sa cum $NUMB sila3 beer , NUMB sila3 bread , NUMB bundles onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+culgili $for Šulgi-ilī ;
+cunigin NUMB sila kac NUMB sila ninda NUMB sa cum $total : NUMB ban2 NUMB sila3 beer ; NUMB ban2 NUMB sila3 bread ; NUMB bundles onions ;
+NUMB sila la NUMB gin i NUMB gin naga $NUMB sila3 less NUMB shekels oil ; NUMB shekels alkali-plant ;
+u NUMBkam $ordNUMB day ,
+iti eitiNUMB $month : “ House-month-6 . ”
+pisanduba$Basket-of-tablets
+nigkak uzu$xxx
+ickurabi agrig$xxx
+igal$xxx
+iti cugara$xxx
+mu ibisuen lugalta$xxx
+iti diri cesagku$xxx
+mu inanna unu mace ipa$xxx
+mubi mu NUMBam$xxx
+itibi iti NUMBam$xxx
+iti diri NUMBam caba igal$xxx
+pisanduba$Basket-of-tablets
+nigkak$Accounts ,
+KA la$… ,
+kurucdaene$of the fatteners ;
+NUMB macgal niga saga$NUMB buck , barley-fed , good quality ,
+NUMB macgal niga saga us$NUMB bucks , barley-fed , ordNUMB grade ,
+NUMB macgal niga NUMBkam us$NUMB bucks , barley-fed , ordNUMB grade ,
+NUMB acgar niga NUMBkam us$NUMB female kids , barley-fed , ordNUMB grade ,
+NUMB acgar niga$NUMB female kids , barley-fed ,
+NUMB mac gaba$NUMB unweaned kid ,
+NUMB acgar X$NUMB female kids … ,
+muku u X teca cumde gecbur nususu$delivery , and … to give , … ;
+ki abaenlilginta$from Aba-Enlilgin ,
+dudu idab$Duyudu accepted ;
+mu cusuen lugal urimake narua mah enlil ninlilra munedu$year : “ Šu-Sin , king of Ur , erected the grand-stele for Enlil  Ninlil ; ”
+NUMB udu$NUMB small cattle .
+X X X X$…
+NUMB GAN gec ara NUMB GANta$NUMB bur3 , NUMB eše3 NUMB iku field , harrowing , NUMB ,
+a erinabi u NUMB$its troop labor : NUMB days ;
+NUMB GAN gec ara NUMB GANta$NUMB bur3 field , harrowing , NUMB ,
+a erinabi u NUMB$its troop labor : NUMB days ;
+NUMB GAN gec ara NUMB GANta$NUMB eše3 , NUMB iku field , harrowing , NUMB ,
+a erinabi u NUMB$its troop labor : NUMB days ;
+a gecura$work of harrowing ;
+NUMB sar gi zea NUMB sarta$NUMB sar , reeds uprooted , at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar gi zea NUMB sarta$NUMB sar , reeds uprooted , at NUMB sar
+abi u NUMB$its labor : NUMB days ;
+a lu hunga$labor of hired men ;
+NUMB sar gi kura NUMB sarta$NUMB sar , reeds cut , at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar , hoeing , at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar al NUMB sarta$NUMB sar , hoeing , at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+NUMB sar X NUMB sarta$NUMB sar , … , at NUMB sar ,
+abi u NUMB$its labor : NUMB days ;
+giri X nubandagu$via … , oxen manager ;
+acage kin ak$field work done ,
+aca latur$field “ Latur ; ”
+ugula urgigir nubandagu$foreman : Ur-gigir , oxen manager ;
+kicib lugalnesage$under seal of Lugal-emaḫe ;
+iti dal$month : “ Flight , ”
+mu X bahul$year : “ … was destroyed . ”
+lugalemahe$Lugal-emaḫe ,
+dubsar$scribe ,
+dumu lugalkugani$son of Lugal-kugani .
+pisanduba$Basket-of-tablets
+kicib gi lu nigdabakene$xxx
+ibtabalaba en tare$xxx
+igal$xxx
+ca bala$xxx
+mu cusuen lugal$xxx
+pisanduba$Basket-of-tablets
+kicib nindingirbaba$sealed documents of Nindingir-Baba ,
+kicib lamu$sealed documents of Layamu
+macdarea nindingirbaba$offerings of Nindingir-Baba ,
+igal$are here .
+n NUMB sila X$NUMB sila3 x ,
+NUMB sila gar$NUMB ban2 NUMB sila3 dried cheese ,
+NUMB sila zulum gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 dates ,
+ki cuecdarta$from Šu-Ešdar ,
+X$…
+cu bati$received ;
+mu cusuen lugal urimake e cara umma mudu$year : “ Šu-Suen , king of Ur , the house of Šara in Umma erected . ”
+nurili$Nūr-ilī ,
+dubsar$scribe ,
+dumu urdumuzi$son of Ur-Dumuzi ,
+dubsar$scribe .
+pisanduba$Basket-of-tablets
+kine ra didli$xxx
+igal$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+kuningal$Ku-Ningal ,
+dumu kalamu$son of Kallamu ,
+cabra$household manager ,
+ninsun$of Ninsun ,
+ARADzu$is your servant .
+X$… ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+X$… ,
+dumu ahua$the son of Aḫḫū'a ,
+ensi$the governor
+puska$of Pus ,
+ARADzu$your servant .
+pisanduba$Basket-of-tablets
+dugan kicib ra$xxx
+zi X$xxx
+mu$xxx
+n gu u NUMB udu u$NUMB ox , grass-fed , NUMB sheep , grass-fed ,
+ki puzurili$with Puzur-ilī ;
+NUMB gu u NUMB udu u$NUMB ox , grass-fed , NUMB sheep , grass-fed ,
+ki nimgirinimgina$with Nimgir-inimgina ;
+NUMB gu u NUMB udu u$NUMB ox , grass-fed , NUMB sheep , grass-fed ,
+ki gabatal$with Gab-atal ;
+NUMB gu u NUMB udu u$NUMB ox , grass-fed , NUMB sheep , grass-fed ,
+ki urbaba$with Ur-Baba ;
+NUMB udu u ki lusaga$NUMB sheep , grass-fed , with Lu-saga ;
+ugula lugalkuzu$foreman : Lugal-kuzu ;
+NUMB gu u NUMB udu u$NUMB ox , grass-fed , NUMB sheep , grass-fed ,
+ugula namhani$foreman : Namḫani ;
+X udu u ki izuzu$NUMB sheep , grass-fed , with Izuzu ,
+ugula tahicatal$foreman : Taḫiš-atal ;
+X gu u NUMB udu u$NUMB ox , grass-fed , NUMB sheep , grass-fed ,
+ki cakuge cabra$with Šakuge , the household manager ;
+X gu u siskur guru$NUMB ox , grass-fed , siskur-offering for the granary ,
+ki lunanna$with Lu-Nanna ;
+X gu u siskur nisaba$NUMB ox , grass-fed , siskur-offering for Nisaba ,
+ki eabani$with Ea-bani ;
+X nigdab ezemcusuen$… taken , month “ Festival of Šu-Suen , ”
+ca nagabtum$in the Fattening House ,
+ARADmu mackim$ARAD-mu , responsible official ;
+u NUMBkam ki dugata bazi$the ordNUMB day , booked out from Duga ,
+giri hulal dubsar$via Ḫulal , the scribe ;
+iti diri ezemekigal usa$extra month following : “ Mekigal Festival , ”
+mu simanum bahul$year : “ Simanum was destroyed . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+X$… ,
+dubsar$scribe ,
+dumu uremahe$son of Ur-Emaḫe ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+nigkak$xxx
+abasaga$xxx
+iti macdaguta$xxx
+iti cesagku$xxx
+iti NUMBkam$xxx
+mu enunugal inanna$xxx
+igal$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmubake$king of the four corners
+puzurenlil$Puzur-Enlil ,
+ARADzu$is your servant .
+enlil$To Enlil ,
+lugal kurkura$the king of all the lands ,
+alan urnamma$a statue of Ur-Namma ,
+nita kalga$the strong man ,
+lugal urima$king of Ur
+lugal kiengi$king of Sumer
+kiurika$and Akkad ,
+nabi$whose stone
+esiam$is diorite ,
+urnamma$I , Ur-Namma ,
+nita kalga$the strong man ,
+lugal urima$king of Ur
+lugal kiengi kiuri$and king of Sumer and Akkad ,
+e nanna$when the temple of Nanna
+lugalga mudua$my master I built ,
+ma magan$and the boats of Magan ,
+di nigina$by the true verdict
+ututa cuna$of Utu , to his control
+munigia$I returned ,
+a munaru$I dedicated it to him .
+uba$At that time ,
+e enlil$within the temple of Enlil
+lugalgata$my master ,
+alan urnammake$for the statue of Ur-Namma
+nidba itida$a monthly food offering of
+NUMB ce gur$NUMB gur of barley ,
+NUMB udu$NUMB sheep ,
+NUMB sila inun$and NUMB sila3 of ghee ,
+saduce$as regular offerings
+munanigar$I established there for him .
+u ane$When An
+enlile$and Enlil
+nannar$to Nanna
+namlugal urima$the kingship of Ur
+munacumucaba$did grant ,
+uba urnamma$at that time , for me , Ur-Namma ,
+dumu tuda$the son born
+ninsunka$of Ninsuna ,
+emedu$her house-born slave
+kiaganir$beloved ,
+nigsisanice$according to his justice ,
+niginanice$according to his righteousness ,
+a X bag$the orders ,
+namlugal$and the kingship
+urima$of Ur
+humunacum$was given to him .
+si X X$…
+X$…
+NUMB X X$NUMB …
+NUMB X X$NUMB …
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+a nanna$By the might of Nanna
+lugalgata$my master ,
+abul iminbi$its seven gates
+gal mundantaka$I opened .
+namhani$Namḫani
+ensi$to governor
+lagac$of Lagaš
+hemil$I elevated .
+kisara$To the ki-sar-ra
+ma magana$the Magan ships
+nanna$of Nanna ,
+a nanna$by the might of Nanna
+lugalgata$my master ,
+hemigi$I returned .
+urima$In Ur
+habazalag$I made them shine .
+uba$At that time ,
+aca nisqum$for fields select
+igalam$there were ;
+namgaec$for long-distance trade
+malahgal$chief boat captains
+igalam$there were ;
+utule$the chief herdsmen
+gu dab udu dab$for those who take cattle , take sheep ,
+ance dab$or take donkeys
+igalam$there were .
+X X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+uba$At that time ,
+urnamma$I , Ur-Namma ,
+nita kalga$the strong man ,
+lugal urima$king of Ur
+lugal kiengi kiuri$and king of Sumer and Akkad ,
+a nanna$by the might of Nanna
+lugalgata$my master ,
+inim gina$and by the lawful command
+ututa$of Utu ,
+nigsisa$justice
+kalama humunigar$in the country I did indeed establish .
+X X$…
+X$…
+cuba hemigi$I returned to their own control .
+namgaec$Long-distance trade
+malahgal$the chief sea-captains ,
+utule$the chief herdsmen ,
+gu dab udu dab$those who take cattle , take sheep ,
+ance dab$or take donkeys ,
+uri lugira$and the Akkadians and foreigners
+kiengi kiuria$in Sumer and Akkad ,
+cuba hemigi$I returned to their own control .
+uba$At that time ,
+umma$Umma ,
+marda$Marad ,
+GIRkal$GIRkal ,
+kazalu$Kazallu
+u mackanpi$and Maškan-pî ,
+us,arum$and Uṣarum ,
+nig ancana$upon which in Anšan
+namARAD hebake$servitude was being imposed ,
+a nanna$by the might of Nanna
+lugalgata$my master ,
+amargibi$their freedom
+humugar$I established .
+bariga$A copper bariga vessel
+humugub$I set up ,
+NUMB silam henigen$and as NUMB sila3 I standardized it .
+ban humudim$A copper ban2 vessel I fashioned ,
+NUMB silam henigen$and as NUMB sila3 I standardized it .
+ban sisa lugala$A just royal ban2
+humudim$I fashioned ,
+NUMBam henigen$and as NUMB  I standardized it .
+NUMB sila zabar$A NUMB sila3 bronze
+humudim$I fashioned ,
+NUMB manam$and as NUMB mina
+henigen$I standardized it .
+NUMB gin ku na$A NUMB shekel of silver stone
+za NUMB manae$all the way up to a NUMB mina
+henigen$I standardized .
+uba$At that time ,
+gu idigna$on the banks of the Tigris ,
+gu buranun$on the banks of the Euphrates ,
+gu i duabi$and on the banks of all the rivers ,
+nidba X$nidba offerings , … ,
+nesag cageguru$and first-fruits and heart’s-desire offerings
+X X$…
+gec hemintag$I offered there .
+kiri$Orchards
+hemigub$I planted there ,
+X$…
+candana lugale hebtuku$and royal gardeners had charge of them .
+nusiki lu nigtukura$The orphan to the rich man
+baranangar$should not be made subordinate ;
+numunSU lu atukura$the widow to the powerful man
+baranangar$should not be made subordinate ;
+lu NUMB gine$the man of NUMB shekel
+lu NUMB manara$to the man of NUMB mina
+baranangar$should not be made subordinate ;
+lu NUMB udura$the man of NUMB sheep
+lu NUMB gue$to the man of NUMB ox
+baranangar$should not be made subordinate .
+caginacaginamune$All my generals ,
+amamu nin cececmu$my mother , my sister and brothers ,
+suasuamune$and all my relatives
+sa habangarec$did indeed advise me .
+aganenea$Upon their orders
+barabaguben$I do not tread ,
+kin barabanigar$and toil I did not set upon them .
+nigerim$Evil ,
+nigazi$violence ,
+iutu ugu henide$and complaint I made disappear ;
+nigsisa$justice
+kalama humunigar$I established in the country .
+uba tukumbi lu$At that time : If a man
+sag gec binra$has committed murder ,
+lubi igazedam$that man is to be killed .
+tukumbi lu$If a man
+sagazce inak ingaze$has acted like a robber , he shall be killed .
+tukumbi lu$If a man
+cece inak$has made someone into a captive ,
+lubi enuga itile$that man shall stay in jail
+NUMB gin kubabbar ilae$and pay NUMB shekels of silver .
+tukumbi ARADde$If a male slave
+geme acani intuku$has married a female slave whom he desires ,
+ARADbi amargini igaga$and that male slave is set free ,
+eta nubtae$she may not leave the household .
+tukumbi ARADde$If a slave
+dumugi intuku$has married a free citizen ,
+dumunita NUMBam lugalanir$and NUMB son under his master
+inangubu$he makes serve ,
+dumu lugalanir$the son which under his master
+inabgubuda$he had to make serve
+nigur e adana$of the goods of his father’s estate
+NUMBbi egar e adana ibae$NUMB of them , and his father’s physical house he shall share .
+dumu dumugi lugalda numea$A son of a free citizen without a master’s agreement
+namARADdanice$into one of his slaves
+labankure$shall not be made .
+tukumbi$If
+dam guruca a nugia$a young man’s  wife , not yet brought into a household ,
+nigagarce lu inakma$has been treated deceitfully by someone ,
+a bingi$and he has brought her into  household ,
+nitabi igaze$that man shall be killed .
+tukumbi$If
+dam guruca$a young man’s  wife
+niteanita$of her own free will
+lu banusma$has gone after another man
+urana banu$and he has lain in her lap ,
+munusbi$and that woman
+lu igaze$is killed by the man ,
+nitabi$that man’s
+amargini$freedom
+igaga$shall be established .
+tukumbi$If
+geme lu$a man’s female slave
+e nugia$not yet brought into a household
+nigagarce$has been seductively
+lu iak$treated by  man ,
+e bigi$and he has brought her into a household ,
+lubi$that man
+NUMB gin kubabbar$NUMB shekels of silver
+ilae$shall pay .
+tukumbi lu$If a man
+dam nitadamani$his equal-ranking wife
+itaktak$divorces ,
+NUMB mana kubabbar$NUMB mina of silver
+ilae$he shall pay .
+tukumbi$If
+numaSU$a  widow
+itaktak$he divorces ,
+NUMB mana ku$NUMB mina of silver
+ilae$he shall pay .
+tukumbi$If
+numaSU$for the widow
+dub kakec$a contractual document
+numea$is lacking ,
+lu urana$and the man in her lap
+banu$has lain ,
+ku nulae$he shall not pay any silver .
+X$…
+tukumbi$If
+ericdingir$an eriš-dingir priestess
+X lu ura$in … a man in the lap
+X banu$… has lain ,
+nunzu nitabi$but he did not know it , that man
+ibiTURnec$…
+tukumbi$If
+nam|KA×X|zu$of witchcraft
+lu lura$one man has another man
+indabla$accused ,
+iluruguce$and to the Ordeal River
+lu itumu$he has the man brought ,
+ilurugu$and the Ordeal River
+umzalagzalag$has then cleared him ,
+lu intumu$the man who brings him
+NUMB gin kubabbar$NUMB shekels of silver
+ilae$shall pay .
+tukumbi$If
+dam gurucada$a young man’s wife
+ura$of in a lap
+nua$having lain
+lu idala$a man has accused ,
+ide$but the River
+umzalagzalag$having cleared him ,
+lu idala$the man who accused her
+NUMB mana ku$1/3rd mina of silver
+ilae$shall pay .
+tukumbi$If
+musatur$a son-in-law
+e uranaka$into the house of his father-in-law
+inku$has entered ,
+ur$but the father-in-law
+egirbita$afterwards
+lu X$to another man …
+banacum$has given her away ,
+nigmusa$the wedding gifts ,
+ara NUMBam$twofold ,
+inacum$he shall give to him .
+tukumbi$If
+X$…
+geme ARAD X$a female or male slave
+bazah$has escaped ,
+kisura irinaka$and the border of her town
+ibtebala$she has crossed over ,
+lu imigur$and someone has turned her in ,
+lugal sagake$the owner of the slave
+lu imingura$to the man who turned her in
+NUMB gin kubabbar$NUMB shekels of silver
+inalae$he shall pay .
+tukumbi$If
+giripadra$a bone
+X$his …
+lu inku$a man has cut ,
+NUMB gin kubabbar$NUMB shekels of silver
+ilae$he shall pay .
+tukumbi$If
+lu lura$one man against another
+tukulta$with a weapon
+giripadra almurani$his … bone
+inzir$has broken ,
+NUMB mana kubabbar$NUMB mina of silver
+ilae$he shall pay .
+tukumbi$If
+lu lura$one man against another
+gecbuta$through a fistfight
+girini inku$has cut off his nose ,
+NUMB mana kubabbar$2/3rd mina of silver
+ilae$he shall pay .
+tukumbi$If
+X$with a …
+giripadra$a bone
+X$he has … ,
+NUMB gin kubabbar$NUMB shekels of silver
+ilae$he shall pay .
+tukumbi gecbuta$If through a fistfight
+ugu lu lu$one man the skull of another man
+ihac$has split open
+nig tukulagin NUMB mana$with something like a weapon , 1/3rd mina
+ilae$he shall pay .
+tukumbi gecbuta$If through a fistfight
+ugu lu lu$one man the skull of another man
+ihac$has split open ,
+NUMB usan irara$he shall be beaten with NUMB lashes .
+tukumbi igi lu$If someone’s eye
+lu imtacub$a man makes fall out ,
+NUMB mana ilae$he shall pay NUMB mina .
+tukumbi lu$If a man
+lu zuni iku$breaks another man’s tooth ,
+NUMB mana ilae$he shall pay NUMB mina .
+tukumbi ARADde$If a slave
+dumugira inira$has struck a free citizen ,
+kicini utak$when half his head hair has been shaved off ,
+iri imniginigin$he shall be paraded around the town .
+tukumbi dumugi$If a free citizen
+ARADra inira$has beaten a slave ,
+NUMB asi NUMB nig$NUMB  with a belt
+irara$he shall be beaten .
+tukumbi$If
+lu bauc$a man has died ,
+damni uranace$and his wife to her father-in-law’s
+inanituc$has gone to reside ,
+sag$the slaves
+agana$of her legacy
+nedea$and the marriage gifts
+habantumu$she may take away .
+tukumbi$If
+geme nutuku$she has no female slaves ,
+NUMB gin kubabbaram$NUMB shekels of silver
+henalae$let her pay him .
+tukumbi$If
+ku nutuku$she has no silver ,
+nigname$nothing
+nunabcumu$shall she give to him .
+tukumbi$If
+geme lu ninanigin$a female slave a person who as her mistress
+dimar$is acting
+ac inidu$has cursed ,
+NUMB sila munam$indeed NUMB sila3 of salt
+kakane$onto her mouth
+isube$shall be rubbed .
+tukumbi$If
+geme lu ninanigin$a female slave a person who as her mistress
+dimar$is acting
+inira$has struck ,
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X$…
+X X ilae$… he shall pay .
+tukumbi$If
+asuh$with a forearm
+dumumunus$the daughter
+luka ininra$of a man he has hit ,
+nig cagana$and the thing of her womb
+cu mundanla$he has caused her to miscarry ,
+NUMB mana kubabbar$NUMB mina of silver
+ilae$he shall pay .
+tukumbi$If
+bauc$she has died ,
+nitabi$that man
+igaze$shall be killed .
+tukumbi$If
+asuh$with a forearm
+geme luka$a man’s female slave
+ininra$he has hit ,
+magig$and an ‘it-has-hurt-me’
+inidu$he has done to her ,
+NUMB gin kubabbar$NUMB shekels of silver
+ilae$he shall pay .
+tukumbi$If
+geme bauc$the female slave has died ,
+X$…
+sag sagce igube$a slave for a slave shall serve .
+tukumbi$If
+lu lu kinimace$a man as a witness
+ibtae$came forth ,
+lu nizuh$and a thief
+banku$he was made out to be ,
+NUMB gin kubabbaram$NUMB shekels of silver
+ilae$he shall pay .
+tukumbi$If
+lu lu kinimace$a man as a witness
+ibtae$came forth ,
+namerimta imaragur$but turned away from  an oath ,
+nig diba ena gala$the concern of that suit , as much as there be ,
+ibsusu$he will compensate .
+tukumbi$If
+aca lu$a man’s field
+nigagarce$by deception
+lu iak$another man has worked ,
+banuru$and he has plowed it ,
+di bidu$and a trial has been held regarding it ,
+gu inigar$and it was put to another’s account ,
+lubi$that man
+ani ibtanede$shall be forced to forfeit his labor .
+tukumbi$If
+aca lu$a man’s field
+lu ada biDU$another man has flooded with water ,
+aca NUMB GAN$per NUMB iku of field
+NUMB ce gur$NUMB gur of barley
+iage$he shall measure out .
+tukumbi$If
+lu lu$a man to another man
+aca apinlace$a field for cultivation
+inacum$has given ,
+nunuru$but he did not plow it ,
+casuga$and empty land
+igar$he has left ,
+NUMB GAN$per NUMB iku
+NUMB ce gur$NUMB gur of barley
+iage$he shall measure out .
+tukumbi$If
+lu lu aca kiduru$a man to another man a field on irrigable land
+apinlace$for cultivation
+inacum$has given ,
+NUMB GAN macbi NUMB ginam$per NUMB bur3 of field NUMB shekels as its interest
+aca indagalam$the field will generate from him .
+tukumbi aca X lu lu apinlace inacum$If a man has given to another man a … field for cultivation ,
+X n ginam$per … NUMB shekels
+inalae$he shall pay him .
+inalae$…
+inalae$If
+inalae$a man has hired oxen or cows for harrowing ,
+inalae$for a NUMB year’s hire of it
+inalae$he shall measure out to him NUMB gur of barley ;
+inalae$for the hire of oxen or cows for lead or middle ,
+inalae$he shall measure out to him NUMB gur of barley .
+inalae$If a man has died
+inalae$and has no sons ,
+inalae$an umarried daughter
+inalae$shall become his heir .
+inalae$If a man has died ,
+inalae$and his daughter … ,
+inalae$she shall inherit the goods of her father’s estate .
+inalae$A younger sister should share the inheritance of the estate ,
+inalae$but the father’s subsistance allotments shall be shared by the  workers .
+inalae$If a man has put barley into another man’s house ,
+inalae$and that house has been broken into ,
+inalae$when the owner of the barley has taken an oath ,
+inalae$the owner of the house shall replace it .
+inalae$If a man has put barley into another man’s house ,
+inalae$and the owner of the house has changed ,
+inalae$after it has been verified ,
+inalae$he shall put in for him twice as much barley as was therein .
+inalae$If a man has put barley into another man’s house ,
+inalae$per NUMB gur barley … will be its nig2-diri levy .
+inalae$If a man who married a wife
+inalae$has left his wife behind ,
+inalae$when she has stayed  NUMB months for him
+inalae$the woman may be married by a husband of her choice .
+inalae$If a man married a wife ,
+inalae$and his wife died ,
+inalae$the man , until he remarries ,
+inalae$his wife’s marriage gifts should be brought to him ;
+inalae$but when the man marries a  wife ,
+inalae$the marriage gifts should return to her people’s household .
+inalae$If a man has died ,
+inalae$his wife , until she remarries ,
+inalae$the house …
+inalae$in/of her … will not be put .
+inalae$If the father has died ,
+inalae$… of his sons
+inalae$will be … ;
+inalae$… the physical house is the elder brother’s .
+inalae$If an ox has been lost in its cattle pen ,
+inalae$the cowherds
+inalae$shall replace it .
+inalae$If a sheep has been lost in its sheepfold ,
+inalae$the shepherds
+inalae$shall replace it .
+inalae$If an ox , a sheep , a donkey , or a pig has been lost among the houses or in a well-pit of a city ,
+inalae$the district
+inalae$shall replace it .
+inalae$If a man has not lost anything ,
+inalae$but he has declared : “ I have lost something of mine ; ”
+inalae$when by the district
+inalae$it has been proved ,
+inalae$that man shall be killed ;
+inalae$the district shall take away his inheritance .
+inalae$The nig2-diri levy for NUMB stolen ox is NUMB barig ;
+inalae$the nig-diri levy for NUMB stolen donkey is NUMB ban2 ;
+inalae$the nig-diri levy for NUMB stolen sheep is NUMB ban2 ,  at the new year .
+inalae$If a man takes another man to court ,
+inalae$after he has made him proceed through  appearances regarding it for the ordNUMB time , the suit shall be ended .
+inalae$If in winter
+inalae$a man has hired a 60-gur boat ,
+inalae$its nig2-diri levy will be NUMB ban2 ,
+inalae$its hire rate for NUMB day will be .
+inalae$If a man has hired a 60-gur boat : for NUMB double-miles , its nig2-diri levy will be NUMB ban2 per NUMB gur ;
+inalae$for NUMB double-miles its nig2-diri levy will be NUMB ban2 per NUMB gur ;
+inalae$for NUMB double-miles the nig2-diri levy will be NUMB ban2 per NUMB gur .
+inalae$It is of barley ; its silver is 1/3rd shekel .
+inalae$NUMB day’s wages of a house-builder will be NUMB ban2 .
+inalae$For a carpenter , leatherworker , reed-mat maker , felt maker , metalsmith , fuller , goldsmith , or stone-cutter ,
+inalae$their harvest-time wages will be NUMB ban2 each ;
+inalae$their winter ones will be NUMB ban2 each .
+inalae$The barley for NUMB …-pots will be NUMB ban2 ;
+inalae$the barley for NUMB kurdu pot will be NUMB ban2 ;
+inalae$for NUMB lahtan pot of NUMB gur  it will be NUMB ban2 ;
+inalae$the barley for NUMB oven will be NUMB sila3 .
+inalae$If a man has broken a leg bone ,
+inalae$and a physician has made him well ,
+inalae$the silver for that will be NUMB shekels .
+inalae$If a man has been mauled by a lion ,
+inalae$and a physician has made him well ,
+inalae$the silver for that will be NUMB shekels .
+inalae$If a physician has taken out a ‘stone , ’
+inalae$the silver for that will be NUMB shekels .
+inalae$If a physician has healed the eyesight ,
+inalae$the silver for that will be NUMB shekels .
+inalae$If a physician … a man ,
+inalae$the silver for that will be NUMB shekels .
+inalae$The harvest-time wages of a … will be NUMB ban2 ;
+inalae$his winter ones will be NUMB ban2 .
+inalae$The harvest-time wages of the … persons will be NUMB ban2 ; the nig2-diri levy will be NUMB barig ;
+inalae$their winter ones will be … and … will be the nig2-diri levy .
+inalae$The daily wages of a female weaver when washing  will be NUMB ban2 ;
+inalae$the daily wages of a senior female weaver will be NUMB ban2 ;
+inalae$the daily wages of a female weaver of šudur-garments will be NUMB ban2 .
+inalae$The wages of the … persons will be NUMB sila3 of barley .
+inalae$The wages of the doorman’s helpers … will be NUMB sila3 of barley .
+inalae$If a female tavern-keeper in the harvest season
+inalae$has given NUMB beer-jar to a person on credit ,
+inalae$at the harvest season NUMB ban2 of barley … ,
+inalae$and its nig2-diri levy will be … ;
+inalae$the winter’s will be …
+inalae$If a man to another man
+inalae$has given NUMB gur of barley as a loan ,
+inalae$its interest for NUMB year shall be NUMB barig and NUMB ban2 of barley .
+inalae$If a man to another man
+inalae$has given NUMB shekels of silver as a loan ,
+inalae$its interest for NUMB year shall be NUMB shekels .
+inalae$If a man to another man … ,
+inalae$and a robber in the house … ,
+inalae$a robber in the house … ,
+inalae$he need not replace it .
+inalae$If a person has fed another person’s child milk ,
+inalae$for NUMB years her barley shall be NUMB gur ,
+inalae$her wool NUMB minas ,
+inalae$and her oil NUMB sila3 ;
+inalae$it is a thing of the office of the nugig-women .
+inalae$The fee per year of a hired wet-nurse shall be NUMB shekel .
+inalae$If , during the term of Gutium ,
+inalae$a man sold a slave ,
+inalae$but that slave someone detained ,
+inalae$when the owner of the slave has taken an oath ,
+inalae$he may take away the slave .
+inalae$If the man who did the selling has died ,
+inalae$when that man’s wife , or his son , or his witness
+inalae$has taken an oath
+inalae$may he take away the slave .
+inalae$During the reign of Ur-Namma , the king of the nig2-diri levy ,
+inalae$after he had been elevated by Nanna over the people ,
+inalae$at that time , if the man who had sold the slave
+inalae$be he the slave’s owner or … ,
+inalae$or be he its … , the  ginabtum-officer
+inalae$if he has not brought in ,
+inalae$that man is a thief .
+inalae$If a man has died , his equal-ranking wife should act as the ordNUMB heir in the house .
+inalae$If a man marries the wife of his older brother ,
+inalae$he shall be killed .
+inalae$If a slave marries his female owner , he shall be killed .
+inalae$If a man … another man ,
+inalae$…
+inalae$… which is equivalent to the house …
+inalae$If a man has bought NUMB sar of a built house ,
+inalae$its silver shall be NUMB shekels .
+inalae$If a vacant lot of NUMB sar
+inalae$a man has bought , its silver shall be NUMB shekel .
+inalae$If NUMB sar of a built house
+inalae$a man has rented for … , he shall pay NUMB shekel of silver .
+inalae$A person who erases this inscription and writes his own name on it ,
+inalae$or because of this curse he incites another to do it ,
+inalae$and the person who erases this inscription and has written for him a name which should not be written ,
+inalae$whether that person be a king , or an en , or a governor , … ,
+inalae$may he who was seated on a throne sit down in the dust .
+inalae$May his people roam about among reed huts .
+inalae$May his city be a disagreeable city to Enlil .
+inalae$May the gates of his city stand open .
+inalae$May the young men of his city be blinded slaves .
+inalae$May the young women of his city be ones unable to bear .
+inalae$May the gods of his town , Enki , Iškur , and Ašnan ,
+inalae$by the exalted might of Enlil …
+inalae$… did not …
+inalae$May no one build the … of cattle pens … ;
+inalae$may no one … the … of sheepfolds for him .
+inalae$…
+inalae$…
+inalae$The city …
+inalae$… favorable …
+inalae$may it …
+inalae$Ur-Namma …
+pisanduba$Basket-of-tablets
+nigkak bala$xxx
+lukala$xxx
+mu mada zabcali$xxx
+u mu magurmah$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+sagapin e cabra$xxx
+mackim dida$xxx
+ragaba$xxx
+agaus$xxx
+malah magura$xxx
+dubsar$xxx
+guzala gunesag$xxx
+erin ugIL$xxx
+e ningeczida$xxx
+sipa dura$xxx
+bursag ningirsu$xxx
+igal$xxx
+mu usa kimac$xxx
+NUMB ceba lugal$NUMB barig of ration barley
+ninurani$for Nin-urani
+ki nabasata$from Nabasa ,
+kicib adaga$sealed tablet of Adaga .
+iti cunumun$Month : “ Sowing ” ,
+mu en nanna mace ipa$year : “ The Nanna priest was found via extispicy . ”
+urlisi$Ur-Lisi ,
+ensi$governor ,
+umma$of Umma
+adaga$Adaga ,
+dubsar$the scribe ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+etum cabra sangane$xxx
+igal$xxx
+mu huhunuri bahul$xxx
+pisanduba$Basket-of-tablets
+zulum kab duga$xxx
+ca umma igal$xxx
+mu en inanna unu mace ipa$xxx
+pisanduba$Basket-of-tablets
+dub gida$xxx
+idub$xxx
+giri bazi$xxx
+igal$xxx
+mu kimac bahul$xxx
+u e kiagani$When his beloved temple
+munadua$he had built for him ,
+|BAD$and Dēr ,
+iri kiagani$his beloved city ,
+kibe munagia$he had restored to its previous condition for him ,
+namtilanice$for his life
+a munaru$he dedicated  to him .
+culgi$For Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi X$and king of Sumer and Akkad ,
+cugurtum$Šūqurtum
+lukur kiagani$his beloved lukur . priestess .
+lu musaraba$A person who this inscription
+cu bibura$shall erase
+muni bibsara$and write his own name on it ,
+ninsun$may Ninsun
+dingirmu$my  goddess
+lugalbanda$and Lugalbanda
+lugalmu$my master
+nam habadakune$curse him .
+NUMB kuc gu agar gua$NUMB hide of ox , tanned ,
+NUMB kuc ab mu NUMB agar gua$NUMB hides of two-year cows , tanned ,
+NUMB kuc gu agar nugua$NUMB hides of oxen , not tanned ,
+NUMB kuc gu agar gua alhula$NUMB hide of ox , tanned , damaged ,
+NUMB kuc cudul gu$NUMB hides of oxen yokes ,
+NUMB kuc amar agar gua$NUMB hides of calves , tanned ,
+NUMB kuc amar agar nugua$NUMB hides of calves , not tanned ,
+NUMB kuc cudul amar$NUMB hide of calf yoke ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+si gu NUMBkam$horn of NUMB oxen ,
+n kun gu$NUMB tails of oxen ,
+n ad gu$NUMB carcases of oxen ,
+muku$delivery .
+n ad geme ucbare gua$NUMB carcasses fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina .
+sa gu NUMBkam kun gu NUMBkam$tendon of NUMB oxen , tail of NUMB oxen ,
+si gu NUMBkam$horn of NUMB ox ,
+NUMB ad gu$NUMB carcases of oxen ,
+laiam$are the deficit .
+luzabala unu$Lu-Zabala , the cowherd .
+NUMB kuc gu agar gua$NUMB hides of ox , tanned ,
+NUMB kuc gu mu NUMB agar gua alhula$NUMB hide of two-year cows , tanned , damaged ,
+NUMB kuc gu KAar agar nugua$NUMB hide of KA-ar oxen , not tanned ,
+NUMB ad gu$NUMB carcases of oxen ,
+NUMB kun gu$NUMB tails of oxen ,
+sa gu NUMBkam$tendon of NUMB ox ,
+si gu NUMBkam$horn of NUMB oxen ,
+muku$delivery .
+n ad gu geme ucbare gua$NUMB carcasses os oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina .
+n kuc gu ala cara$NUMB hide , ala of Šara ,
+sa gu NUMBkam kicib kugani$tendons of NUMB oxen , sealed tablet of Kugani ,
+laia NUMB kun gu sa gu NUMBkam$deficit : NUMB tails of oxen , tendon of NUMB oxen ,
+lugalezem unu$Lugal-ezem , the cowherd .
+NUMB kuc gu agar gua$NUMB hides of oxen , tanned ,
+NUMB kuc gu mu NUMB agar gua$NUMB hides of two-year oxen , tanned ,
+NUMB kuc gu alhula agar gua$NUMB hide of ox , damaged , tanned ,
+NUMB kuc gu alhula X X nugua$NUMB hide of ox , damaged , not “ fed ” … ,
+NUMB kuc cudul$NUMB hides of  yokes ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+NUMB kun gu$NUMB tails of oxen ,
+si gu NUMBkam$horn of NUMB oxen ,
+NUMB ad gu$NUMB carcasses of oxen ,
+muku$delivery .
+NUMB kuc gu sa gu NUMBkam$NUMB hides of oxen , tendon of NUMB oxen ,
+kicib kugani$sealed tablet of Kugani ,
+NUMB la NUMB ad geme ucbare gua$NUMB carcasses fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+laia kun gu NUMBkam$deficit : tail of NUMB oxen ,
+urnigar unu$Ur-nigar , cowherd .
+NUMB kuc gu agar gua$NUMB hide of ox , tanned ,
+NUMB kuc gu mu NUMB agar gua$NUMB hide of two-year ox , tanned ,
+NUMB kuc gu alhula agar gua$NUMB hide of ox , damaged , tanned ,
+NUMB kuc cudul$NUMB hide of  yoke ,
+NUMB kun gu$NUMB tails of oxen ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+si gu NUMBkam$horn of NUMB oxen ,
+muku$delivery .
+NUMB ad gu geme ucbare gua$NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+laia NUMB kun gu$deficit : NUMB tail of ox .
+carakam unu$Šara-kam , cowherd .
+NUMB kuc gu agar gua$NUMB hides of oxen , tanned ,
+NUMB kuc gu mu NUMB agar gua$NUMB hide of two-year ox , tanned ,
+NUMB kuc gu agar nugua$NUMB hide of ox , not tanned ,
+NUMB kuc gu alhula agar nugua$NUMB hide of ox , damaged , not tanned ,
+NUMB kuc cudul gu$NUMB hides of oxen yokes ,
+NUMB kun gu$NUMB tails of oxen ,
+X gu nkam$… of NUMB oxen ,
+muku$delivery .
+NUMB ad gu geme ucbare gua$NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+sa gu NUMBkam$tendon of NUMB oxen ,
+kicib kugani$sealed tablet of Kugani ,
+caramu unu$Šara-amu , cowherd .
+NUMB kuc gu agar gua$NUMB hides of oxen , tanned ,
+NUMB kuc gu alhula agar gua$NUMB hides of oxen , damaged , tanned ,
+NUMB kuc gu agar nugua$NUMB hide of ox , not tanned ,
+NUMB kuc cudul$NUMB hides of  yokes ,
+NUMB kuc cudul amar$NUMB hides of calf yokes ,
+NUMB kun gu$NUMB tails of oxen ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+NUMB ad gu$NUMB carcasses of oxen ,
+muku$delivery ;
+NUMB ad gu geme ucbare gua$NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+laia NUMB kuc gu NUMB ad gu$deficit : NUMB hide of ox , NUMB carcass of ox ,
+sa gu NUMBkam NUMB kun gu$tendon of NUMB ox , NUMB tails of oxen ,
+si gu NUMBkam$horn of NUMB oxen ,
+laiam$are the deficit .
+lugalkuzu unu$Lugal-kuzu , cowherd .
+NUMB kuc gu mu NUMB agar gua$NUMB hides of two-year oxen , tanned ,
+NUMB kuc cudul NUMB ad gu$NUMB hide of  yoke , NUMB carcasses of oxen ,
+sa gu nkam NUMB kun gu$tendon of NUMB oxen , NUMB tails of oxen ,
+si gu NUMBkam$horn or NUMB oxen ,
+muku$delivery ;
+lugalcunire unu$Lugal-šunire , cowherd .
+NUMB kuc gu agar gua$NUMB hide of ox , tanned ,
+NUMB kuc gu alhula agar gua$NUMB hide of ox , damaged , tanned ,
+NUMB kuc cudul gu sa gu NUMBkam$NUMB hide of ox yoke , tendon of NUMB oxen ,
+NUMB kun gu si gu NUMBkam$NUMB tail of ox , horn of NUMB oxen ,
+muku$delivery ;
+NUMB ad gu geme ucbare gua$NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+laia NUMB kun gu$deficit : NUMB tail of ox ;
+ursuda unu$Ur-ANsida , cowherd .
+NUMB cudul gu$NUMB  ox yoke ,
+muku$delivery ;
+budu unu$Budu , cowherd .
+NUMB kuc gu agar gua$NUMB hides of oxen , tanned ,
+NUMB kuc cudul amar$NUMB hides of calves yokes ,
+NUMB ad gu$NUMB carcasses of oxen ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+NUMB kun gu si gu NUMBkam$NUMB tails of oxen , horn of NUMB oxen ,
+muku$delivery ;
+muku$delivery ;
+muku$delivery ;
+albanidu unu$Albanidu , cowherd .
+NUMB kuc gu agar gua$NUMB hide of ox , tanned ,
+NUMB kuc gu mu NUMB alhula agar gua$NUMB hide of two-year ox , damaged , tanned ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+NUMB kun gu$NUMB tail of ox ,
+si gu NUMBkam$horn of NUMB oxen ,
+muku$delivery ;
+NUMB ad gu geme ucbare gua$NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+laia NUMB kuc gu$deficit : NUMB hide of ox ,
+NUMB kun gu$NUMB tail of ox ,
+si gu NUMBkam$horn of NUMB ox ,
+laiam$are the deficit .
+UC unu$UŠ , cowherd .
+NUMB kuc gu agar gua$NUMB hides of oxen , tanned ,
+NUMB kuc gu mu NUMB agar gua$NUMB hides of two-year oxen , tanned ,
+NUMB kuc gu alhula agar gua$NUMB hides of oxen , damaged , tanned ,
+NUMB kuc gu mu NUMB alhula agar gua$NUMB hides of two-year oxen , damaged , tanned ,
+NUMB kuc cudul gu$NUMB hide of ox yoke ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+NUMB kun gu$NUMB tails of oxen ,
+si gu NUMBkam$horn of NUMB oxen ,
+muku$delivery ;
+NUMB la NUMB ad gu geme ucbare gua$NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+si gu NUMBkam$horn of NUMB oxen ,
+daga cu bati$did Da'aga receive ;
+laia NUMB kun gu$deficit : NUMB tail of ox ,
+akicar unu$Akišar , cowherd .
+e cara$house of Šara .
+NUMB kuc cudul gu$NUMB hide of ox yoke ,
+sa gu NUMBkam$tendon of one ox ,
+NUMB ad gu$NUMB carcass of ox ,
+muku$delivery ;
+abagina unu$Abbagina , cowherd .
+NUMB kuc gu agar gua$NUMB hide of ox , tanned ,
+NUMB kuc gu mu NUMB agar gua$NUMB hide of two-year old ox , tanned ,
+NUMB kuc gu mu NUMB alhula agar gua$NUMB hide of two-year ox , damaged , tanned ,
+n kun gu$NUMB tail ,
+si gu NUMBkam$horn or NUMB ox ,
+muku$delivery ;
+n ad gu geme ucbare gua$NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+X NUMB kun gu$NUMB tails of oxen ,
+lalu unu$Lalu , cowherd .
+NUMB kuc gu alhula agar gua$NUMB hide of ox , destroyed , tanned ,
+NUMB kuc gu mu NUMB alhula agar gua$NUMB hide of two-year ox , damaged , tanned ,
+NUMB kuc amar agar nugua$NUMB hides of calves , not tanned ,
+NUMB kuc amar alhula agar gua$NUMB hide of calf , damaged , tanned ,
+NUMB kuc cudul gu$NUMB hide of ox yoke ,
+NUMB ad gu$NUMB carcass of ox ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+NUMB kun gu$NUMB tails of oxen ,
+muku$delivery ;
+NUMB ad gu geme ucbare gua$NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+laia NUMB ad gu$deficit : NUMB carcasses of oxen ,
+NUMB kun gu$NUMB tails of oxen ,
+si gu NUMBkam$horn or NUMB oxen ,
+sa gu NUMBkam$tendon of NUMB ox ,
+laiam$are the deficit ;
+ure unu$Ur-e'e , cowherd .
+NUMB kuc gu agar nugua$NUMB hides of oxen , not tanned ,
+NUMB kuc gu caba alhul$NUMB hide of ox , damaged on the inside ,
+NUMB kuc cudul amar$NUMB hides of calves yokes ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+NUMB kun gu$NUMB tail of ox ,
+muku$delivery ;
+NUMB ad gu geme ucbare gua$NUMB carcass of ox fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+urictaran unu$Ur-Ištaran , cowherd .
+NUMB kuc cudul gu$NUMB hide of ox yoke ,
+muku$delivery ;
+cecani unu$Šešani , cowherd .
+e ninura$house of Ninura ,
+namena$of lordship .
+NUMB kuc gu agar gua$NUMB hides of oxen , tanned ,
+NUMB kuc gu mu NUMB agar gua$NUMB hides of two-year oxen , tanned ,
+NUMB kuc gu mu NUMB alhula gua$NUMB hides of two-year oxen , damaged , “ fed ” ,
+NUMB kuc gu mu NUMB agar nugua$NUMB hides of two-year oxen , not tanned ,
+NUMB kuc cudul gu mu NUMB$NUMB hide of ox yoke ,
+NUMB kuc gu ga muku za nucu$NUMB hide of sucking bullcalf , delivery , uncovered side ,
+NUMB kun gu$NUMB tails of oxen ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+NUMB ad gu$NUMB carcasses of oxen ,
+si gu NUMBkam$horn of NUMB oxen ,
+muku$delivery ;
+NUMB ad gu geme ucbare gua$NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+NUMB kuc gu mu NUMB$NUMB hide of two-year ox ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+kicib kugani$sealed tablet of Kugani ,
+laia NUMB sa gu ga$deficit : NUMB tendon of sucking bull-calf ,
+NUMB kun gu$NUMB tail of ox ,
+laiam$are the deficit .
+adada u urgigir$Addada and Ur-gigir
+ki atuta$from Atu
+NUMB kuc abmah agar nugua$NUMB hide of full-grown cow , not tanned ,
+NUMB kuc ab mu NUMB agar nugua$NUMB hide of two-year cow , not tanned ,
+NUMB kuc gu mu NUMB agar nugua$NUMB hide of two-year ox , not tanned ,
+NUMB ad gu$NUMB carcasses of oxen ,
+sa gu NUMBkam$tendon of NUMB oxen ,
+n kun gu$NUMB tail ,
+abagina u cecani$Abbagina and Šešani ,
+gulah$oxen drivers .
+NUMB kuc cu eme$NUMB hide of old jenny ,
+muku$delivery ;
+urcara$Ur-Šara ,
+giri X$via … ,
+ki kasta$from Kas .
+cunigin NUMB kuc gu agar gua$Together : NUMB hides of oxen , tanned ;
+cunigin NUMB kuc gu mu NUMB agar gua$together : NUMB hides of two-year oxen , tanned ,
+cunigin n kuc amar agar gua$together : NUMB hides of calves , tanned ,
+cunigin NUMB kuc gu agar nugua$together : NUMB hides of oxen , not tanned ,
+cunigin NUMB kuc gu mu NUMB agar nugua$together : NUMB hides of two-year oxen , not tanned ,
+cunigin NUMB la NUMB kuc amar agar nugua$together : NUMB hides of calves , not tanned ,
+cunigin NUMB kuc gu alhula agar gua$together : NUMB hides of oxen , damaged , tanned ,
+cunigin NUMB kuc gu mu NUMB alhula agar gua$together : NUMB hides of two-year oxen , damaged , tanned ,
+cunigin NUMB kuc amar alhula agar gua$together : NUMB hide of calf , damaged , tanned ,
+cunigin NUMB kuc gu alhula agar nugua$together : NUMB hides of oxen , damaged , not tanned ,
+cunigin NUMB kuc cudul gu$together : NUMB hides of oxen yokes ,
+cunigin NUMB kuc cudul amar$together : NUMB hides of calves yokes ,
+cunigin sa gu NUMBkam$together : tendon of NUMB oxen ,
+cunigin NUMB kun gu$together : NUMB tails of oxen ,
+cunigin NUMB ad gu$together : NUMB carcasses of oxen ,
+cunigin si gu NUMBkam$together : horn of NUMB oxen ,
+cunigin NUMB kuc cu eme$together : NUMB hide of old jenny ,
+muku$delivery ;
+cunigin NUMB ad gu geme ucbare gua$together : NUMB carcasses of oxen fed to weaving female laborers ,
+giri lugalinimgina$via Lugal-inim-gina ;
+cunigin NUMB kuc gu$together : NUMB hides of oxen ,
+cunigin n kuc gu mu NUMB$together : NUMB hides of two-year oxen ,
+cunigin sa gu NUMBkam$together : tendon of NUMB oxen ,
+kicib kugani$sealed tablet of Kugani ,
+laia NUMB kuc gu$deficit : NUMB hides of oxen ,
+NUMB kuc amar$NUMB hides of calves ,
+sa gu n NUMBkam$tendon of NUMB oxen ,
+NUMB kun gu$NUMB tails of oxen ,
+NUMB ad gu$NUMB carcasses of oxen ,
+si gu NUMBkam$horn or NUMB oxen ,
+laiam$are the deficit .
+sa kuc muku$tendon and hides , delivery
+ca apisal$in Apisal .
+mu enunugalana inanna en inanna bahun$Year : “ Enunugalana of Inanna , the priest of Inanna , was installed ”
+pisanduba$Basket-of-tablets
+nigkak$accounts
+GAN urua$fields in plow ,
+cabra sangane$of  chief household administrators and chief temple administrators ,
+igal$are here ;
+mu usa e puzuricdagan badu mu usabi$year following : “ The house of Puzriš-Dagan was erected . ” the year following that .
+NUMB tug bardul du $NUMB ordinary bar-dul5 textiles
+NUMB tug ucbar $NUMB uš-bar textiles .
+pisanduba$Basket-of-tablets
+sadu dingirene$xxx
+mu bad badu$year : “ xxx . ”
+igal$are here ;
+diri NUMB ce gur$Surplus : NUMB gur NUMB barig NUMB ban2 barley ,
+ce GANgu$barley of GANgu-fields ,
+abata$from A’abba
+zizidam$to be booked out ;
+NUMB sila lugina$NUMB barig NUMB ban2 NUMB sila3 , Lugina ;
+NUMB ce gur lugal$NUMB gur , NUMB ban2 barley , royal ;
+ureana$Ur-Eanna ;
+NUMB ce GANgusuhub ki lugalemahe$NUMB bur3 GAN-oxenboots , with Lugal-Emaḫ ;
+NUMB ceba guba aca cara$NUMB gur NUMB barig barley-ration , stationed , field of Šara .
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+kunanna$Ku-Nanna ,
+dumu lubalasaga cuc$son of Lu-balasaga , chief cattle manager ,
+ARADzu$is your servant .
+cusuen$Šū-Sîn ,
+kiag enlila$the beloved of Enlil ,
+lugal enlile$the king whom Enlil
+kiag cagana$as the beloved in his heart ,
+inpa$did choose ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+dingiranir$his god ,
+lugalmagure$Lugalmagure ,
+nubanda enuga$the overseer of the guard ,
+ensi$governor
+urima$of Ur ,
+ARADdane$his servant ,
+e kiagani$his beloved temple
+munandu$he built for him .
+pisanduba$Basket-of-tablets
+gurum ak daba$xxx
+gala$xxx
+damgar$xxx
+lu geci$xxx
+girsuta$xxx
+guabce$xxx
+igal$xxx
+mu guza enlila badim$xxx
+urlamma$Ur-Lamma ,
+dubsar$scribe ,
+dumu urbaba$son  Ur-Baba .
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents of conveyance
+ARAD ugula$of ARAD , foreman ,
+igal$are here ;
+mu cusuen lugale mada zabcali muhul$year : “ Šū-Suen , the king , the lands of Zabšali destroyed . ”
+anahilibi kurucda$Ana-ḫilibi ,
+dumu utuge$son of Utu-ge .
+NUMB gu niga$NUMB oxen , barley-fed ,
+NUMB gu gecdu niga$NUMB breeding bull , barley-fed ,
+NUMB ab niga$NUMB cows , barley-fed ,
+NUMB udu niga saga$NUMB sheep , barley-fed , of good quality ,
+NUMB udu niga$NUMB sheep , barley-fed ,
+NUMB udu alum$NUMB long-fleeced sheep ,
+NUMB udu NUMB sila$NUMB sheep , NUMB lambs ,
+kacdea nunida$“ beer-pouring ” of Nunida ;
+n sila$NUMB lambs ,
+ziqurili$Ziqur-ilī ;
+muku$delivery ,
+nasa idab$Nasa accepted .
+iti ezemekigal$month : “ Mekigal Festival , ”
+mu usa kimac bahul$year after : “ Kimaš was destroyed ; ”
+u NUMBkam$ordNUMB day .
+NUMB mana kubabbar$NUMB mina silver ,
+NUMB sila igec gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 sesame oil ,
+NUMB gina NUMB silata$of NUMB shekel : NUMB sila3 each ;
+NUMB zulum gur$NUMB gur dates
+NUMB gina NUMBta$of NUMB shekel : NUMB ban2 each ;
+NUMB zulum gur$NUMB gur NUMB barig of dates
+NUMB gina NUMBta$of NUMB shekel : NUMB ban2 NUMB sila3 each ;
+kubi NUMB mana igiNUMBgal NUMB ce$its silver : NUMB minas NUMB  NUMB grains ,
+cunigin NUMB mana igiNUMBgal NUMB ce kubabbar$total : NUMB minas NUMB shekel NUMB grains of silver ;
+cabita$therefrom
+NUMB udu NUMB mac$NUMB rams , NUMB billy goats ,
+NUMB ginta$NUMB shekels each ,
+iti mackugu$month “ Gazelle-Feast ; ”
+NUMB udu NUMB mac NUMB ginta$NUMB rams , NUMB billy goats , NUMB shekels each ,
+iti ubigu$month “ ubi-Feast ; ”
+NUMB udu NUMB mac NUMB ginta$NUMB rams , NUMB billy goats , NUMB shekels each
+iti kisikininazu$month “ kisiki-Ninazu ; ”
+NUMB udu NUMB mac NUMB ginta$NUMB rams , NUMB billy goats , NUMB shekels each ,
+iti ezemninazu$month “ Festival-of-Ninazu ; ”
+NUMB la NUMB udu NUMB sila NUMB mac$NUMB rams , NUMB lambs , NUMB billy goats ,
+NUMB ginta$NUMB shekels each ,
+iti akiti$month “ Akitu ; ”
+NUMB udu NUMB la NUMB mac NUMB manata$NUMB rams , NUMB billy goats , NUMB mina each ,
+iti ezemculgi$month “ Festival-of-Šulgi ; ”
+NUMB udu NUMB mac NUMB mana NUMB ginta$NUMB rams , NUMB billy goats , NUMB mina , NUMB shekels each ,
+iti cueca$month “ šu’ešša ; ”
+NUMB udu NUMB mac NUMB manata$NUMB rams , NUMB billy goats , NUMB mina each
+iti ezemah$month “ Great-Festival ; ”
+cunigin NUMB udu mac hia$total : NUMB rams , billy goats , mixed ,
+cunigin kubi NUMB gu NUMB mana NUMB gin$total , the silver : NUMB talent NUMB minas NUMB shekels ;
+NUMB mana kubabbar har giri gu$NUMB mina silver , nose rings for oxen ,
+ezem akiti cunumunace$for the festivals Akitu & Sowing ;
+diri NUMB mana NUMB gin (|NINDA NUMB ce ku$surplus : NUMB minas NUMB shekels NUMB grains silver ,
+urbagara$Ur-Bagara ;
+NUMB mana kubabbar$NUMB mina silver
+NUMB sila igec$NUMB gur NUMB barig NUMB ban2 NUMB sila3 sesame oil
+NUMB zulum gur NUMBta$NUMB gur dates , NUMB ban2 each ,
+NUMB zulum gur NUMB silata$NUMB gur NUMB barig dates , NUMB sila3 each ,
+kubi NUMB mana NUMB gin NUMB ce$the silver : NUMB minas NUMB shekels , NUMB grains ,
+cunigin NUMB mana NUMB gin NUMB ce$total : NUMB minas NUMB shekels , NUMB grains ;
+cabita$therefrom
+NUMB udu NUMB mac NUMB ginta$NUMB rams , NUMB billy goat , NUMB shekels each ,
+iti mackugu$month “ Gazelle-Feast ; ”
+NUMB udu NUMB mac NUMB ginta$NUMB rams , NUMB billy goats , NUMB shekels each ,
+iti ubigu$month “ ubi-Feast ; ”
+NUMB udu NUMB mac NUMB ginta$NUMB rams , NUMB billy goats , NUMB shekels each ,
+iti kisikininazu$month “ kisiki-Ninazu ; ”
+NUMB udu NUMB mac NUMB ginta$NUMB rams , NUMB billy goats , NUMB shekels each ,
+nannadalla idab$Nanna-dalla took in possession ;
+NUMB sila NUMB gin$NUMB lamb , NUMB shekels ,
+egala  kura$in the palace delivered ,
+giri X$via Nur-…
+n NUMB udu NUMB ginta$n+1 rams , NUMB shekels each ,
+kicib cuea sukkalmah$under seal of Šu-Ea , chief minister ,
+iti ezemninazu$month “ Festival-of-Ninazu ”
+NUMB udu NUMB mac NUMB ginta$NUMB rams , NUMB billy goats , NUMB shekels each ,
+iti akiti$month “ Akitu ; ”
+NUMB udu NUMB mac NUMB manata$NUMB rams , NUMB billy goat , NUMB shekels each ,
+iti ezemculgi$month “ Festival-of-Šulgi ”
+NUMB  n udu n mac NUMB mana NUMB ginta$12+ rams , NUMB billy goats , NUMB shekels each ,
+iti cueca$month “ šu’ešša ; ”
+n udu NUMB sila NUMB mac NUMB manata$NUMB rams , NUMB lamb , NUMB billy goats , NUMB mana each ,
+iti ezemah$month “ Great-Festival ; ”
+cunigin NUMB udu mac hia$total : NUMB rams , billy goats , mixed ;
+cunigin kubi NUMB X$total , the silver : NUMB …
+NUMB mana kubabbar har giri gu$NUMB mina silver , nose ring for oxen ,
+laia NUMB mana n gin kubabbar$deficit : NUMB minas NUMB shekels silver ,
+ma anace$for “ Boat-of-Heaven ; ”
+NUMB mana kubabbar$NUMB mina of silver ,
+NUMB sila igec gur$NUMB gur NUMB barig NUMB ban2 NUMB sila3 of sesame oil ,
+NUMB zulum gur NUMBta$NUMB gur dates , NUMB ban2 each ,
+NUMB zulum gur NUMB silata$NUMB gur NUMB barig dates , NUMB sila3 each ,
+kubi NUMB mana NUMB gin NUMB ce$the silver : NUMB minas NUMB shekels NUMB grains ;
+cunigin NUMB mana NUMB gin NUMB ce kubabbar$total : NUMB minas NUMB shekels NUMB grains of silver ;
+cabita$therefrom
+NUMB X$NUMB …
+X$…
+X$…
+X$…
+n X$NUMB …
+iti kisikininazu$month “ kisiki-Ninazu ; ”
+NUMB udu NUMB n mac X NUMB ginta$NUMB rams , 2+ billy goats , NUMB shekels each ,
+iti ezemninazu$month “ Festival-of-Ninazu ”
+NUMB udu n mac NUMB ginta$NUMB rams , NUMB billy goats , NUMB shekels each ,
+iti akiti$month “ Akitu ; ”
+n NUMB udu n mac NUMB mana ginta$n+2 rams , NUMB billy goats , NUMB shekels each ,
+iti ezemculgi$month the “ Festival-of-Šulgi ; ”
+NUMB udu NUMB n mac NUMB ginta$NUMB rams , 3+ billy goats , NUMB shekels each ,
+iti cueca$month “ šu’ešša ; ”
+NUMB udu NUMB mac NUMB manata$NUMB rams , NUMB billy goats , NUMB mina each ,
+muku$deliveries
+laia NUMB mana n gin igiNUMBgal n ce kubabbar$the deficit : NUMB minas n+1/6 shekels NUMB grains of silver ;
+nigkak$account
+damgarne$of the merchants
+iti mackuguta$from month “ Gazelle-Feast ”
+iti ezemahce itibi iti NUMB la NUMBam$to the month “ Great-Festival ; ” its months : NUMB ;
+mu usa ibisuen lugal urimake nibru urima badgalbi mudu$year following “ Ibbi-Suen , king of Ur , at Nippur , Ur , the great walls built . ”
+NUMB udu niga NUMBkam us$NUMB sheep , grain-fed , ordNUMB grade ,
+NUMB udu alum niga NUMBkam us$NUMB ašlum sheep , grain-fed , ordNUMB grade ,
+u NUMBkam$ordNUMB day ,
+ki abasagata$from Abbasaga
+cumama$Šu-Mama
+idab$accepted ;
+iti ezemekigal$month : “ festival of Mekigal , ”
+mu huhnuri bahul$Year : “ Ḫuḫnuri was destroyed ; ”
+NUMB$NUMB .
+NUMB sila ga$NUMB male lambs , suckling ,
+NUMB kir ga$NUMB female lambs , suckling ,
+NUMB mac ga$NUMB male kids , suckling ,
+NUMB acgar ga$NUMB female kids , suckling ,
+utuda$newborns ,
+ca nagabtum$in the Nagabtum ,
+u NUMBkam$the ordNUMB day ,
+culgiamu idab$did Šulgi-ayamu take on ;
+iti cesagku$month “ Harvest , ”
+mu en nanna bahun$year : “ The priestess of Nanna was installed ; ”
+NUMB udu$NUMB ovicaprids .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+ARADnanna$ARAD-Nanna ,
+sukkalmah$the sukkalmaḫ ,
+dumu urculpae$son of Ur-Šulpa’e ,
+sukkalmah$the sukkalmaḫ ,
+ARADzu$is your servant .
+amarsuen$Amar-Suena ,
+nibrua$whom in Nippur
+enlile$Enlil
+mu pada$chose by name ,
+sagus$the constant supporter
+e enlilka$of the temple of Enlil ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubame$and king of the four world quarters -
+alanba$of this statue
+amarsuen kiag urima$Amar-Suena is the Beloved of Ur
+mubim$is its name .
+alanba$Of this statue ,
+lu ki gubabi$a person who its standing-place
+ibdabkurea$shall change ,
+bara sigabi$and its socle
+iburea$shall rip out ,
+nanna$may Nanna
+lugal urima$the king of Ur ,
+ningal$and Ningal
+ama urimake$the mother of Ur
+nam habandakune$curse him ,
+numunani$and his seed
+hebtilene$may they bring to an end .
+pisanduba$Basket-of-tablets
+nigkak$xxx
+ekikken$xxx
+igal$xxx
+mu cacrum$xxx
+pisanduba$Basket-of-tablets
+gurumak$inspections
+sipa unu$of shepherds and cattle herdsmen
+kinunir$in Kinunir ,
+nigin$Nigin ,
+guaba$and Guabba ;
+sipa cagan$of equid herdsmen ,
+sipa unu culgi$shepherds and cattle herdsmen of Šulgi
+u sagapin e ninhursag$and head-ploughmen of the house of Ninḫursag ,
+igal$are here ;
+mu harci bahul$year : “ Ḫarsi was destroyed . ”
+X$To …
+X$his ,
+urnamma$did Ur-Namma ,
+lugal urimake$king of Ur ,
+u cucin$when he Susa
+muhula$destroyed
+namrac$and to booty
+munaka$made ,
+namtilanice$for  life
+a munaru$dedicate .
+NUMB mac$NUMB male kid
+ceczimu$Šešzimu ,
+NUMB sila$NUMB male lamb
+puzurecdar$Puzur-Ešdar ,
+NUMB sila$NUMB male lamb
+kala$Kalla ,
+NUMB sila nuida$NUMB male lambs  Nu’’idā ,
+NUMB sila zabardab$NUMB male lambs  the zabar-dab5 official ,
+NUMB sila ursuen dumulugal$NUMB male lamb  Ur-Suen , the prince ,
+NUMB sila ensi nibru$the governor of Nippur ,
+muku$delivery ;
+iti cueca$month “ Šu’eša , ”
+mu simurum u lulubu ara NUMB la NUMBkamac bahul$year : “ Simurrum and Lullubu for the ordNUMB time were destroyed , ”
+u NUMBkam$ordNUMB day .
+pisanduba$Basket-of-tablets
+nigkak$accounts of
+urenlila nubandagu$Ur-Enlila , manager of oxen ,
+igal$are here ;
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen , the king , Urbilum destroyed . ”
+pisanduba$Basket-of-tablets
+gurum ak girisega cara girisega dingirene$xxx
+girisega ca irika$xxx
+u nigdiri daumma$xxx
+erin girisega$xxx
+mu gurum luduga KA usa$xxx
+igal$xxx
+mu cacru bahul$xxx
+pisanduba$Basket-of-tablets
+udu gukkal guba$sheep , fat-tailed sheep , stationed ,
+zusika kura$of ivory , sent in ,
+udu abisimti$sheep of Abi-simti ,
+nin idi$lady of … ,
+datiecdar dumulugal$Dati-Ištar , prince ,
+u urictaran dumulugal$and Ur-Ištaran , prince ,
+igal$are here ;
+ugula carakam ensi$foreman Šarakam , the governor ,
+u ugula urbaba dumu gududu$and foreman Ur-Baba , son of Gududu ,
+giri igia ragaba$via Igi'aya , rider ,
+ca girsu$in Girsu ,
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+gurumak diba$xxx
+malah lu marsa$xxx
+gacam damgar$xxx
+erin agauc$xxx
+mauzala$xxx
+e culgi$xxx
+igal$xxx
+mu$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+ahamwaqar$Aḫam-waqar ,
+dubsar$scribe ,
+ARADzu$is your servant .
+akala$Akalla ,
+dubsar$scribe ,
+dumu urnigar$son of Ur-nigar ,
+cuc$cattle manager .
+NUMB udu X$NUMB sheep …
+enlil$for Enlil ,
+NUMB X$xxx
+ninlil$NUMB … ,
+siskur ca ea$siskur-offering in the house ;
+NUMB X duku$NUMB … for Silver Mound ,
+NUMB X ninhursag$NUMB … for Ninḫursag ,
+NUMB X nusku$NUMB … for Nusku ,
+NUMB X ninurta$NUMB … for Ninurta ,
+NUMB X inanna$NUMB … for Inanna ,
+NUMB udu niga ninsun$NUMB sheep , barley-fed , for Ninsun ,
+NUMB macgal niga lugalbanda$NUMB buck , barley-fed , for Lugalbanda ,
+NUMB macgal culgi$NUMB buck for Šulgi ,
+NUMB macgal nintiuga$NUMB buck for Nin-ti’uga ,
+siskur ge$siskur-offering at night ;
+nanceGIRgal mackim$Nanše-GIRgal , responsible official ;
+iti u NUMB bazal$of the month , day NUMB elapsed ;
+cunigin NUMB udu niga NUMB macgal niga$total : NUMB sheep , barley-fed ,  NUMB bucks , barley-fed , ;
+ki naluta bazi$from Nalu booked out ;
+iti cesagku$month : “ Harvest , ”
+mu harci u kimac bahul$year : “ Ḫarši and Kimaš were destroyed . ”
+pisanduba$Basket-of-tablets
+ecucuma ca nigin$consignment house in Nigin
+igal$are here ;
+mu cacrum bahul$year : “ Šašrum was destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+unuene$xxx
+mu harci bahul kita$xxx
+mu usa bad mada baduta$xxx
+mu NUMBkam$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+zi KA iria gara$xxx
+NUMB GAN NUMB$xxx
+u zi KA luta$xxx
+igal$xxx
+bala dubsag$xxx
+mu en inanna mace ipa$xxx
+NUMB dug dida NUMB sila kac saga $NUMB jug wort , NUMB sila3 fine beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ,
+puzurecdar sukkal gabac $for Puzriš-Ištar , the messenger , to the frontier ;
+NUMB dug dida NUMB sila kac $NUMB jug wort , NUMB sila3 beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ,
+da gabac $for Dayya , to the frontier ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundle onions ,
+luane gabata $for Lu’ane , from the frontier ;
+cunigin NUMB dug dida du NUMB $total : NUMB jugs of common wort , NUMB ban2 ;
+cunigin NUMB sila kac saga cunigin NUMB sila kac $total : NUMB sila3 fine beer ; total : NUMB sila3 beer ;
+cunigin NUMB sila ninda cunigin NUMB gin i $total : NUMB ban2 NUMB sila3 bread ; total : NUMB shekels oil ;
+cunigin NUMB gin naga $total : NUMB shekels alkali-plant ;
+cunigin NUMB sa cum $total : NUMB bundles onions ;
+u NUMB la NUMBkam $ordNUMB day ,
+iti cesagku $month : “ Harvest , ”
+mu usa simanum bahul $year following : “ Simanum was destroyed . ”
+NUMB sila$three lambs and
+NUMB mac$NUMB male goats
+ca urima$in Ur ,
+u NUMB la NUMBkam$on the ordNUMB day ,
+ki abasagata$from Abba-saga
+nalu idab$Nalu assumed administrative responsibility ;
+iti kisikininazu$month : “ The … of Ninazu , ”
+mu en nanna bahun$Year : “ The en priestess of Nanna was appointed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+edula$estates of
+ensi$the governors
+u dumunene$and their sons ,
+lu cabra sangane$the chief house and temple administrators ,
+igal$are here .
+mu guza enlila badim$year : “ The chair of Enlil was fashioned . ”
+dingiricar$Ilum-išar ,
+X$governor-general
+mari$of Mari ,
+ucurid$caused to be brought down
+hubur$the god Hubur
+ana kamer$to Bāb-Mēr .
+pisanduba$Basket-of-tablets
+im sikiba$xxx
+giri ursuen$xxx
+igal$xxx
+mu simurum bahul$xxx
+NUMB sila ce gur lugal$NUMB gur , NUMB ban NUMB sila barley ,
+NUMB ziz gur$NUMB gur emmer
+NUMB gig gur$NUMB gur NUMB ban wheat
+ki ARADta$from ARAD .
+NUMB sila ce gur$NUMB gur , NUMB barig NUMB ban NUMB sila barley ,
+NUMB sila imgaga gur$NUMB gur , NUMB barig NUMB ban NUMB sila spelt ,
+NUMB ziz$NUMB barig , NUMB ban emmer
+ki lugalucurta$from Lugal-ušur .
+NUMB ce gur$NUMB gur barley
+laia suga bida$restored deficit of Bida .
+NUMB sila imgaga$NUMB barig , NUMB ban NUMB sila spelt
+ki ninmelamta$from Nin-melam .
+cunigin cebi NUMB sila gur$Together , the equivalent barley : NUMB gur , NUMB barig NUMB ban NUMB sila .
+NUMB geme NUMB$NUMB female laborers , ,
+iti cekaragala$from month “ Barley brought to the harbor ”
+mu harci kimac bahul$of the year “ Harši and Kimaš were destroyed ”
+u NUMB zalata$the completed day NUMB ,
+iti sigicubagara$until month “ Bricks cast in moulds ”
+mu usa harci kimac bahul$of the year following “ Harši and Kimaš were destroyed ” ,
+u NUMB zalace$the completed day NUMB ,
+abi u NUMB geme u NUMBce$its labor : NUMB , NUMB female laborer days .
+NUMB gin geme u NUMBce$NUMB shekels  female laborer days ,
+a udua geme bauca$labor of the “ free ” days of the deceased female laborer .
+sagnigurakam$It is the debit .
+cabita$Therefrom
+NUMB a udua geme$NUMB , NUMB , labor of the “ free ” days of the female laborers .
+NUMB la NUMB sila dabin gur$NUMB gur , NUMB barig NUMB ban minus NUMB sila dabin flour .
+NUMB sila zi sig gur$NUMB gur , NUMB barig NUMB ban NUMB sila sig-flour ,
+NUMB sila zi gaz gur$NUMB gur , NUMB barig NUMB ban NUMB sila “ pounded ” flour ,
+NUMB dabin bigu zi ea siga$NUMB barig , NUMB ban dabin flour , loss , flour “ filled ” into the house ,
+abi u NUMBkam$its labor : NUMB , NUMB days .
+NUMB sila eca gur$NUMB gur , NUMB barig NUMB ban NUMB sila eša flour ,
+NUMB sila ninda ara saga$NUMB ban NUMB sila fine , ground bread ,
+abi u NUMBkam$its labor : NUMB days .
+kicib ludingira$sealed tablet of Lu-dingira .
+NUMB sar kin sahar$NUMB sar soil ,
+ale NUMB ginta$per ,
+a gemebi u NUMBkam$labor of the female laborers : NUMB days ,
+kicib urnamnunka$sealed tablet of Ur-Namnunka .
+NUMB la NUMB a geme ce ziga$NUMB  labor of the female laborers who winnowed barley ,
+kicibi NUMBam$the sealed tablets are NUMB ,
+kicib ARAD$sealed tablets of ARAD .
+NUMB geme u NUMBce$NUMB female laborer days
+zi ma siga$flour loaded onto the barge ,
+kicib cecani$sealed tablet of Šešani .
+NUMB la NUMB geme inu gaga$NUMB female laborer , straw carried
+e culgirace$to the temple of Šulgi ,
+kicib akala$sealed tablet of Akalla .
+NUMB geme u NUMBce$NUMB female laborers ,  NUMB female laborer days ,
+abi u NUMBkam$its labor : NUMB days ,
+kicib carazame$sealed tablet of Šara-zame .
+NUMB geme u NUMBce balace gena$NUMB female laborers in NUMB days went to the bala ,
+NUMB geme u NUMBce balata gura$NUMB female laborers in NUMB days returned from the bala ,
+abi u NUMBkam$its labor : NUMB days .
+NUMB geme u NUMBce$NUMB female laborer days
+eucbar tuca$at the weaving-mill ,
+kicib adu$sealed tablet of Adu .
+NUMB geme u NUMBce$NUMB female laborer days
+dabina mansim gia$sieved dabin flour ,
+kicib urzu$sealed tablet of Ur-zu .
+NUMB geme u NUMBce geme arzana$NUMB female laborer days , female laborers of the arzana ,
+kicib lugalniglagare$sealed tablet of Lugal-nig-lagare .
+uc ninhegal$Dead : Nin-hegal ,
+iti eitiNUMB$from the month “ House sixth month ”
+mu harci kimac bahulta$of the year “ Harši and Kimaš were destroyed ” ,
+iti sigicubagara$until month “ bricks cast in moulds ”
+mu usa harci kimac bahul u NUMB zalace$of the year following “ Harši and Kimaš were destroyed ” , the completed day NUMB ,
+abi u NUMBkam$its labor : NUMB days .
+cunigin NUMB la NUMB sila dabin gur$Total : NUMB gur , NUMB barig NUMB ban minus NUMB sila dabin flour ,
+cunigin NUMB la NUMB sila zi sig gur$total : NUMB gur , NUMB barig NUMB ban minus NUMB sila sig-flour ,
+cunigin NUMB sila eca gur$total : NUMB gur NUMB barig NUMB ban NUMB sila eša flour ,
+cunigin NUMB sila ninda ara saga$total : NUMB ban NUMB sila fine , ground bread ,
+cunigin cebi NUMB sila gur$total , its barley : NUMB gur , NUMB barig NUMB ban NUMB sila ,
+cunigin NUMB geme u NUMBce$total : NUMB , NUMB female laborer days
+zigam$booked out .
+laia NUMB sila gur$Deficit : NUMB gur , NUMB barig NUMB ban NUMB sila ,
+laia NUMB gin geme u NUMBce$deficit : NUMB female laborer days ,
+laiam$are the deficit .
+nigkak urcara ugula kikkena$Account of Ur-Šara , foreman of milling ,
+iti sigicubagara$in the month “ bricks cast in moulds ”
+mu usa harci kimac bahul$of the year following “ Harši and Kimaš were destroyed ” .
+pisanduba$Basket-of-tablets
+kicib daba$xxx
+kaguru$xxx
+igal$xxx
+mu en eridu bahun$xxx
+pisanduba$Basket-of-tablets
+siki i ga egala kura$xxx
+kicib utuGIRgal$xxx
+mu usa en eridu bahunta$xxx
+mu e puzuricdagan baduce$xxx
+igal$xxx
+NUMB sila cegeci gur$NUMB gur NUMB ban2 NUMB sila3 sesame seeds ,
+situm mu kimac bahul$remaining deficit from the year : “ Kimaš was destroyed ; ”
+NUMB gur albanidu$NUMB gur , Albanidu ,
+NUMB gur lugirizal$NUMB gur , Lu-girizal ,
+NUMB gur urnigar$NUMB gur , Ur-nigar ,
+NUMB gur lugaldingirmu$NUMB gur , Lugal-dingirmu ,
+NUMB gur urnungal$NUMB gur , Ur-Nun-gal ,
+NUMB gur zabasage$NUMB gur , Zabasage ,
+NUMB gur eckidu$NUMB gur , Eškidu ,
+NUMB gur urgechamuna$NUMB gur , Ur-gešḫamuna ,
+NUMB gur urickur$NUMB gur , Ur-Iškur ,
+n NUMB uga$… NUMB ban2 , Uga ,
+n ninukkene$… , Nin-ukkene ,
+X ARADcara$… , ARAD-Šara ;
+n X gur$… gur ,
+X X culpae$… Šulpa’e ,
+NUMB cegeci ugu ure bagar$NUMB barig sesame seeds , in the debit account of Ur-e’e set ;
+kicib urcara caduba$under seal of Ur-Šara , chief accountant ;
+NUMB gin ku cegecibi NUMB gur$NUMB shekels silver , its sesame seed : NUMB bur NUMB ban2 ;
+kubi ugu dadaga bagar ugua garata$its silver in the debit account of Dadaga set , in the debit account having set ,
+NUMB guruc iti NUMBce$NUMB male laborers for NUMB months ,
+ugu lugalkuzu bagar ugua garata$in the debit account of Lugal-kuzu set , in the debit account having set ;
+cunigin NUMB cegeci gur$total : NUMB gur NUMB barig NUMB ban2 sesame seeds ,
+cunigin NUMB engargecikata gura$total : NUMB flax-ploughmen , returned ,
+zigam$booked out ;
+laia NUMB sila cegeci gur$the deficit : NUMB gur NUMB barig NUMB sila3 sesame seeds ,
+nigkak urbaba$account of Ur-Baba ,
+mu usa kimac bahul$year after : “ Kimaš was destroyed . ”
+NUMB esir EA$NUMB barig EA bitumen ,
+ki gududuta$from Gududu ,
+kicib agu$under seal of Agu ;
+iti nesag$month “ First-fruits , ”
+mu e cara ummaka badu$year : “ The house of Šara of Umma was erected . ”
+agu$Agu ,
+dubsar$scribe ,
+dumu lugalemahe$son of Lugal-emaḫe .
+pisanduba$Basket-of-tablets
+barakara hala$xxx
+carabdu$xxx
+acace hala$xxx
+igal$xxx
+mu madarabzu enkika babdu$xxx
+pisanduba$Basket-of-tablets
+gurum girisega$xxx
+etum ebappir$xxx
+ugnim$xxx
+igal$xxx
+mu magurmah badim$xxx
+pisanduba$Basket-of-tablets
+dub gida$xxx
+lunarua$xxx
+urlamma$xxx
+abamu$xxx
+cabrame$xxx
+urgulamu$xxx
+u luduga$xxx
+dumu urbaba$xxx
+igal$xxx
+mu e cara umma badu$xxx
+pisanduba$Basket-of-tablets
+cabi tug suga$xxx
+ua gi sangakene$xxx
+ugula urcucbaba$xxx
+iti ezemah$xxx
+mu en inanna mace ipata$xxx
+iti akiti$xxx
+mu dumumunus lugal ensi zabcalike bantukuac$xxx
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+sipa unu$xxx
+kinunir$xxx
+nigin$xxx
+guaba$xxx
+sipa cagan$xxx
+sipa unu culgi$xxx
+u sagapin e ninhursag$xxx
+igal$xxx
+mu harci bahul$xxx
+urningirsu $Ur-Ningirsu ,
+enmeziana $Enmeziana ,
+cennu $the šennu-priest
+en kiag nance $and the beloved en-priest of Nanše .
+NUMB ce ceckala$NUMB barig NUMB ban2 barley did Šeškalla
+NUMB azida$NUMB barig NUMB ban2 did Azida
+NUMB urninurta$NUMB barig NUMB ban2 did Ur-Ninurta
+ce ura enlila$barley loan  of Enlil
+ki lugalnamtareta$from Lugal-namtare
+cu batiec$receive ;
+kicib urninurta$under seal of Ur-Ninurta ;
+buru amabi gigi$the harvest will remit this debt ;
+acamu ae babre$That “ My field by flooding was ruined! ” , or
+ude babre$“ by the storm was ruined! ”
+nubenea$they will not say ,
+lugalra u sanga nunabenea$to the king or the chief administrator they will not say ,
+mu lugalbi ipadec$by the royal name they have sworn ;
+iti diri cesagku$the extra month “ Harvest , ”
+mu enamgal inanna mace ipa$the year : “ En-amgal of Inanna by omens was chosen . ”
+urninurta$Ur-Ninurta ,
+dumu lulamma$son of Lu-Lamma .
+enlil lugal kurkura $To Enlil , the king of all the lands ,
+lugalanir $his master ,
+enlilbani $Enlil-bāni ,
+lugal kalga lugal isina $the mighty king , king of Isin
+lugal kiengi kiuri $and king of Sumer and Akkad ,
+kiag enlil $beloved of Enlil
+u ninisinakake $and Nininsina ,
+nig X $a thing …
+carazame$Šara-zame , 
+ARAD cara$servant of Šara . 
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+pisanduba$Basket-of-tablets
+gurum ak girisega$xxx
+sagapin$xxx
+erin ugIL$xxx
+e dumuzi$xxx
+u e nindara$xxx
+mu en inanna mace ipa$xxx
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+cugute$for Šu-Gute ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+imtidam$for Imtidam ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+urdamu$for Ur-Damu ;
+NUMB sila kac NUMB sila ninda NUMB gin cum NUMB gin i NUMB gin naga$NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions , NUMB shekels oil , NUMB shekels alkali-plant ,
+mac$for Maš ;
+cunigin NUMB sila kac cunigin NUMB ninda$total : NUMB ban2 NUMB sila3 beer ; total : NUMB ban2 bread ;
+cunigin NUMB gin cum cunigin NUMB gin i cunigin NUMB gin naga$total : NUMB shekels onions ; total : NUMB shekels oil ; total : NUMB shekels alkali-plant ;
+u NUMBkam$ordNUMB day ;
+iti sigicubagara$month : “ Bricks cast in moulds , ”
+mu usa cusuen lugal urimake bad martu mudua mu usabi$year after : “ Šu-Suen , king of Ur , the Amorite wall erected , ” year after that .
+pisanduba$Basket-of-tablets
+ziga$xxx
+kicibac catamene$xxx
+u engarene$xxx
+X$xxx
+halha$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+gurum ak girisega$xxx
+etum$xxx
+e namhani$xxx
+igal$xxx
+mu ibisuen lugal$xxx
+NUMB X$NUMB … ,
+NUMB amar X$NUMB calf … ,
+eninanna$of En-dingirmu ;
+NUMB cegbar X$NUMB deer … ,
+cuecdar$of Šu-ešdar ;
+NUMB sila$NUMB lamb ,
+lugalnirgal$of Lugal-nirgal ;
+muku$delivery ;
+iti kisikininazu$month : “ ki-siki of Ninazu , ”
+mu en nanna mace ipa$“ The high-priestess of Nanna by means of extispicy was chosen ; ”
+u NUMBkam$ordNUMB day ,
+X$… .
+pisanduba$Basket-of-tablets
+bitum$xxx
+ecusuma$xxx
+igal$are here ;
+mu guza enlila badim$year : “ xxx . ”
+pisanduba$Basket-of-tablets
+gu apin$xxx
+gu udu ud$xxx
+mu e puzurdagan$xxx
+igal$xxx
+X$xxx
+meslamtaea$To Meslamtaea ,
+dingirani$his god ,
+lunimgirke$Lunimgira ,
+namti$for the life
+culgice$of Šulgi ,
+a munaru$dedicated .
+pisanduba$Basket-of-tablets
+kicib daba mungazi$xxx
+lukala$xxx
+igal$xxx
+mu en eridu bahun$xxx
+pisanduba$Basket-of-tablets
+nigkak$xxx
+situm$xxx
+urcugalama$xxx
+u luigisasa$xxx
+igal$xxx
+mu cacrum bahul$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+lucgina$Lu-ušgina ,
+dubsar$scribe ,
+dumu urlamma$son of Ur-Lamma ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+nigkak udu abisimti$accounts of sheep of Abī-simtī ,
+ugula SIAa$foreman SIAa ,
+kubatum$Kubātum ,
+ugula lunanna$foreman Lu-Nanna ,
+nawerdingir$Nāwer-ilī ,
+ugula namhani$foreman Namḫani ,
+ca girsu$in Girsu .
+NUMB kuc gu niga$NUMB ox-hides , grain-fed ,
+NUMB la NUMB kuc udu$NUMB sheep-hides ,
+NUMB kuc sila$NUMB lamb-hides ,
+sadu cara umma$regular offerings of Šara of Umma ;
+NUMB kuc gu niga NUMB kuc udu niga$NUMB ox-hide , grain-fed , NUMB sheep-hides , grain-fed ,
+NUMB kuc udu$NUMB sheep-hides ,
+sadu cara |KI.AN|$regular offerings of Šara of KI . AN ;
+NUMB kuc udu niga NUMB kuc sila$NUMB sheep-hides , grain-fed , NUMB lamb-hides ,
+nigtaga lugal$royal sacrifice ;
+NUMB kuc gu niga$NUMB ox-hide , grain-fed ,
+NUMB la NUMB kuc udu niga$NUMB sheep-hides , grain-fed ,
+NUMB kuc udu$NUMB sheep-hides ,
+ca sadu X$in the regular offerings … ;
+NUMB kuc mac$NUMB billy goat-hides ,
+sadu daha culgi$regular offerings , additional , of Šulgi ;
+NUMB kuc udu NUMB kuc sila$NUMB sheep-hides , NUMB lamb-hides ,
+ninura$for Ninura ;
+NUMB kuc udu NUMB kuc sila$NUMB sheep-hides , NUMB lamb-hides ,
+ebgal$Ebgal ;
+NUMB kuc udu NUMB kuc sila$NUMB sheep-hide , NUMB lamb-hides ,
+enlil$Enlil ;
+NUMB kuc udu nance umma$NUMB sheep-hides  Nanše of Umma ;
+NUMB kuc udu gula X$NUMB sheep-hide for Gula ;
+NUMB kuc udu NUMB kuc X$NUMB sheep-hides , NUMB …-hides ,
+inanna zabala ninilduma u kusigbanda$for Innana of Zabala , Nin-ilduma and Kusig-banda ;
+NUMB kuc udu ensi X X$NUMB sheep-hides , for the governor of … ;
+NUMB kuc udu NUMB kuc X$NUMB sheep-hides , NUMB …-hides ,
+e X X$for E’e … ;
+NUMB kuc udu NUMB kuc X$NUMB sheep-hides , NUMB …-hides ,
+dalagac$for Da-Lagaš ;
+NUMB kuc udu NUMB kuc sila$NUMB sheep-hides , NUMB lamb-hides ,
+enki u UCkalimmu$for Enki and UŠkalimmu ;
+NUMB kuc udu NUMB kuc sila$NUMB sheep-hides , NUMB lamb-hides ,
+dumuzi irimin$for Dumuzi of double-city ;
+sadu dingirene$regular offerings of the gods ;
+mu usa bad badu$year after : “ The wall was erected . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+ahuni$Aḫuni ,
+dumu X$son of Abba-…
+sagi$cupbearer .
+pisanduba$Basket-of-tablets
+kicib daba didli$sealed documents of dab , various ,
+igal$are here .
+pisanduba$Basket-of-tablets
+kicib lu nig dabakene$xxx
+ugua gara igi karkar$xxx
+u enbi tare$xxx
+igal$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmubake$king of the four corners
+abiabih$to Abī-abiḫ ,
+sagi$cupbearer ,
+ARADdanir$his servant ,
+inaba$he gifted .
+pisanduba$Basket-of-tablets
+gurumak erin$inspection of troops ,
+gizi nubanda$fodder reed , overseer ,
+mu$year : “ … . ”
+lugal enlile$then king whom Enlil
+kiag cagana$as beloved in the heart
+inpa$did choose ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur ,
+NUMB kuc gu$NUMB oxen hide ,
+NUMB sa gu$NUMB  oxen sinews ,
+NUMB kuc udu a irina$NUMB sheep skins “ with madder , ”
+NUMB gin cegin$NUMB shekels of glue ,
+mu simanum$year : “ Simanum . ”
+NUMB guruc u NUMBce$NUMB male laborer days ,
+kunzida aca duimduaka guba$at the reservoir of the field “ Du’imdua ” stationed ,
+ugula alinisu$foreman : Alinisu ,
+ziga$booked out ;
+iti nigega$month “ Nigega , ”
+mu en eridu bahun$year : “ The high-priestess of Eridu was installed . ”
+pisanduba$Basket-of-tablets
+ab ud guba$xxx
+u i ab uda gara$xxx
+ziga girsuta$xxx
+guabace$xxx
+pisanduba$Basket-of-tablets
+cabi suga sagnigura$therefroms , replaced , debits ,
+u ziga$and lifted outs
+basa dubsarmah$of Basa , August-scribe ,
+mu NUMBkam$the ordNUMB year ,
+igal$are here ;
+mu usa e puzuricdagan mu usata$from the year following : “ The house of Puzris-Dagan , ” the year after ,
+mu X$to the year : “ … . ”
+ururbartab$Ur-Urbartab ,
+dumu lugalazida$son of Lugal-azida ,
+gudu emah$gudu of the Emaḫ .
+pisanduba$Basket-of-tablets
+abilgi$Apil-kīn ,
+danum$the mighty ,
+X$governor-general
+mari$of Mari ,
+X$builder
+sahuri$of the šaḫũru-building .
+NUMB esir had gur lugal$NUMB royal gur of dried bitumen ,
+mu ma gibilce$for the new boat
+ki ensi ummata$from the governor of Umma ;
+kicib endingirmu$under seal of En-dingir-mu ,
+giri amursuen lu kas$via Amur-Suen , the runner ,
+u cecani lu X$and Šeš-ani , the … ;
+iti ezemah$month : “ Ezem-mah , ”
+mu bad mada badu$year : “ The wall of the land was erected . ”
+culgi$Šulgi ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four quarters ,
+endingirmu$En-dingir-mu ,
+ragaba$the courier ,
+ARADzu$your servant .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+nawirdingir$Nawir-ilim ,
+sukkal idu$courrier , doorman ,
+ARADzu$your servant ,
+ana$Anaya ,
+lukurani$his lukur .
+ala$Alla ,
+dubsar$scribe ,
+dumu luirisag$son of Lu-irisag .
+nabasa$To Nabasa
+unadu$speak
+geme ludumuzike intukua$“ The slave girl whom Lu-dumu-zi married ,
+ecgirice$to a nose-rope
+nabadu$he shall not attach ;
+geme duganizikam$she is the slave girl of Duganizi . ”
+ninkala $Ninkala ,
+dumu nibru $a citizen of Nippur ,
+kiagani $his beloved ,
+alanani $a statue of him
+mudim $she fashioned .
+murgu culgi $the shoulder of Šulgi .
+NUMB dug dida NUMB sila kac saga $NUMB jug wort , NUMB sila3 fine beer ,
+n ninda NUMB gin i NUMB gin naga $… ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ,
+cunumucda sukkal gabac $for Šū-Numušda , the messenger , to the frontier ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundle onions ,
+baba sukkal kausa $Babaya , the messenger , the ka’usa ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundle onions ,
+atu gabata $for Atu , from the frontier ,
+cunigin NUMB dug dida du NUMB $total : NUMB jug of common wort , NUMB ban2 ;
+cunigin NUMB sila kac saga cunigin NUMB sila kac $total : NUMB sila3 fine beer ; total : NUMB sila3 beer ;
+cunigin n n sila ninda cunigin NUMB gin i $total : NUMB ban2 , NUMB sila3 bread ; total : NUMB shekels oil ;
+cunigin NUMB gin naga $total : NUMB shekels alkali-plant ,
+cunigin NUMB sa cum $total : NUMB bundles onions ,
+u nkam $nth day ,
+iti paue $month : “ pa’u’e , ”
+mu simanum bahul $year : “ Simanum was destroyed . ”
+pisanduba$Basket-of-tablets
+ziga lugal$xxx
+gurumta$xxx
+lamba$xxx
+igal$xxx
+mu kimac$xxx
+NUMB mana$one-third mina
+NUMB gu gizi$NUMB talents , fodder-reed ,
+ca puzuricdagan$in Puzrish-Dagan ;
+NUMB gu gizi$NUMB talents , fodder-reed ,
+ca nibru$in Nippur ;
+NUMB gu$NUMB talents ,
+cagal udu nigace$fodder for the grain-fed sheep ;
+a erin girsu$labor of the troops from Girsu ,
+ki sukkalmah$with the sukkalmaḫ ,
+muku$delivery ,
+culgili$Šulgi-ilī
+cu bati$received ;
+giri lugirizal$via Lu-girizal
+iti macdagu$month : “ Gazelle-feast , ”
+mu ibisuen lugal$year : “ Ibbi-Suen is king . ”
+an lugal dingirene$For An , the king of the gods ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+lugal urimake$king of Ur ,
+kirimah$a large  garden
+munagub$he set up for him ,
+bara ki sikila$and a dais on a pure place
+munadu$he built for him .
+meslamtaea$To Meslamtaea ,
+lugalani$his master ,
+namti$for the life
+culgi$of Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmubakace$and king of the four world quarters ,
+dingirbani$Ilum-bāni ,
+dumu hasisEMUNUSke$the son of Hasīs-E2 . MUNUS ,
+a munaru$dedicated  to him .
+nusku$To Nusku ,
+sukkalmah$the chief minister
+enlila$of Enlil ,
+lugalani$his master ,
+namti$for the life
+culgi$of Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurikace$and King of Sumer and Akkad ,
+urnanibgal$Ur-Nanibgal ,
+ensi$the governor
+nibru$of Nippur ,
+dumu lugalengardu$son of Lugal-engardug ,
+ensi$governor
+nibrukake$of Nippur ,
+a munaru$dedicated  to him .
+ningeczida$To Ningeŝzida ,
+dingirani$his god ,
+namti$for the life
+culgi$of Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur ,
+pisanduba$Basket-of-tablets
+gurumak daba$inspections of dab ,
+sagapin erin ugIL$head plowmen , troops , porters ,
+e namhani$of the house of Namḫani ,
+igal$are here ;
+mu ibisuen lugal$year : “ Ibbi-Suen is king . ”
+pisanduba$Basket-of-tablets
+gurum ak daba$xxx
+lu gecikene$xxx
+eda tuca$xxx
+cuku aduga$xxx
+cuku aba$xxx
+cuku kida$xxx
+cuku X$xxx
+erin e X$xxx
+igal$xxx
+mu usa mada zabcali bahulta$xxx
+mu ibisuen lugalce$xxx
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+hulal$Ḫulal ,
+dubsar$scribe ,
+dumu cuickur$son of Šū-Adda ,
+cuc ARADzu$chief cattle manager , is your servant .
+NUMB kuc ab babbar uhab$NUMB hide of white cow ,  stink-plant : 
+urnigar$Ur-nigar 
+ziga$booked out ; 
+iti cesagku$month “ Harvest . ” 
+kubi i NUMB la NUMBkam$its silver : oil of the sort NUMB - NUMB
+NUMB sila igec duga NUMBkam$NUMB sila3 fine plant oil
+dada$Dada
+unadu$speak
+NUMB sa gi$NUMB bundles of reed
+nannakiag$Nanna-kiag .
+culgi$Šulgi ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal anubda limmuba$king of the four quarters
+pisanduba$Basket-of-tablets
+cukura ak$xxx
+damgar garakene$xxx
+igal$xxx
+mu en nanna mace ipa$xxx
+nanna$For Nanna ,
+dumusag$the first-born son
+enlila$of Enlil ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+sug pec dua$a swamp planted with  seedlings -
+sug hemeam$it was indeed a swamp -
+acabi$a field of it
+cargal GANam$which was NUMB
+ata$from the water
+hamunataDU$he brought out for him .
+ebi NUMB dana NUMB nigra$Levees for it , NUMB danna ,
+henak$he made for him .
+urie gilsac$Next to Ur , as a  treasure
+hemina$he made it .
+eba aba nannagin$Of that canal : Who Is Like Nanna
+mubi$is its name .
+ninlil$For Ninlil ,
+ninani$his mistress ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+ecutum kiagani$her beloved storehouse ,
+munadu$he built for her .
+pisanduba$Basket-of-tablets
+gurumak$inspections of
+girisega$personnel ,
+guapinlakam$oxen of the plow ,
+ugula ceckala$foreman Šeškala ,
+u urengaldudu$and Ur-engaldudu ,
+e X$house … ,
+igal$are here .
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur ,
+hachamer$Hašḫamer ,
+ensi$the governor
+ickunsuen$of Iškun-Sin ,
+ARADzu$is your servant .
+caninga$Ša-ninga ,
+dubsar$scribe ,
+dumu lugalucur$son of Lugal-ušur .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+abaenlilgin$Aba-Enlilgin ,
+dumu ida$son of Iddaya
+damgar$trade agent ,
+ARADzu$is your servant .
+nisaba$To Nisaba ,
+munus zi$the faithful woman ,
+munus saga$the beautiful woman ,
+munus mulmula$the radiant woman ,
+kiag ana$beloved of An ,
+munus hili kurkur$woman who is the luxuriance of all the lands ,
+munus dur imin$woman with the seven seats
+X imin$and seven … ,
+gectu ki ku$intelligent one of the pure place ,
+dubsar mah$chief scribe
+ana$of An ,
+sadu mah$chief land recorder
+enlila$of Enlil
+NUMB ce gur lugal $NUMB gur NUMB barig of barley , .
+ce ura engar nubanda $Barley loan for the plowmen of the oxen overseer
+idub ninhursagta $from the warehouse of Ninhursag ,
+ki bazita $from Bazi ,
+mu mancum $instead of Manšum
+kicib namhani $under seal of Namḫani ,
+cecana $his brother ;
+e namhani $household of Namḫani ;
+iti amarasi $month : “ Amar-ayasi , ”
+mu kimac bahul $year : “ Kimaš was destroyed . ”
+namhani $Namḫani ,
+dubsar $scribe ,
+X $…
+ibisuen$Ibbi-Sîn ,
+dingir kalamana$the god of his country ,
+lugal kalga$the mighty king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+namgal kiag$because of the great love
+suenada$of Sîn ,
+uri$Ur
+dagalede$to widen
+sa imacigar$he decided .
+urta$Therefore ,
+kalam gine$to make the country secure
+signim GAMede$and to make the lower and upper countries bow down ,
+bad gal$a great wall
+zapagba cu nukuku$through whose loop-holes ,
+hursag sigagin$like a verdant mountain range
+irini imidab$he made encircle his city .
+urua temenbe$In the foundations , for its foundation deposits
+ki inmanipa$he sought out places .
+badba$Of that wall
+ibisuen gugal namnuna$Ibbi-Sîn Is the Canal inspector of Princeliness
+mubim$is its name .
+pisanduba$Basket-of-tablets
+nigka caze$accounts … ,
+mu usa ancan bahul$year following : “ Anšan was destroyed . ”
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+ceba sikiba$xxx
+geme e kikken$xxx
+igal$xxx
+mu usa kimac bahul$xxx
+pisanduba$Basket-of-tablets
+kicib daba a erinaka$xxx
+ipae u urninsu$xxx
+iti NUMBkam$xxx
+igal$xxx
+iti cesagkuta$xxx
+iti dumuzice$xxx
+mu usa bad martu muriqtidnim mudu$xxx
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents of conveyances of
+urnintu ugula ucbar$Ur-Nintu , weaver ,
+igal$are here ;
+mu en nanna karzida bahun$year : “ The en of Nanna of Karzida was installed . ”
+emahkidu$Emahkidu
+dubsar$scribe , 
+dumu ursilaluh$son of Ur-silaluh . 
+pisanduba$Basket-of-tablets
+a uda erin ka egal$xxx
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents of conveyances ,
+urutu nubandagu$of Ur-Utu , oxen manager ,
+igal$are here ;
+mu cusuen lugale naruamah mudu$year : “ Šū-Suen , the king , Great Stele erected . ”
+pisanduba$Basket-of-tablets
+nigkak u$xxx
+guzalaene$xxx
+mu cusuen lugal urimake mada zabcali muhul$xxx
+igal$xxx
+X$xxx
+luisina$Lu-Isina ,
+dumu lugalazida$son of Lugal-azida .
+pisanduba$Basket-of-tablets
+gurumak daba$inspections , seized ,
+erin sagapin$troops , head-plows , of
+e culgi$the house of Šulgi
+u nukiri gec galgal$and orchardists of the big woods ,
+gu i nigincedu$bank of the waterway To Nigin-Going ,
+igal$are here ;
+mu huhunuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+a ente$xxx
+a buru$xxx
+cabrane$xxx
+igal$xxx
+mu cusuen lugal urimake simanum muhul$xxx
+NUMB buka$NUMB : Buka ,
+ARAD alalakam$slave of Alala ;
+alala igini icigar$Alala examined him ;
+mu lugal u bazahdenaga$by the royal name : “ On the day , I flee
+cerda hea$let it be a  crime , ”
+bindu$he swore ;
+zanMENI amani$Zan-MENI , his mother ,
+u gemenlil damnani$and Geme-Enlil , his wife ,
+cudu nuzahda$as guarantors of not fleeing ,
+bandec$went carried ;
+NUMB lugalgur$NUMB : Lugal-gur ,
+NUMB namhani$NUMB : Namḫani ,
+NUMB urgagia$NUMB : Ur-Gagia ,
+NUMB ceckala$NUMB : Šeškalla ,
+NUMB urebadu$NUMB : Ur-Ebadu ,
+NUMB usani$NUMB : Us’ani ,
+NUMB halimu$NUMB : Ḫallimu ,
+luinimabime$are the witnesses ;
+iti cesagku min$month : “ Harvest , ” the second ,
+mu usa bad martu badu$year after : “ The Martu wall was erected . ”
+pisanduba$Basket-of-tablets
+daba udu gukkalme$seized , fat-tailed sheep
+mu harci bahulta$from the year : “ Harši was destroyed ”
+mu amarsuen lugalce$to the year : “ Amar-Suen is king , ”
+mu NUMBakam$of NUMB years ,
+igal$are here .
+NUMB gu ku duru$xxx
+NUMB pisanduba cuna$basket-of-tablets xxx
+NUMB cen$xxx
+NUMB NIGezem agala$xxx
+NUMB guza dus$xxx
+NUMB dug igec$xxx
+NUMB dug girsu$xxx
+NUMB dug ga$xxx
+NUMB dug unu mun algazga$xxx
+ara NUMB la NUMBkam$xxx
+giri cuecdar$xxx
+NUMB dabin gur$xxx
+ara NUMBkam$xxx
+giri lusaga$xxx
+niguna ma gara$xxx
+ca babazta$xxx
+egal TUMce$xxx
+mu cusuen lugal$xxx
+NUMB sila$NUMB lamb ,
+NUMB macgal$NUMB buck ,
+NUMB ud$NUMB nanny goat ,
+bauc u NUMBkam$slaughtered , the ordNUMB day ,
+ki naluta$from Nalu
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti ezemana$month : “ Festival of An , ”
+mu cusuen lugal urimake bad martu muriqtidnim mudu$year : “ Šu-Suen , king of Ur , the western wall ‘muriq-tidnim’ erected ; ”
+NUMB$NUMB .
+cusuen$Šū-Sîn ,
+kiag enlila$the beloved of Enlil ,
+lugal enlile$the king whom Enlil
+kiag cagana$as the one beloved in his heart
+inpa$did choose ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur
+lugal an ubda limmuba$and king of the four world quarters ,
+dingiranir$his god ,
+ceckala$Šeškala ,
+cagina$the military governor ,
+ARADdane$his servant ,
+eani$his temple
+munadu$he built for him .
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmubake$king of the four corners
+suenabi$to Suen-abī ,
+sagi$cupbearer ,
+ARADdanir$his servant ,
+inaba$he gifted .
+pisanduba$Basket-of-tablets
+dub gida$xxx
+lu nigdaba akene$xxx
+girsuta$xxx
+guabace$xxx
+igal$xxx
+mu cusuen lugal$xxx
+NUMB dug dida NUMB sila kac saga $NUMB jug wort , NUMB sila3 fine beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ,
+X gabac $for … , to the frontier ;
+NUMB dug dida NUMB sila kac $NUMB jug wort , NUMB sila3 beer ,
+NUMB ninda NUMB gin i NUMB gin naga $NUMB ban2 bread , NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundles onions ,
+lutu gabac $for Lu-Utu , to the frontier ;
+NUMB sila kac NUMB sila ninda $NUMB sila3 beer , NUMB sila3 bread ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+NUMB sa cum $NUMB bundle onions ,
+amursuen gabata $for Amur-Suen , from the frontier ;
+cunigin NUMB dug dida du NUMB $total : NUMB jugs of common wort , NUMB ban2 ;
+cunigin NUMB sila kac saga cunigin NUMB sila kac $total : NUMB sila3 fine beer ; total : NUMB sila3 beer ;
+cunigin NUMB sila ninda cunigin NUMB gin i $total : NUMB ban2 NUMB sila3 bread ; total : NUMB shekels oil ;
+cunigin NUMB gin naga $total : NUMB shekels alkali-plant ;
+cunigin NUMB sa cum $total : NUMB bundles onions ;
+u NUMBkam iti dumuzi $ordNUMB day , month : “ Dumuzi , ”
+mu simanum bahul $year : “ Simanum was destroyed . ”
+pisanduba$Basket-of-tablets
+cegecika$xxx
+erin ugnim$xxx
+cu tia$xxx
+pisanduba$Basket-of-tablets
+erin e guzala$troops , house of the chair-holders ,
+erin esukkal$troops of the messenger house ,
+erin X$troops of Lugal-… ,
+damgar X ensigal$exchange agents , silver , … , big-governor ,
+igal$are here ;
+mu en eridu$year : “ The en of Eridu . ”
+NUMB mac u NUMBkam$NUMB billy goat , ordNUMB day ,
+NUMB udu mac hia$NUMB various sheep and goats ,
+u NUMBkam$ordNUMB day ,
+muku$delivery ,
+urkununa$Urkununa
+idab$took control of ;
+iti ezemah$Month “ big festival , ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen destroyed Urbilum . ”
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen destroyed Urbilum . ”
+NUMB$NUMB
+NUMB gu mu NUMB$NUMB bull  one year ,
+NUMB udu$NUMB sheep ,
+NUMB u$NUMB ewe ,
+NUMB sila$NUMB lamb ,
+bauc u NUMBkam$slaughtered , on the ordNUMB day ;
+ki duduta$from Du'udu
+culgirimu$Šulgi-irimu
+cu bati$has received ;
+iti ubigu$month : “ Eating Ubi-birds , ”
+mu cusuen lugal urimake bad martu muriqtidnim mudu$year : “ Šu-Suen , king of Ur , erected the Amorite wall Muriq-tidnim . ”
+pisanduba$Basket-of-tablets
+nigkak$xxx
+X dumu lugalgaba$xxx
+ca nigin$xxx
+eucbar lammacusuen$xxx
+iti GANmac$xxx
+mu usa bad martu baduta$xxx
+iti cesagku u NUMBkam$xxx
+mu e cara baduce$xxx
+iti NUMBkam$xxx
+iti diri NUMBam caba igal$xxx
+igal$xxx
+pisanduba$Basket-of-tablets
+situm$xxx
+ca nigin$xxx
+mu urbilum bahul$xxx
+NUMB udu niga saga us$NUMB sheep , grain-fed , fine , ordNUMB grade ,
+bauc u NUMBkam$slaughtered , ordNUMB day ;
+ki utamicaramta$from Uta-mišaram ,
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti ezemninazu$month : “ Festival of Ninazu , ”
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed ; ”
+NUMB$NUMB .
+pisanduba$Basket-of-tablets
+etum$xxx
+nigkak$xxx
+sipaene$xxx
+igal$xxx
+cara$For Šara ,
+nirgal ana$the trusted one of An ,
+dumu kiag$beloved son
+inanna$of Inanna ,
+adanir$his father ,
+cusuen$Šū-Sîn ,
+lugal kalga$the strong king ,
+lugal urima$king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+e cagipada$the House Chosen by the Heart ,
+e kiagani$his beloved temple ,
+namtilanice$for his life
+munadu$he built for him .
+NUMB amar gu ga$NUMB suckling bull calf ,
+NUMB sila ga$NUMB suckling male lambs ,
+NUMB kir ga$NUMB suckling female lambs ,
+NUMB mac ga$NUMB suckling kids ,
+utuda$newborns ;
+ca nagabtuma$inside the Fattening House ,
+u NUMBkam$the ordNUMB day
+culgiamu idab$Šulgi-ayamu accepted ;
+iti cesagku$month : “ Harvest , ”
+mu enmahgalana en nanna bahun$year : “ Enmaḫgalana , the high-priestess of Nanna , was hired ; ”
+NUMB gu NUMB udu$NUMB ox , NUMB small cattle .
+pisanduba$Basket-of-tablets
+nigkak cas,e$reckoned accounts xxx
+e nindingir$of the household of the priestess
+baba$of Baba
+igal$are here .
+mu X X X X$xxx
+mu amarsuen lugale urbilum bahulce$xxx
+pisanduba$Basket-of-tablets
+cabi suga ca ze$xxx
+lu nigdabkene$xxx
+igal$xxx
+mu simanum bahul$xxx
+pisanduba$Basket-of-tablets
+sagnigura$debits ,
+gu udu zizi iri$oxen , sheep , … ,
+ecucuma ensi$house of consignment of the governor ,
+u niginba udu gukkal$and grand totals of sheep and fat-tailed sheep ,
+mu NUMBkam$NUMB years ,
+igal$are here .
+NUMB guruc a u NUMBbi |ZI&ZI|a gunigin NUMBtam$NUMB male laborers , the labor of NUMB day : rushes , NUMB bales each ,
+cunigin NUMB guniginam$total : NUMB bales ,
+a u NUMBbim$being the labor of NUMB days ,
+sagnigurakam$they are the debits ;
+cabita$therefrom
+NUMB guniginam$NUMB bales ,
+ure idab$did Ur-e’e receive ;
+dabi madagake e$… Madaga … ,
+iti paue$month “ pa’u’e , ”
+mu simurum bahul$year “ Simurrum was destroyed . ”
+pisanduba$Basket-of-tablets
+kicib NUMB$sealed documents NUMB ,
+gizi$fodder reed ,
+giri abasaga$via Abbasaga .
+NUMB guruc u NUMBce$NUMB workdays , male laborers
+cura zar taba u ce gura$leveled , sheaves piled , grain harvested
+aca gibil u aca icibene$in New Field and Priests Field ;
+ugula basa$foreman : Basa ,
+kicib iniminanna$under seal of Inim-Inanna ;
+mu usa amarsuen lugal$year after : “ Amar-Suen is king . ”
+iniminanna$Inim-Inanna ,
+dumu lugalitida$son of Lugal-itida .
+NUMB sila kac NUMB sila ninda NUMB gin cum $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+nannakam $for Nanna-kam ;
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+dingirizu $for Dingir-izu ;
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+cuecdar $for Šū-Ištar ;
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+nasa $for Nasa ;
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+ana $for Anaya ;
+NUMB sila kac NUMB sila ninda NUMB gin  $NUMB sila3 beer , NUMB sila3 bread , NUMB shekels onions ,
+NUMB gin i NUMB gin naga $NUMB shekels oil , NUMB shekels alkali-plant ,
+ARADhula $for ARAD-ḫula ;
+cunigin NUMB sila kac NUMB sila ninda NUMB sila cum $total : NUMB ban2 NUMB sila3 beer ; NUMB ban2 NUMB sila3 bread ; NUMB sila3 onions ;
+cunigin NUMB gin i NUMB gin naga $total : NUMB shekels oil ; NUMB shekels alkali-plant ;
+X $…
+u NUMBkam iti minec $ordNUMB day , month : “ mineš . ”
+iti minec $month : “ mineš . ”
+NUMB amar macdamunus$NUMB calf , female gazelle ,
+u NUMBkam$on the ordNUMB day ;
+NUMB sila NUMB amar macdanita$NUMB lamb and NUMB calf , male gazelle ,
+u NUMBkam$ordNUMB day ;
+NUMB sila NUMB gu$NUMB lamb , NUMB ox
+NUMB ab$NUMB cows ,
+NUMB la NUMB dusunita$NUMB jackasses ,
+NUMB dusumunus$NUMB jennies ,
+cugid u NUMBkam$extispicy , ordNUMB day ;
+ki intaeata$from Inta’ea ;
+NUMB udu ki naluta$NUMB sheep from Nalu ;
+cabita$therefrom
+NUMB udu ca X mu giri cuili$NUMB sheep … via Šu-ilī ;
+NUMB sila NUMB amar macda$NUMB lambs , NUMB calfs , gazelles ,
+giri intaea$via Intake ;
+urmes idab$did Ur-mes accept ;
+NUMB ab NUMB dusu$NUMB cows , NUMB donkeys ,
+enlila idab$did Enlila accept ;
+iti akiti$month “ Akiti , ”
+mu ma darabzu babdu$year “ The barge Dara-abzu was calked . ”
+pisanduba$Basket-of-tablets
+sagnigura$credits
+mani$of Mani
+igal$are here ;
+mu urbilum bahul$year : “ Urbilum was destroyed . ”
+NUMB mana cagu sig$NUMB mina of … šagu ,
+ki aduta$from ADU
+lanimu cu bati$Lanimu received ;
+mu amarsuen lugal$year : “ Amar-Suen  king . ”
+pisanduba$Basket-of-tablets
+mu NUMB$NUMB years ,
+ceba$barley rations of
+geme ucbar$female weavers
+ca guaba$in Guabba ,
+mu$year : “ … . ”
+pisanduba$Basket-of-tablets
+kicib sagnigure$xxx
+urictaran$xxx
+igal$xxx
+mu usa bad martu badu$xxx
+enki$For Enki ,
+lugalani$his master ,
+urnamma$Ur-Namma ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+eani$his temple
+munadu$he built for him .
+pisanduba$Basket-of-tablets
+dugan$xxx
+cabi suga$xxx
+ca hurim$xxx
+iti diri cesagku$xxx
+mu cacruta iti gurabimumu$xxx
+mu en nanna mace ipace$xxx
+iti NUMBkam iti diri NUMBam caba igal$xxx
+igal$xxx
+giri ala dumu nasilim$xxx
+urgepar$To Ur-gepar
+unadu$speak!
+guruc NUMBam$Workmen , NUMB of them ,
+ma dug balede$the boat of pots to unload ,
+lucarara$to Lu-Šara
+henacumu$may he give!
+lu usgar hebdangigi$May … with it return!
+lukala$Lukalla ,
+dubsar$scribe ,
+dumu ursaga$son of Ur-saga .
+pisanduba$Basket-of-tablets
+sagnigura$xxx
+ziga cabi suga$xxx
+ucmu dubsar kurucda$xxx
+igal$xxx
+mu en eridu bahun$xxx
+pisanduba$Basket-of-tablets
+im etum$xxx
+ab etura$xxx
+gu apin$xxx
+gabari ensika$xxx
+igal$xxx
+mu naruamah badu$xxx
+ninlil eric mah$For Ninlil , the exalted queen ,
+anunkene pa e$most resplendant of of the Anuna gods ,
+X X X ankia$… in heaven and earth
+X X$like …
+X X$…
+X X  X$…
+X ki X X$…
+bara barabi X$their daises …
+namlugalce X X X$for kingship …
+men gidri cumam$he the one given the crown and scepter ,
+ama gal anunakene$for the great mother of the Anuna gods ,
+nin kiura X X$the mistress of the Ki'ur … ,
+ekur ec maha$the exalted shrine Ekur's
+mebi bar tamede$divine attributes to select ,
+ec nibru durankika$the Nippur shrine Duranki's
+culuhbi sikilede$ritual lustrations to cleanse ,
+garza cuta cubabe$to make the divine rites that had fallen away
+dalla mah ede$reappear magnificently ,
+nibru mac sag kalama$and Nippur , the bellwether of the nation ,
+kibe gigide$to restore to its previous state ,
+urninurtake$it was Ur-Ninurta ,
+ekurce gubam$the one serving the Ekur ,
+enlil lugal kurkurake$upon whom Enlil , the king of all the lands ,
+ug dagal carada$out over the broad population
+igi mininil$did lift his eye
+zidec binpa$and did rightly choose .
+an enlil ninlil X$Ninlil
+nighul imtabur$I removed evil ,
+ekur zagin iri X ki bad im$and  the shining Ekur temple in the city …
+X munesu$I set them up for them .
+alam medimbi$copper figures whose bodily features
+mucmega sega$were made to resemble me ,
+mac kadraka$with an offering kid ,
+imturture$were made in miniature ,
+namcitamuce guba$and , set up for  my prayers ,
+kisal mah gagecuaka$as the main courtyard of the Gagiššua's
+metebi munadim$ornament , I fashioned for her ,
+namtilamuce$and for my life
+a munaru$I dedicated them to her .
+lu a nighuldima$A person who an order of wickedness
+ibciagea$shall issue against it ,
+nig dimamu$and my creation
+ibzirea$shall efface ,
+X mah enlilake$by the exalted command of Enlil
+X X X mu padane$… may his revealed name
+ekurta inim hemibgigi$be revoked from within the Ekur .
+ninurta ursag kalga enlila$May Ninurta , the mighty warrior of Enlil ,
+mackim nukurubi hea$be the inseparable bailiff for this
+u darice$for an eternity of days!
+pisanduba$Basket-of-tablets
+pisan ku muku$baskets , silver , deliveries of
+urlamma ensi$Ur-Lamma , the governor ,
+igal$are here .
+turam$The sick one
+ada$Adda
+iuc$has died ;
+iti minec$month : “ mineš , ”
+mu cusuen lugal naruamah enlila mudu$year : “ Šu-Suen , the king , Grand-Stele of Enlil erected . ”
+lukala$Lukalla ,
+dubsar$scribe ,
+dumu ure cuc$son of Ur-e’e , cattle manager .
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur ,
+pisanduba$Basket-of-tablets
+gurumak$inspections ,
+ab etur$cows of the stall ,
+guapin$plow-oxen ,
+udu emegi$sheep , domestic ,
+udu kura$sheep , foreign ,
+sipa ud$shepherds of nannies ,
+gusuhub$boot-oxen ,
+igal$are here ;
+mu huhnuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+pisanduba$Basket-of-tablets
+kicib daba a erinaka$sealed documents daba , labor of troops ,
+ipae nubandagu$of Ipa’e , oxen manager ,
+iti NUMBkam$NUMB months ,
+igal$are here ;
+iti sigicubagarata$from month “ Bricks set in the molds , ”
+iti dumuzice$to month “ Dumuzi , ”
+mu cusuen lugale mada zabcali muhul$year : “ Šū-Suen , the king , the lands of Zabšali destroyed . ”
+pisanduba$Basket-of-tablets
+kicib daba lu nigdabakene$xxx
+aca guedina$xxx
+u mucbiana$xxx
+guruta ea$xxx
+giri ensi$xxx
+u nabienlila$xxx
+igal$xxx
+mu urbilum bahul$xxx
+lucara$xxx
+dubsar$xxx
+dumu lugalenun$xxx
+NUMB udu niga NUMB silata$NUMB barley-fed sheep at NUMB sila3 each ,
+udu bala$bala sheep ,
+cebi NUMB gur$their barley : NUMB gur NUMB barig NUMB ban2 ,
+giri lugalazida$via Lugalazida ;
+iti dal$month “ Flight , ”
+mu enunugal inanna bahun$year : “ Enunugal of Inanna was installed . ”
+pisanduba$Basket-of-tablets
+im duru$wet tablets
+igal$are here ;
+mu X lugal$year : “ …-Suen is king . ”
+pisanduba$Basket-of-tablets
+gurumak daba$inspections , seized ,
+edingirene$of the houses of the gods
+ca girsu$in Girsu ,
+igal$are here ;
+mu guza enlila badim$year : “ The chair of Enlil was fashioned . ”
+pisanduba$Basket-of-tablets
+sadu nigezema$xxx
+ninmar$xxx
+narua$xxx
+igimace$xxx
+ca guaba$xxx
+ninmar$xxx
+narua$xxx
+igimacgi$xxx
+ca guaba gula$xxx
+ninmar enku$xxx
+ninmar hurim$xxx
+acnan egibil$xxx
+acnan elibir$xxx
+sisakalama$xxx
+ensignun$xxx
+tirac$xxx
+antasura$xxx
+igal$xxx
+mu harci bahul$xxx
+pisanduba$Basket-of-tablets
+udu gukkal guba$sheep , fat-tailed sheep stationed ,
+abisimti$Abi-simti
+ugula cia cuc$foreman Ši’aya , cattle manager ,
+udu kubatum nin$sheep k . of the queen ,
+ugula izuarik cuc$foreman Izu-arik , cattle manager ,
+udu egal$sheep of the palace ,
+ugula nawerdingir$foreman Nawer-ili ,
+namhani cuc$Namḫani , cattle manager ,
+igal$are here ;
+ca girsu$in Girsu ,
+mu usa cusuen lugal urimake bad martu muriqtidnim mudu$year following : “ Šu-Suen , king of Ur , the Martu wall ‘muriq-tidnim’ erected . ”
+pisanduba$Basket-of-tablets
+barakara$Barakara
+igal$are here ;
+mu guza enlila badim$year : “ The chair of Enlil was fashioned . ”
+lugal urima$the king of Ur
+lugal an ubda limmubake$and king of the four world quarters ,
+namtilanice$for his life
+a munaru$he dedicated  to him/her .
+lu musarana$A person who his inscription
+cu binur$shall erase
+muni bibsarea$and write his name on it ,
+utu$may Utu ,
+lugal zimbirake$the king of Sippar ,
+numunani$to his seed
+hebtile$put an end!
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur .
+pisanduba$Basket-of-tablets
+sadu dingirene$xxx
+nigka nukirikeneta$xxx
+cusuba$xxx
+igal$xxx
+mu mada zabcali bahul$xxx
+NUMB ce gur lugal$NUMB gur barley by the royal measure ,
+macbi NUMB gin kubabbar$its interest : NUMB shekels of silver
+bala$too little ,
+urlamma lu lunga nance$did Ur-Lamma , brewer of Nanše ,
+cu bati$receive ;
+ce urakam buru amabi gigi$It is barley on loan , the harvest will remit the debt ;
+susudam$it is to be replaced ;
+iti cesagku$month “ Harvest , ”
+mu dumulugal usa$year after : “ Princess . ”
+pisanduba$Basket-of-tablets
+etum$xxx
+sagnigura$xxx
+u ziga$xxx
+ki X$xxx
+iti macdaguta$xxx
+iti ezemanace$xxx
+iti NUMBkam$xxx
+mu amarsuen lugal$xxx
+igalim$To Igalima ,
+dumu kiag$the beloved son
+ningirsuka$of Ningirsu ,
+lugalani$his master ,
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal kiengi kiurike$and king of Sumer and Akkad ,
+namtilanice$for his life
+pisanduba$Basket-of-tablets
+kicib daba$sealed documents of dab ,
+uruda nigcitima$copper of … ,
+u damgar$and trade agents ,
+ki dadagata$from Dadaga ,
+mu NUMBakam igal$NUMB year , are here ;
+mu harci kimac bahul$year : “ Ḫarši Kimaš were destroyed . ”
+NUMB la NUMB geme$NUMB less NUMB female laborers ,
+iti mucuduta$from month : “ musudu , ”
+iti ceilace$to month : “ Grain-carried , ”
+mu ibisuen lugal$year : “ Ibbi-Suen  king , ”
+NUMB geme$NUMB female laborers ,
+iti GANmacta$from month : “ GANmaš , ”
+iti ezembabace$to month : “ Festival of Baba , ”
+mu en inanna unu mace ipa$year : “ The high-priest of Inanna with extispicy was named , ”
+abi NUMB geme u NUMBce$the labor : NUMB , NUMB workdays , female laborers ;
+zi X$…
+nigkak a geme X ki X$account of the labor of female laborers …
+luningirsu dumu urnance$Lu-Ningirsu , son of Ur-Nanše ;
+iti NUMBkam$of NUMB months ,
+mu en inanna unuga mace ipa$year : “ The high-priest of Inanna with extispicy was named . ”
+NUMB tug didila gibil garig ak $NUMB small new combed garments ,
+kilabi NUMB mana $their weight is NUMB mana ;
+NUMB tug sag ucbar $NUMB “ sagušbar ” garments ,
+kilabi NUMB mana $their weight is NUMB mana ;
+n tug ucbar $NUMB “ ušbar ” garment ,
+kilabi NUMB mana $its/their weight is NUMB mana ;
+n tug mug $NUMB “ mug ” garment ,
+kilabi NUMB mana $its/their weight is NUMB mana ;
+ki ananata $from Anana ,
+muku $delivery ,
+idiera lu azlag $Iddin-Erra , the fuller ,
+cu bati $received them .
+iti cueca $Month : “ šu’ešša , ”
+mu harci u kimac bahul $year : “ Harši and Kimaš were destroyed . ”
+pisanduba$Basket-of-tablets
+barakara$xxx
+u erin gu$xxx
+hala$xxx
+cabrane$xxx
+igal$xxx
+mu en eridu bahun$xxx
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+u NUMBce$for NUMB days ,
+iti minec$month : “ mineš ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+u NUMBce$for NUMB days ,
+cebi NUMB gur$its barley : NUMB gur ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+u NUMBce$for NUMB days ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti eitiNUMB$month : “ House month NUMB ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti lisi$month : “ Lisi ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB$its barley : NUMB gur NUMB barig NUMB ban2 ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti ezemculgi$month : “ Šulgi ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti paue$month : “ pa’u’e ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti dumuzi$month : “ Dumuzi ; ”
+mu bad badu$year : “ mineš ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti cesagku$month : “ Harvest ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti sigicubgara$month : “ Bricks in the moulds set ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti cekaragala$month : “ Barley at the dock ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti nesag$month : “ First fruits ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur ,
+iti dal$month : “ Flight ; ”
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB sila  gur$its barley : NUMB gur NUMB barig NUMB sila3 ,
+NUMB udu niga NUMB silata$NUMB sheep , grain-fed , at NUMB sila3 each ,
+cebi NUMB gur$its barley : NUMB gur NUMB barig NUMB ban2 ,
+iti cunumun$month : “ Sowing ; ”
+mu usa bad badu$year after : “ The wall was erected ; ”
+cunigin NUMB sila gur$total : NUMB gur NUMB ban2 NUMB sila3 ,
+cagal udu niga$fodder of the sheep , grain-fed ,
+giri urnisaba$via Ur-Nisaba ,
+udu niga bala$sheep , grain-fed , of the bala ;
+giri namcatam$via the official office ;
+iti minec$from the month : “ mineš , ”
+mu bad baduta$year : “ The wall was erected , ”
+iti cunumun$to the month : “ Sowing , ”
+mu usa bad baduce$year after : “ The wall was erected . ”
+lugal urimake$the king of Ur ,
+NUMB dabin$NUMB barig flour ,
+ki lugalnirgalta$from Lugal-nirgal ,
+kicib adumu$under seal of Aramu ;
+iti cekargala$month : “ Barley at the quay , ”
+mu lulubum simurum bahul$year : “ Lullubum  Simurrum were destroyed . ”
+ursuen$Ur-Suen
+dubsar$scribe ,
+dumu urgigir$son of Ur-gigir ,
+catam$official .
+pisanduba$Basket-of-tablets
+gu apin gub$xxx
+e ninmar$xxx
+e dumuzi$xxx
+e nindara$xxx
+e bagara$xxx
+e gatumdu$xxx
+e nance$xxx
+e ningeczida$xxx
+e uru$xxx
+e inanna$xxx
+u gu X$xxx
+igal$xxx
+mu huhunuri$xxx
+pisanduba$Basket-of-tablets
+dub gida$xxx
+gec kiri sila gur$xxx
+mu cacrum$xxx
+pisanduba$Basket-of-tablets
+gurum ak$xxx
+sagapin e enlil$xxx
+e enki$xxx
+e ningul$xxx
+e dumuzi$xxx
+e namhani$xxx
+e nindara$xxx
+igal$xxx
+mu en nanna mace ipa$xxx
+NUMB GAN gecura$NUMB eše3 land for harrowing ,
+NUMB guruc al NUMB sarta$NUMB workers each hoeing NUMB sar ,
+lutu engar$Lu-Utu , the plot manager ;
+NUMB GAN gec ura$NUMB eše3 land for harrowing ,
+NUMB guruc al NUMB sarta$NUMB workers each hoeing NUMB sar
+nimgirhedu engar$Nimgir-ḫedu , the plot manager ;
+NUMB GAN gec ura$NUMB eše3 land for harrowing ,
+NUMB guruc al NUMB sarta$NUMB workers each hoeing NUMB sar ,
+engarzi engar$Engar-zi , the plot manager ;
+NUMB GAN gec ura$NUMB eše3 land for harrowing ,
+NUMB guruc al NUMB sarta$NUMB workers each hoeing NUMB sar ,
+caramutum engar$Šara-mutum , the plot manager ;
+NUMB GAN gec ura$NUMB eše3 land for harrowing ,
+NUMB guruc al NUMB sarta$NUMB workers each hoeing NUMB sar ,
+bala engar$Bala the plot manager ;
+aca menkar$field “ Menkar ; ”
+gurum u NUMBkam$inspection on the ordNUMB day ;
+iti cunumun$month : “ Sowing , ”
+mu huhunuri bahul$year : “ Ḫuḫnuri was destroyed . ”
+pisanduba$Basket-of-tablets
+guru ak daba$xxx
+eninmar$xxx
+ec didli$xxx
+egal ekas$xxx
+ca guaba$xxx
+mu amarsuen lugale urbilum muhul$xxx
+diritum $Diritum ,
+dam urnamma $the wife of Ur-Namma
+lugal urima $the king of Ur -
+lugalkuzu $Lugalkuzu
+nubanda $the overseer
+ARADzu $your servant .
+pisanduba$Basket-of-tablets
+etum tug guna$xxx
+mu usa kimac bahul$xxx
+baba$Baba ,
+dumu dada$son of Dada .
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+culgili$Šulgi-ilī ,
+dubsar$scribe ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+bitum$“ house ” ,
+kicib bala$the sealed documents of the bala
+nasa$of Nasa
+u gabaribi$and their copies
+ki urkununa$—that were with Ur-kununa—
+igal$are inside .
+cusuen$Šū-Suen ,
+nita kalga$strong man ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of heaven with its four corners
+X$Lu-ada-… ,
+dubsar$scribe ,
+dumu X$son of … ,
+ARADzu$is your servant .
+pisanduba$Basket-of-tablets
+ceba sikiba$xxx
+girisega cairi$xxx
+igal$xxx
+mu cusuen lugal urimake mada zabcali muhul$xxx
+NUMB udu$NUMB sheep ,
+NUMB sila$NUMB lamb ,
+bauc u NUMBkam$slaughtered , the ordNUMB day ,
+ki urnannata$from Ur-Nanna
+culgirimu$Šulgi-irimu
+cu bati$received ;
+iti sesdagu$month : “ Piglet feast , ”
+mu usa simanum bahul$year after : “ Simanum was destroyed ; ”
+NUMB udu$NUMB small cattle .
+pisanduba$Basket-of-tablets
+ziga lugal u sagnigura$credits royal and debits of
+ce gu udu i siki ku uruda u diri laia ku gara$barley , oxen , sheep , oill , wool , silver , copper and extras , debts , silver inlayed ,
+mu NUMBakam$NUMB year ,
+igal$are here ;
+mu usa kimac bahul$year following : “ Kimaš was destroyed . ”
+NUMB sila ce gur$NUMB gur NUMB ban NUMB sila barley
+cenumun murgu u a lu hunga$seed , oxen feed and wages of day laborers ,
+ki luginata$out of  Lu-gina
+bazi$booked ;
+kicib ursuen$sealed document of Ur-Suen .
+mu usa simanum bahul$Year after : “ Simanum was destroyed . ”
+pisanduba$Basket-of-tablets
+X$xxx
+apinla$xxx
+X$xxx
+aca pus$xxx
+X$xxx
+giri lucara$xxx
+X$xxx
+mu usa ibisuen lugal$xxx
+pisanduba$Basket-of-tablets
+ca laia suga$xxx
+al kin u$xxx
+habuda$xxx
+igal$xxx
+cara$To Šara ,
+nirgal ana$trusted one of An ,
+dumu kiag inanna$beloved son of Inanna ,
+lugalani$his master ,
+namti$for the life of
+culgi$Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$king of Ur
+lugal an ubda limmubakace$and king of the four world quarters ,
+lunanna$Lu-Nanna ,
+dumu cuera$the son of Šū-Erra
+damgarke$the merchant ,
+X X$…
+pisanduba$Basket-of-tablets
+gurumak$inspections
+ugIL$of the porters ,
+ugula sanga ninmar$foremen , temple administrator of Ninmar ,
+mu en nanna mace ipa$year : “ The en of Nanna by goat was found . ”
+NUMB gin igiNUMBgal kubabbar$NUMB shekels silver ,
+ce buru anagbi NUMB ce gurta$its barley to be measured out at harvest : NUMB gur NUMB barig each ,
+ki urlammata$from Ur-Lamma
+luguza dumu lumah sagubke$did Lu-guza , son of Lu-maḫ of Sagub
+cu bati$receive ;
+iti GANmac susudam$in month “ GANmaš ” to be replaced ;
+mu lugal igal$royal name entered ;
+iti ezembaba$month “ Festival-of-Baba , ”
+mu en karzida$year : “ Lord of Karzida . ”
+NUMB gin igiNUMBgal kubabbar$NUMB shekels silver ,
+ce burubi NUMB gurta$its barley at harvest : NUMB gur NUMB barig each
+X$to be measured out ;
+ki urlamma dumu urnig$from Ur-Lamma son of Ur-nig ,
+kicib luguza dumu lumah sagub$under seal of Lu-guza , son of Lu-maḫ of Sagub
+iti ezembaba$month “ Festival-of-Baba , ”
+mu en nanna karzida$year : “ Lord of Nanna of Karzida . ”
+cusuen$Šū-Suen ,
+lugal kalga$strong king ,
+lugal urima$king of Ur ,
+lugal an ubda limmuba$king of the four corners
+atakalcum$Atalkalšum ,
+X$… ,
+X$… .
+NUMB sila enlil$NUMB male lamb  Enlil
+NUMB sila ninlil$Ninlil ,
+muku cecdada sanga$delivery  Šešdada , the household manager ,
+zabardab mackim$the zabar-dab5 official  the deputy ;
+NUMB ab NUMB la NUMB udu$NUMB cows , NUMB rams ,
+NUMB u NUMB sila$NUMB ewe , NUMB male lamb ,
+NUMB mac NUMB ud$NUMB male kids  NUMB nanny goats ,
+cugid emuhaldimce$šu-gid2 for the kitchen ;
+NUMB dusumunus$NUMB domestic jennies ,
+bauc ekicibace$slaughtered , for the warehouse ;
+ziga u NUMBkam$booked out , ordNUMB day ;
+iti ezemah$month “ Big Festival , ”
+mu culgi lugale urbilum lulubu simurum u karhar ace sagdubi cubura bira$year : “ Sulgi , the king , the heads of Urbilum , Simurrum , Lullubu and Karḫar in a single campaign did smash . ”
+pisanduba$Basket-of-tablets
+kicib sikiba zamu urickur$sealed documents of wool rations of New Year’s ,  of Ur-Iškur ,
+kugani lusaga$Kugani ,  Lu-saga ,
+caramu ARAD$Šara-amu , ARAD ,
+nigulpae lugalmumuag$Nig-ul-pa’e , Lugal-mumag ,
+akala dumu duranice$Ayakalla , son of Duraniše ,
+lucara dumu ANbaAN$Lu-Sara , son of ANbaAN ,
+igal$are here ;
+mu en eridu bahun$year : “ The en in Eridu was installed . ”
+pisanduba$Basket-of-tablets
+kicib daba a erinaka$xxx
+lugalitida nubandagu$xxx
+iti NUMBkam$xxx
+igal$xxx
+iti sigicubagarata$xxx
+iti dumuzice$xxx
+mu cusuen lugale mada zabcali muhul$xxx
+pisanduba$Basket-of-tablets
+cabra ibdab$xxx
+ziga lugal$xxx
+kurucdae ibdab$xxx
+ca dugana$xxx
+kicib lugalitida$xxx
+ki abasagata bazi$xxx
+iti macdaguta$xxx
+iti cesagkuce$xxx
+iti NUMBkam$xxx
+mu huhnuri bahul$xxx
+pisanduba$Basket-of-tablets
+indub$xxx
+ma siga$xxx
+u cenumun$xxx
+cabra sangane$xxx
+igal$xxx
+mu usa ancan bahul$xxx
+pisanduba$Basket-of-tablets
+udu gukkal$sheep , fat-tailed sheep ,
+niginba girsuta$grand totals from Girsu
+guabace$to Guabba ,
+igal$are here ;
+mu usa ancan bahul$year following “ Anšan was destroyed . ”
+NUMB geme$NUMB female laborers
+iti NUMBce$for NUMB months ,
+abi u NUMB$labor involved : NUMB , NUMB workdays ,
+iti cesagkuta$from month “ Harvest ”
+iti dirice$to month “ Extra ” ;
+NUMB sila dabin gur$NUMB gur , NUMB ban2 , NUMB sila3 dabin flour ,
+abi u NUMB igi NUMBgalbi ibgar$labor involved : NUMB , its 1/6th included ,
+ki ARADta$from ARAD ;
+NUMB ce gur$NUMB gur of barley ,
+abi u NUMB$labor involved : NUMB workdays ;
+nigka ce lugalezemta$from the grain account of Lugal-ezem ;
+NUMB geme iti NUMB u NUMBce$NUMB female laborers for NUMB months NUMB days ,
+abi u NUMB$labor involved : NUMB workdays ;
+geme balace gena$female laborers to bala-service gone ;
+NUMB geme u NUMBce$NUMB female laborer days ,
+a zi ara$labor of flour milling ,
+igi NUMBgalbi NUMB$its ordNUMB : NUMB
+NUMB geme u NUMBce$NUMB female laborer days ,
+a ziga didli$labor booked out , various ,
+ki lugalniglagare ugula ucbarta$from Lugal-niglagare , foreman of weavers ;
+NUMB tug guza du$NUMB regular guzza-garments ,
+abi u NUMB$labor involved : NUMB , NUMB workdays .
+NUMB dabin gur$NUMB gur , NUMB barig , NUMB ban2 dabin flour ,
+abi u NUMB$labor involved : NUMB workdays ,
+igi NUMBgalbi ibgar$its 1/6th included ;
+gu gara ca umma$burden set  in Umma
+u ca apisal$and in Apisal ;
+mu nanna karzida ara NUMBkam eana banku$year : “ Nanna of Karzida was for the second time brought into Eanna ” .
+pisanduba$Basket-of-tablets
+bitum$‘chambers , ’
+muku$deliveries ,
+meictaran$of Me-Ištaran ,
+iti sesdagu$month “ Piglet feast , ”
+mu e cara mudu$year : “ The house of Šara built , ”
+igal$are here .
+n ce gur$… gur barley
+ce enlila$barley for  of Enlil ,
+kiba segede$to be stored in that place ,
+ki lugalnamtareta$from Lugal-namtare
+urhaiake$did Ur-Ḫaya
+cu bati$receive ;
+iti diri cesagku$the extra month “ Harvest , ”
+mu enmahgalana en inanna bahun$year : “ En-maḫgal-ana as en priestess of Innana was installed . ”
+cebi buru amabi gigi$the harvest will remit this barley
+e enlilaka$into the household of Enlil
+inikukua$which he is entering ;
+acamu ude babde$That “ My field by the storm was ruined! ” , or
+ae babde$“ by flood water was ruined! ”
+lugalra u sanga nunabea$to the king or to the chief administrator he will not say ,
+mu lugalbi inpa$by the royal name he swore .
+urhaia$Ur-Ḫaya ,
+dubsar$scribe ,
+dumu engardu$son of Engar-du ,
+sagi$cupbearer .
+inanna$To Inanna ,
+ninanir$his mistress ,
+namti$for the life
+culgi$of Šulgi ,
+nita kalga$the mighty man ,
+lugal urima$the king of Ur ,
+hazi nubanda$did Ḫazi , the overseer ,
+ARADdane$his servant ,
+a munaru$dedicate .
+pisanduba$Basket-of-tablets
+etum$‘chambers , ’
+sagnigura$debit accounts
+u ziga$and credits ,
+utamicaram$of Utamišarram ,
+iti macdaguta$from month “ Gazelle feast , ”
+iti cesagkuce$to month “ Harvest , ”
+iti NUMBkam$NUMB months ,
+mu en eridu bahun$year : “ The en in Eridu was installed , ”
+igal$are here ;
+X babati$… of Babati ,
+igal$are here .
+NUMB la NUMB ce gur$NUMB gur barley ,
+kubi NUMB mana NUMB gin$its silver : NUMB mina NUMB shekels ,
+ara NUMBkam$first time ;
+NUMB ce gur$NUMB gur NUMB barig NUMB ban2 barley ,
+kubi NUMB gin NUMB ce$its silver : NUMB shekels NUMB grains
+ara NUMBkam$second time ;
+NUMB pec cergu UDUA$NUMB strings of dates , dried ,
+NUMB sila hachur hul$NUMB ban2 NUMB sila3 crushed crabapples ,
+kubi NUMB gin la NUMB ce$their silver : NUMB shekels less NUMB grains ;
+NUMB gin ki urututa$NUMB shekels from Ur-Utu ;
+cunigin NUMB mana NUMB gin igiNUMBgal NUMB ce ku$total : NUMB mina NUMB shekels NUMB grains silver ;
+cabita$therefrom
+NUMB mana kubabbar$NUMB mina silver
+kicib lukala ki ursilaluh muku$under seal of Lukalla , delivered from Ur-silaluh ;
+NUMB gin ku esir kicib nura$NUMB shekels silver  bitumen , unsealed ;
+NUMB gin luinanna cu bati$NUMB shekels received by Lu-Inanna ;
+cunigin NUMB mana NUMB gin kubabbar$total : NUMB mina NUMB shekels silver ;
+laia NUMB gin NUMB ce kubabbar$deficit : NUMB shekels NUMB grains silver ;
+nigkak ursilaluh damgar$account of Ur-silaluh , the trade agent ;
+egir baucta nigkabi bak$after he died , this account was done ;
+iti diri$extra month ,
+mu amarsuen lugale urbilum muhul$year : “ Amar-Suen the king destroyed Urbilum . ”
+pisanduba$Basket-of-tablets
+e X GA ga$…
+cabrane$the chief house administrators ,
+igal$are here ;
+mu X bahul$year : “ … was destroyed . ”


### PR DESCRIPTION
I have made a few corrections to the original sum_eng_train.csv - saved it as sum_eng_train_alt.csv for now. The following have been changed (one can have a diff b/w the 2 files to know the exact changes):
1. $ sign on newline for various sentences has been corrected to reflect on the same line.
2. Missing translations for a few words which have the same translation as a few lines above have now been replaced with the same words to reflect the changes.
3. Replaced non-existent translations for a few words with a placeholder "..." (without quotes) 

Execution of point 3 might not be the accurate way to deal with it - is why a separate file was created for review.